### PR TITLE
feat(site): add Brotli/gzip compression via .htaccess

### DIFF
--- a/site/.htaccess
+++ b/site/.htaccess
@@ -5,6 +5,14 @@ RewriteEngine On
 RewriteCond %{HTTP:CF-Visitor} '"scheme":"http"'
 RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
+# Brotli compression (falls back to gzip if unavailable)
+<IfModule mod_brotli.c>
+    AddOutputFilterByType BROTLI_COMPRESS text/html text/css text/javascript application/javascript text/xml application/xml image/svg+xml
+</IfModule>
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript text/xml application/xml image/svg+xml
+</IfModule>
+
 # Cache-Control headers — tell Cloudflare and browsers how long to cache
 <IfModule mod_expires.c>
     ExpiresActive On


### PR DESCRIPTION
## Summary
- Enables Brotli compression via `mod_brotli` (falls back to gzip via `mod_deflate`)
- Compresses HTML, CSS, JS, SVG at the server level
- Expected ~30% reduction in transfer size for text assets