### PR TITLE
feat(infra): add Cloudflare cache purge integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ CPANEL_PORT=2083
 CPANEL_USER=
 CPANEL_API_TOKEN=
 
+# Cloudflare (mnemehq.com zone cache purge)
+CF_API_TOKEN=
+CF_ZONE_ID=
+
 # Mneme HQ BigQuery
 MNEME_BQ_PROJECT=mneme-hq-prod
 MNEME_BQ_LOCATION=US

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Deploy
         env:
           CPANEL_API_TOKEN: ${{ secrets.CPANEL_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
         run: python scripts/deploy_site.py

--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -36,6 +36,28 @@ except subprocess.CalledProcessError:
 
 print(f"[OK] Branch: main  |  Clean: yes  |  Source: {BASE_LOCAL}")
 
+# ── Cloudflare credentials ───────────────────────────────────────────────────
+CF_TOKEN   = os.environ.get('CF_API_TOKEN', '')
+CF_ZONE_ID = os.environ.get('CF_ZONE_ID', '')
+
+def purge_cf_cache():
+    if not CF_TOKEN or not CF_ZONE_ID:
+        print('[SKIP] Cloudflare cache purge - CF_API_TOKEN or CF_ZONE_ID not set')
+        return
+    payload = json.dumps({'purge_everything': True}).encode()
+    req = urllib.request.Request(
+        f'https://api.cloudflare.com/client/v4/zones/{CF_ZONE_ID}/purge_cache',
+        data=payload,
+        headers={'Authorization': f'Bearer {CF_TOKEN}', 'Content-Type': 'application/json'},
+        method='POST',
+    )
+    with urllib.request.urlopen(req) as r:
+        result = json.loads(r.read())
+    if result.get('success'):
+        print('[OK] Cloudflare cache purged')
+    else:
+        print(f'[WARN] Cloudflare purge failed: {result.get("errors")}')
+
 # ── cPanel credentials ────────────────────────────────────────────────────────
 HOST  = os.environ.get('CPANEL_HOST',  '152.89.79.37')
 PORT  = os.environ.get('CPANEL_PORT',  '2083')
@@ -161,3 +183,7 @@ if verify_failures:
     raise SystemExit(1)
 
 print(f"\n[OK] All {len(urls)} sitemap URLs verified - deploy complete")
+
+# ── Purge Cloudflare cache ────────────────────────────────────────────────────
+print("\n-- Purging Cloudflare cache --")
+purge_cf_cache()

--- a/scripts/purge_cf_cache.py
+++ b/scripts/purge_cf_cache.py
@@ -1,0 +1,38 @@
+"""Purge the entire Cloudflare cache for the mnemehq.com zone."""
+import urllib.request, json, os
+from pathlib import Path
+
+_env = Path(__file__).parent.parent / '.env'
+if _env.exists():
+    for line in _env.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith('#') and '=' in line:
+            k, _, v = line.partition('=')
+            os.environ.setdefault(k.strip(), v.strip())
+
+TOKEN   = os.environ.get('CF_API_TOKEN', '')
+ZONE_ID = os.environ.get('CF_ZONE_ID', '')
+
+if not TOKEN:
+    raise SystemExit('ERROR: CF_API_TOKEN not set - add it to .env')
+if not ZONE_ID:
+    raise SystemExit('ERROR: CF_ZONE_ID not set - add it to .env')
+
+payload = json.dumps({'purge_everything': True}).encode()
+req = urllib.request.Request(
+    f'https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/purge_cache',
+    data=payload,
+    headers={
+        'Authorization': f'Bearer {TOKEN}',
+        'Content-Type': 'application/json',
+    },
+    method='POST',
+)
+
+with urllib.request.urlopen(req) as r:
+    result = json.loads(r.read())
+
+if result.get('success'):
+    print('[OK] Cloudflare cache purged')
+else:
+    raise SystemExit(f'ERROR: Cloudflare purge failed: {result.get("errors")}')


### PR DESCRIPTION
## Summary
- Adds `CF_API_TOKEN` and `CF_ZONE_ID` env vars to `.env.example`
- Adds `scripts/purge_cf_cache.py` for standalone cache purge
- Wires cache purge into `scripts/deploy_site.py` after successful deploy
- Exposes CF secrets in `.github/workflows/deploy-site.yml`