### PR TITLE
Add web UI for compare flow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,4 +30,7 @@ def create_app():
     from app.web.dashboard_views import dashboard
     app.register_blueprint(dashboard)
 
+    from app.web.compare_views import compare
+    app.register_blueprint(compare)
+
     return app

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -202,3 +202,244 @@ code { background: #f3f4f6; padding: 0.15rem 0.4rem; border-radius: 3px; font-si
 .pattern-negative { background: #fee2e2; color: #991b1b; }
 
 .warning { color: #dc2626; font-weight: 600; }
+
+/* ── Compare UI ─────────────────────────────────────────────────────────── */
+
+.compare-header {
+    margin-bottom: 2rem;
+}
+.compare-header h1 {
+    margin-bottom: 0.25rem;
+}
+.compare-subtitle {
+    color: #6b7280;
+    font-size: 0.95rem;
+    margin-bottom: 0.75rem;
+}
+.compare-prompt-display {
+    font-size: 1rem;
+    color: #374151;
+    font-style: italic;
+    border-left: 3px solid #2563eb;
+    padding-left: 0.75rem;
+    margin-bottom: 0;
+}
+
+/* Form card */
+.compare-form-card {
+    background: #fff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    margin-bottom: 1.5rem;
+    max-width: 680px;
+}
+
+.form-group {
+    margin-bottom: 1.25rem;
+}
+.form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+    font-size: 0.9rem;
+}
+.form-group input[type="text"],
+.form-group select,
+.form-group textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    font-family: inherit;
+}
+.form-group select {
+    background: #fff;
+}
+.form-group textarea {
+    resize: vertical;
+}
+
+.hint {
+    font-size: 0.82rem;
+    color: #6b7280;
+    margin-top: 0.35rem;
+}
+.hint a {
+    color: #2563eb;
+}
+
+/* Prompt idea list */
+.compare-prompt-ideas {
+    max-width: 680px;
+    margin-bottom: 2rem;
+}
+.hint-heading {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 0.4rem;
+}
+.compare-prompt-ideas ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.compare-prompt-ideas li {
+    font-size: 0.88rem;
+    color: #2563eb;
+    cursor: pointer;
+    padding: 0.3rem 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+.compare-prompt-ideas li:hover {
+    color: #1d4ed8;
+    text-decoration: underline;
+}
+
+/* Compare outputs (A vs B) */
+.compare-outputs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.compare-output {
+    background: #fff;
+    padding: 1.25rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+.compare-output-label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+    margin-bottom: 0.75rem;
+}
+.compare-output-text {
+    white-space: pre-wrap;
+    font-size: 0.92rem;
+    line-height: 1.7;
+    color: #1a1a1a;
+}
+
+/* Vote form */
+.compare-vote-form {
+    background: #fff;
+    padding: 1.25rem 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    margin-bottom: 1rem;
+    text-align: center;
+}
+.vote-instruction {
+    margin-bottom: 1rem;
+    color: #374151;
+}
+.vote-buttons {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+.btn-vote {
+    padding: 0.65rem 1.75rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    border-radius: 5px;
+    border: none;
+    cursor: pointer;
+    margin-top: 0;
+}
+.btn-a  { background: #2563eb; color: #fff; }
+.btn-a:hover  { background: #1d4ed8; }
+.btn-b  { background: #7c3aed; color: #fff; }
+.btn-b:hover  { background: #6d28d9; }
+.btn-tie  { background: #6b7280; color: #fff; }
+.btn-tie:hover  { background: #4b5563; }
+.btn-skip { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+.btn-skip:hover { background: #e5e7eb; }
+
+/* Compare nav */
+.compare-nav {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+/* Stats page */
+.stats-user-select {
+    margin-bottom: 1.5rem;
+}
+.stats-user-select select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    background: #fff;
+    min-width: 200px;
+}
+
+.stats-card {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    max-width: 480px;
+}
+.stats-user-name {
+    font-weight: 700;
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    color: #374151;
+}
+
+.stats-win-rate {
+    font-size: 3.5rem;
+    font-weight: 800;
+    line-height: 1;
+    margin-bottom: 0.25rem;
+}
+.win-rate-strong { color: #16a34a; }
+.win-rate-weak   { color: #d97706; }
+.win-rate-low    { color: #dc2626; }
+
+.stats-win-rate-label {
+    font-size: 0.85rem;
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+}
+
+.stats-breakdown {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 1rem;
+    margin-bottom: 1rem;
+}
+.stats-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.35rem 0;
+    font-size: 0.9rem;
+    border-bottom: 1px solid #f9fafb;
+}
+.stats-label { color: #6b7280; }
+.stats-value { font-weight: 600; }
+.stats-win  { color: #16a34a; }
+.stats-loss { color: #dc2626; }
+
+.stats-hint {
+    font-size: 0.82rem;
+    color: #6b7280;
+    font-style: italic;
+    margin-top: 0.5rem;
+}
+.stats-empty {
+    color: #6b7280;
+    font-size: 0.95rem;
+}
+.stats-empty a {
+    color: #2563eb;
+}

--- a/app/templates/compare/add_user.html
+++ b/app/templates/compare/add_user.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Mneme — Add User{% endblock %}
+{% block content %}
+<div class="compare-header">
+  <h1>Add User</h1>
+  <a href="{{ url_for('compare.index') }}" class="btn btn-secondary">← Back</a>
+</div>
+
+<div class="compare-form-card">
+  <form method="POST">
+    <div class="form-group">
+      <label for="name">Name</label>
+      <input type="text" name="name" id="name" value="{{ name or '' }}"
+        placeholder="Your name" required>
+    </div>
+
+    <div class="form-group">
+      <label for="profile_json">Decision Profile (JSON)</label>
+      <textarea name="profile_json" id="profile_json" rows="16"
+        placeholder='{"decision_style": "...", "risk_tolerance": "...", ...}'
+        required>{{ profile_json or default_profile }}</textarea>
+      <p class="hint">Edit the values to match how you actually think and decide.</p>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Create User</button>
+  </form>
+</div>
+
+<script>
+// Pre-fill with the sample profile if textarea is empty
+const ta = document.getElementById('profile_json');
+if (!ta.value.trim()) {
+  ta.value = JSON.stringify({
+    "decision_style": "analytical and deliberate — prefers written briefs over verbal discussion",
+    "risk_tolerance": "medium — willing to take calculated risks with clear reversibility criteria",
+    "prioritization_rules": [
+      "customer impact over internal efficiency",
+      "speed to learning over polish",
+      "depth over breadth when resources are constrained"
+    ],
+    "communication_style": "direct and structured — prefers numbered lists and clear tradeoffs",
+    "constraints": [
+      "no decisions requiring more than 2 weeks lead time without async alignment first",
+      "must preserve team psychological safety"
+    ],
+    "anti_patterns": [
+      "analysis paralysis on reversible decisions",
+      "consensus-seeking when a clear owner exists"
+    ]
+  }, null, 2);
+}
+</script>
+{% endblock %}

--- a/app/templates/compare/index.html
+++ b/app/templates/compare/index.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Mneme — Compare{% endblock %}
+{% block content %}
+<div class="compare-header">
+  <h1>Mneme Compare</h1>
+  <p class="compare-subtitle">Run a prompt through default AI and your personalized AI. Pick the better output.</p>
+  <a href="{{ url_for('compare.stats') }}" class="btn btn-secondary">View Stats</a>
+  <a href="{{ url_for('compare.add_user') }}" class="btn btn-secondary">Add User</a>
+</div>
+
+<div class="compare-form-card">
+  <form method="POST" action="{{ url_for('compare.run') }}">
+    <div class="form-group">
+      <label for="user_id">Who are you?</label>
+      <select name="user_id" id="user_id" required>
+        <option value="">— select user —</option>
+        {% for user in users %}
+        <option value="{{ user.id }}" {% if user.id == selected_user_id %}selected{% endif %}>
+          {{ user.name }}
+        </option>
+        {% endfor %}
+      </select>
+      {% if not users %}
+      <p class="hint"><a href="{{ url_for('compare.add_user') }}">Add a user first →</a></p>
+      {% endif %}
+    </div>
+
+    <div class="form-group">
+      <label for="prompt">Prompt</label>
+      <textarea name="prompt" id="prompt" rows="4"
+        placeholder="How would you prioritize a backlog when everything feels urgent?"
+        required></textarea>
+      <p class="hint">Ask something you'd actually face: a decision, a trade-off, a communication challenge.</p>
+    </div>
+
+    <button type="submit" class="btn btn-primary" {% if not users %}disabled{% endif %}>
+      Run Comparison
+    </button>
+  </form>
+</div>
+
+<div class="compare-prompt-ideas">
+  <p class="hint-heading">Try these:</p>
+  <ul>
+    <li onclick="setPrompt(this)">How would you decide between shipping fast and shipping well?</li>
+    <li onclick="setPrompt(this)">Three stakeholders each think their request is most urgent. How do you handle it?</li>
+    <li onclick="setPrompt(this)">A vendor offers a 40% discount if you commit today with no trial. What do you do?</li>
+    <li onclick="setPrompt(this)">Write a project status update for a delayed initiative.</li>
+    <li onclick="setPrompt(this)">How do you decide when to stop gathering data and just make a call?</li>
+  </ul>
+</div>
+
+<script>
+function setPrompt(el) {
+  document.getElementById('prompt').value = el.textContent.trim();
+  document.getElementById('prompt').focus();
+}
+</script>
+{% endblock %}

--- a/app/templates/compare/result.html
+++ b/app/templates/compare/result.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Mneme — Pick the Better Output{% endblock %}
+{% block content %}
+<div class="compare-header">
+  <h1>Which is better?</h1>
+  <p class="compare-subtitle compare-prompt-display">{{ pending.prompt }}</p>
+</div>
+
+<div class="compare-outputs">
+  <div class="compare-output" id="output-a">
+    <div class="compare-output-label">Option A</div>
+    <div class="compare-output-text">{{ pending.output_a }}</div>
+  </div>
+  <div class="compare-output" id="output-b">
+    <div class="compare-output-label">Option B</div>
+    <div class="compare-output-text">{{ pending.output_b }}</div>
+  </div>
+</div>
+
+<form method="POST" action="{{ url_for('compare.vote') }}" class="compare-vote-form">
+  <p class="vote-instruction">Pick the output that feels more like how <strong>you</strong> think.</p>
+  <div class="vote-buttons">
+    <button type="submit" name="choice" value="a" class="btn btn-vote btn-a">A is better</button>
+    <button type="submit" name="choice" value="b" class="btn btn-vote btn-b">B is better</button>
+    <button type="submit" name="choice" value="tie" class="btn btn-vote btn-tie">Tie</button>
+    <button type="submit" name="choice" value="skip" class="btn btn-vote btn-skip">Skip</button>
+  </div>
+</form>
+
+<div class="compare-nav">
+  <a href="{{ url_for('compare.index', user_id=pending.user_id) }}" class="btn btn-secondary">← Run another</a>
+  <a href="{{ url_for('compare.stats', user_id=pending.user_id) }}" class="btn btn-secondary">View stats</a>
+</div>
+{% endblock %}

--- a/app/templates/compare/stats.html
+++ b/app/templates/compare/stats.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}Mneme — Stats{% endblock %}
+{% block content %}
+<div class="compare-header">
+  <h1>Mneme Win Rate</h1>
+  <a href="{{ url_for('compare.index') }}" class="btn btn-secondary">← Run comparison</a>
+</div>
+
+<div class="stats-user-select">
+  <form method="GET">
+    <select name="user_id" onchange="this.form.submit()">
+      <option value="">— select user —</option>
+      {% for user in users %}
+      <option value="{{ user.id }}" {% if user.id == selected_user_id %}selected{% endif %}>
+        {{ user.name }}
+      </option>
+      {% endfor %}
+    </select>
+  </form>
+</div>
+
+{% if selected_user and stats %}
+<div class="stats-card">
+  <div class="stats-user-name">{{ selected_user.name }}</div>
+
+  <div class="stats-win-rate {% if stats.win_rate and stats.win_rate >= 0.6 %}win-rate-strong{% elif stats.win_rate and stats.win_rate >= 0.45 %}win-rate-weak{% elif stats.win_rate %}win-rate-low{% endif %}">
+    {% if stats.win_rate is not none %}
+      {{ "%.0f"|format(stats.win_rate * 100) }}%
+    {% else %}
+      —
+    {% endif %}
+  </div>
+  <div class="stats-win-rate-label">
+    {% if stats.win_rate is not none %}
+      Mneme win rate
+    {% else %}
+      No decisive comparisons yet
+    {% endif %}
+  </div>
+
+  <div class="stats-breakdown">
+    <div class="stats-row">
+      <span class="stats-label">Total comparisons</span>
+      <span class="stats-value">{{ stats.total }}</span>
+    </div>
+    <div class="stats-row">
+      <span class="stats-label">Mneme wins</span>
+      <span class="stats-value stats-win">{{ stats.mneme_wins }}</span>
+    </div>
+    <div class="stats-row">
+      <span class="stats-label">Default wins</span>
+      <span class="stats-value stats-loss">{{ stats.default_wins }}</span>
+    </div>
+    <div class="stats-row">
+      <span class="stats-label">Ties</span>
+      <span class="stats-value">{{ stats.ties }}</span>
+    </div>
+    <div class="stats-row">
+      <span class="stats-label">Skipped</span>
+      <span class="stats-value">{{ stats.skips }}</span>
+    </div>
+  </div>
+
+  <p class="stats-hint">
+    {% if stats.total < 5 %}
+      Run {{ 5 - stats.total }} more comparison{{ 's' if (5 - stats.total) != 1 }} for a directional signal.
+    {% elif stats.total < 10 %}
+      Run {{ 10 - stats.total }} more for a reliable rate.
+    {% elif stats.win_rate and stats.win_rate >= 0.6 %}
+      Strong signal — Mneme is improving your outputs.
+    {% elif stats.win_rate and stats.win_rate >= 0.45 %}
+      Inconclusive — keep comparing or refine the profile.
+    {% elif stats.win_rate is not none %}
+      Weak signal — consider updating your profile.
+    {% endif %}
+  </p>
+</div>
+
+{% elif selected_user %}
+<div class="stats-card">
+  <div class="stats-user-name">{{ selected_user.name }}</div>
+  <p class="stats-empty">No comparisons yet. <a href="{{ url_for('compare.index', user_id=selected_user.id) }}">Run your first one →</a></p>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/web/compare_views.py
+++ b/app/web/compare_views.py
@@ -1,0 +1,161 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+from app.db import get_db
+from app.config import Config
+from app.models.user import list_users, get_user, insert_user
+from app.models.comparison import insert_comparison, get_comparisons_for_user, compute_win_rate
+from app.runner.compare import run_comparison
+from app.profiles.extractors import extract_qa_signals
+from app.profiles.builder import build_mneme_profile
+import json
+
+compare = Blueprint("compare", __name__)
+
+
+@compare.route("/compare")
+def index():
+    db = get_db()
+    users = list_users(db)
+    selected_user_id = request.args.get("user_id", "")
+    return render_template("compare/index.html", users=users, selected_user_id=selected_user_id)
+
+
+@compare.route("/compare/run", methods=["POST"])
+def run():
+    user_id = request.form.get("user_id", "").strip()
+    prompt_text = request.form.get("prompt", "").strip()
+
+    if not user_id:
+        flash("Please select a user.")
+        return redirect(url_for("compare.index"))
+    if not prompt_text:
+        flash("Please enter a prompt.")
+        return redirect(url_for("compare.index", user_id=user_id))
+
+    db = get_db()
+    user = get_user(db, user_id)
+    if not user:
+        flash("User not found.")
+        return redirect(url_for("compare.index"))
+
+    try:
+        result = run_comparison(
+            user=user,
+            prompt_text=prompt_text,
+            api_key=Config.ANTHROPIC_API_KEY,
+            model=Config.MODEL,
+            temperature=Config.TEMPERATURE,
+            max_tokens=Config.MAX_TOKENS,
+        )
+    except Exception as e:
+        flash(f"LLM call failed: {e}")
+        return redirect(url_for("compare.index", user_id=user_id))
+
+    session["compare_pending"] = {
+        "user_id": user_id,
+        "user_name": user["name"],
+        "prompt": prompt_text,
+        "output_a": result["output_a"],
+        "output_b": result["output_b"],
+        "option_a_mode": result["option_a_mode"],
+        "option_b_mode": result["option_b_mode"],
+    }
+    return redirect(url_for("compare.result"))
+
+
+@compare.route("/compare/result")
+def result():
+    pending = session.get("compare_pending")
+    if not pending:
+        flash("No active comparison. Run one first.")
+        return redirect(url_for("compare.index"))
+    return render_template("compare/result.html", pending=pending)
+
+
+@compare.route("/compare/vote", methods=["POST"])
+def vote():
+    pending = session.get("compare_pending")
+    if not pending:
+        flash("Session expired. Run the comparison again.")
+        return redirect(url_for("compare.index"))
+
+    choice = request.form.get("choice", "").strip().lower()
+    if choice not in ("a", "b", "tie", "skip"):
+        flash("Invalid choice.")
+        return redirect(url_for("compare.result"))
+
+    winner = choice
+    if winner == "a":
+        preferred_mode = pending["option_a_mode"]
+    elif winner == "b":
+        preferred_mode = pending["option_b_mode"]
+    else:
+        preferred_mode = None
+
+    db = get_db()
+    insert_comparison(
+        db,
+        user_id=pending["user_id"],
+        prompt=pending["prompt"],
+        option_a_mode=pending["option_a_mode"],
+        option_b_mode=pending["option_b_mode"],
+        winner=winner,
+        preferred_mode=preferred_mode,
+    )
+    session.pop("compare_pending", None)
+
+    label = {"a": "Option A", "b": "Option B", "tie": "Tie", "skip": "Skipped"}[winner]
+    flash(f"Saved — {label}" + (f" ({preferred_mode})" if preferred_mode else ""))
+    return redirect(url_for("compare.index", user_id=pending["user_id"]))
+
+
+@compare.route("/compare/stats")
+def stats():
+    db = get_db()
+    users = list_users(db)
+    selected_user_id = request.args.get("user_id", "")
+
+    stats_data = None
+    selected_user = None
+    if selected_user_id:
+        selected_user = get_user(db, selected_user_id)
+        if selected_user:
+            comparisons = get_comparisons_for_user(db, selected_user_id)
+            stats_data = compute_win_rate(comparisons) if comparisons else None
+
+    return render_template("compare/stats.html",
+        users=users,
+        selected_user=selected_user,
+        selected_user_id=selected_user_id,
+        stats=stats_data,
+    )
+
+
+@compare.route("/compare/add-user", methods=["GET", "POST"])
+def add_user():
+    if request.method == "GET":
+        return render_template("compare/add_user.html")
+
+    name = request.form.get("name", "").strip()
+    profile_json = request.form.get("profile_json", "").strip()
+
+    if not name:
+        flash("Name is required.")
+        return render_template("compare/add_user.html", name=name, profile_json=profile_json)
+
+    if not profile_json:
+        flash("Profile JSON is required.")
+        return render_template("compare/add_user.html", name=name, profile_json=profile_json)
+
+    try:
+        qa_input = json.loads(profile_json)
+    except json.JSONDecodeError as e:
+        flash(f"Invalid JSON: {e}")
+        return render_template("compare/add_user.html", name=name, profile_json=profile_json)
+
+    qa_signals = extract_qa_signals(qa_input)
+    merged_profile = build_mneme_profile({"qa": qa_signals})
+
+    db = get_db()
+    user = insert_user(db, name=name, mneme_profile=json.dumps(merged_profile), source="web")
+    flash(f"User created: {user['name']} ({user['id'][:8]}...)")
+    return redirect(url_for("compare.index", user_id=user["id"]))


### PR DESCRIPTION
## Summary
- New Flask blueprint (`compare`) with routes for running comparisons, voting on A/B outputs, viewing win-rate stats, and adding users via a web form
- Four Jinja2 templates under `app/templates/compare/` with a clean, minimal design
- Compare-specific CSS appended to `style.css` (no existing styles touched)
- Uses Flask sessions to hold LLM outputs between `/compare/run` and `/compare/vote` — no schema changes needed

## How to test
1. `flask run` (with `ANTHROPIC_API_KEY` set)
2. Browse to `http://localhost:5000/compare`
3. Click **Add User** → fill in name + tweak the sample profile JSON → Create
4. Select the user, type a prompt, click **Run Comparison**
5. Pick A / B / Tie / Skip on the result page
6. Check **View Stats** to see the win-rate update

## Test plan
- [ ] `pytest` passes (107 tests, no regressions)
- [ ] `/compare` renders with user dropdown and example prompts
- [ ] `/compare/add-user` creates a user and redirects to index with that user pre-selected
- [ ] `/compare/run` calls LLM, stores in session, redirects to result page
- [ ] `/compare/result` shows prompt + two outputs side by side
- [ ] Each vote button saves correctly and flashes a confirmation
- [ ] `/compare/stats` shows win rate with correct colour coding
- [ ] Flashes appear for missing user, empty prompt, invalid JSON, expired session

🤖 Generated with [Claude Code](https://claude.com/claude-code)