### PR TITLE
[ci] wire mneme check --mode warn into PR workflow

### DIFF
--- a/.github/workflows/mneme-check.yml
+++ b/.github/workflows/mneme-check.yml
@@ -1,0 +1,160 @@
+name: mneme self-check (warn mode)
+
+# Runs the mneme self-governance check against files changed in a PR.
+#
+# Mode is intentionally `warn`: the CLI returns exit code 0 for every
+# verdict, so verdicts are surfaced as a sticky PR comment but never
+# block a merge. Strict mode for narrow paths (.mneme/, mneme-project-memory/mneme/,
+# docs/adr/) is a planned follow-up after we accumulate clean warn-history,
+# per the rollout plan in `.mneme/README.md`.
+#
+# Path filter: we only check files where rules can plausibly apply
+# (package code, ADRs, .mneme/ itself, the marketing site, and automation
+# scripts). This keeps comment noise low. Auto-generated files (lockfiles,
+# binary assets) are excluded.
+#
+# Query construction: the mneme retriever scores rules by keyword overlap
+# with the `--query` arg, so we combine the PR title (intent) with the
+# changed file path (subsystem). PR title alone is too narrow to match
+# subsystem-specific rules like the no-vector-db / no-langchain anti-pattern.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  mneme-check:
+    name: mneme check --mode warn
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install local mneme package
+        run: pip install -e mneme-project-memory
+
+      - name: Verify enforcement memory exists
+        id: verify-memory
+        shell: bash
+        run: |
+          if [ -f .mneme/project_memory.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::.mneme/project_memory.json not present on this branch — skipping check."
+          fi
+
+      - name: Compute changed files (filtered)
+        if: steps.verify-memory.outputs.present == 'true'
+        id: files
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1 >/dev/null 2>&1
+          base_sha="$(git rev-parse "origin/${{ github.base_ref }}")"
+          mkdir -p /tmp/mneme
+          : > /tmp/mneme/files.txt
+          # diff-filter=ACMR: Added, Copied, Modified, Renamed (skip Deleted)
+          git diff --name-only --diff-filter=ACMR "$base_sha"...HEAD > /tmp/mneme/raw.txt
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              mneme-project-memory/mneme/*|docs/adr/*|.mneme/*|site/*|scripts/*) ;;
+              *) continue ;;
+            esac
+            case "$f" in
+              *.lock|*.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.webp|*.woff|*.woff2|*.ttf|*.eot|*.docx|*.xlsx|*.pdf|*.zip|*.tar|*.gz) continue ;;
+              package-lock.json|yarn.lock|pnpm-lock.yaml|poetry.lock|Pipfile.lock|uv.lock) continue ;;
+            esac
+            [ -f "$f" ] || continue
+            echo "$f" >> /tmp/mneme/files.txt
+          done < /tmp/mneme/raw.txt
+          count=$(wc -l < /tmp/mneme/files.txt | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Files in scope ($count):"
+          cat /tmp/mneme/files.txt || true
+
+      - name: Run mneme check on each file
+        if: steps.verify-memory.outputs.present == 'true'
+        id: run-check
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -uo pipefail
+          summary=/tmp/mneme/summary.md
+          {
+            echo "## mneme self-governance check"
+            echo ""
+            echo "_Mode: \`warn\` - verdicts are visible but **do not block merge**. Rollout plan: \`.mneme/README.md\`._"
+            echo ""
+          } > "$summary"
+
+          if [ ! -s /tmp/mneme/files.txt ]; then
+            echo "_No files in scope. Filter: \`mneme-project-memory/mneme/\`, \`docs/adr/\`, \`.mneme/\`, \`site/\`, \`scripts/\`._" >> "$summary"
+            cat "$summary"
+            exit 0
+          fi
+
+          pass=0; warn=0; fail=0
+          : > /tmp/mneme/rows.txt
+          : > /tmp/mneme/details.txt
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            query="${PR_TITLE:-} ${f}"
+            out="$(python -m mneme.cli check \
+              --memory .mneme/project_memory.json \
+              --input "$f" \
+              --query "$query" \
+              --mode warn 2>&1 || true)"
+            verdict="$(printf '%s\n' "$out" | tr -d '\r' | awk -F': ' '/^Result:/ {print $2; exit}')"
+            verdict="${verdict:-UNKNOWN}"
+            case "$verdict" in
+              PASS) pass=$((pass+1)); icon=":white_check_mark:" ;;
+              WARN) warn=$((warn+1)); icon=":warning:" ;;
+              FAIL) fail=$((fail+1)); icon=":x:" ;;
+              *)    icon=":grey_question:" ;;
+            esac
+            printf '| %s %s | `%s` |\n' "$icon" "$verdict" "$f" >> /tmp/mneme/rows.txt
+            if [ "$verdict" = "FAIL" ] || [ "$verdict" = "WARN" ]; then
+              {
+                printf '\n<details><summary><code>%s</code> — %s</summary>\n\n' "$f" "$verdict"
+                printf '```\n%s\n```\n\n</details>\n' "$out"
+              } >> /tmp/mneme/details.txt
+            fi
+          done < /tmp/mneme/files.txt
+
+          {
+            echo "**Summary:** ${pass} pass, ${warn} warn, ${fail} fail"
+            echo ""
+            echo "| verdict | file |"
+            echo "| :--- | :--- |"
+            cat /tmp/mneme/rows.txt
+            if [ -s /tmp/mneme/details.txt ]; then
+              echo ""
+              echo "### Details"
+              cat /tmp/mneme/details.txt
+            fi
+            echo ""
+            echo "<sub>Generated by \`.github/workflows/mneme-check.yml\` · query = PR title + file path · scope = repo-governance paths.</sub>"
+          } >> "$summary"
+          cat "$summary"
+
+      - name: Post sticky PR comment
+        if: steps.verify-memory.outputs.present == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        continue-on-error: true
+        with:
+          header: mneme-check
+          path: /tmp/mneme/summary.md

--- a/.mneme/README.md
+++ b/.mneme/README.md
@@ -62,7 +62,8 @@ on a narrow set of paths once we have a clean warn history.
 
 CI runs `mneme check` in `--mode warn` against changed files. Warn mode
 exits 0 on every verdict; conflicts are surfaced as PR comments only and do
-not block merges.
+not block merges. The workflow that drives this lives at
+[`.github/workflows/mneme-check.yml`](../.github/workflows/mneme-check.yml).
 
 ```bash
 mneme check --memory .mneme/project_memory.json \


### PR DESCRIPTION
## Summary

Adds `.github/workflows/mneme-check.yml`, a GitHub Actions workflow that
runs `mneme check --mode warn` against PR-changed files and posts a
sticky summary comment.

**This PR is non-blocking**: the workflow runs in `warn` mode, where
the CLI exits 0 for every verdict (`PASS`, `WARN`, `FAIL`). Conflicts
are visible to reviewers but do not fail the check. Strict mode for
narrow paths (`.mneme/`, `mneme-project-memory/mneme/`, `docs/adr/`)
is a planned follow-up after we accumulate a clean warn-history, per
the rollout plan in `.mneme/README.md`.

## Dependency on #8

This PR depends on #8 (which adds `.mneme/project_memory.json` and
`.mneme/README.md`). Originally stacked, but the trigger filter
`pull_request: branches: [main]` only fires on main-targeted PRs, so I
retargeted base to `main` to satisfy the test plan ("workflow should
show up in the Actions tab on the PR itself"). As a result, the diff
view currently includes #8's commits — those are already reviewed in
#8 and will drop out of the diff once #8 merges.

**The two files this PR actually owns**:
- `.github/workflows/mneme-check.yml` (new)
- `.mneme/README.md` (one-sentence addition pointing to the workflow path)

`.mneme/project_memory.json` is **not** modified, per the
`rule-memory-pr-isolation` rule.

**Recommended merge order:** merge #8 first, then this PR.

## What's in the workflow

- Triggers on `pull_request` to `main`.
- Sets up Python 3.12 (matches `mneme` `requires-python = ">=3.11"` and
  the existing `deploy-site.yml` workflow).
- Installs the local package: `pip install -e mneme-project-memory`.
- Computes changed files via `git diff --name-only --diff-filter=ACMR`
  against the PR base.
- **Path filter** (documented inline): only checks
  `mneme-project-memory/mneme/`, `docs/adr/`, `.mneme/`, `site/`,
  `scripts/`. Skips lockfiles and common binary assets.
- **Query construction**: PR title + changed-file path. The retriever
  scores rules by keyword overlap with the query, so combining intent
  (title) and subsystem (path) gives broader coverage than title alone.
  This was load-bearing in local testing — a query of just "ci wiring"
  did not retrieve the `anti-vector-langchain-agents` rule, but
  `"<title> <file path>"` did.
- Aggregates verdicts into a markdown summary and posts a sticky
  comment via `marocchino/sticky-pull-request-comment@v2`.
- The comment step has `continue-on-error: true` so fork-PR runs
  (where `GITHUB_TOKEN` is read-only) don't fail the workflow.
- Guarded by a `verify-memory` step: if `.mneme/project_memory.json`
  is absent (e.g., before #8 merges), the workflow emits a notice and
  skips cleanly.

## Out of scope (future PRs)

- Strict mode (`--mode strict`) for narrow paths
- Path-specific strict gates with required status checks
- Any change to `.mneme/project_memory.json` (would itself trigger
  `rule-memory-pr-isolation` and require a `[memory]` PR)
- Any package code change

## Test plan

- [ ] PR opens and the new workflow run shows up in the Actions tab.
- [ ] The sticky comment posts on this PR with verdicts for the
      changed files in scope.
- [ ] The check exits 0 even if it surfaces FAIL verdicts.
- [ ] (Manual, post-merge) Open a follow-up PR that intentionally
      adds violating text (e.g., "add langchain and a vector
      database") to a file under `scripts/` or `.mneme/` and confirm
      the workflow surfaces a FAIL verdict in the sticky comment
      without blocking merge.