### PR TITLE
[docs] add root CLAUDE.md with repo-level instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Mneme Repo Instructions
+
+- Use `.mneme/project_memory.json` as the governance source.
+- Validate changes against ADRs in `docs/adr/`.
+- Do not modify `.mneme/project_memory.json` unless this is a `[memory]` task.
+- Keep GTM/pricing/customer/internal strategy content out of this repo.
+- Run `mneme check --mode warn` before finalizing governance-related changes.
+- Keep PRs narrowly scoped.


### PR DESCRIPTION
## Summary

Adds a concise `CLAUDE.md` at the repo root. Claude Code automatically
picks this up repo-wide, so contributors using Claude Code get the
governance instructions on every session without needing to remember
to look at `.mneme/`.

The instructions point at the canonical sources of truth (`.mneme/project_memory.json`,
`docs/adr/`) rather than duplicating their content, so they can't drift.

## Content

```
# Mneme Repo Instructions

- Use `.mneme/project_memory.json` as the governance source.
- Validate changes against ADRs in `docs/adr/`.
- Do not modify `.mneme/project_memory.json` unless this is a `[memory]` task.
- Keep GTM/pricing/customer/internal strategy content out of this repo.
- Run `mneme check --mode warn` before finalizing governance-related changes.
- Keep PRs narrowly scoped.
```

## Independence

This PR does not depend on #8 or #9. It references their paths
(`.mneme/project_memory.json`, `mneme check --mode warn`) but the file
is just guidance — it doesn't import or execute against them, so it
can land in any merge order.

## Test plan

- [ ] `CLAUDE.md` lands at repo root.
- [ ] Future Claude Code sessions opened against this repo automatically
      load the file's instructions in their context.