### PR TITLE
[ascii] make CLI runtime output Windows-safe

### DIFF
--- a/mneme-project-memory/mneme/benchmark.py
+++ b/mneme-project-memory/mneme/benchmark.py
@@ -113,7 +113,7 @@ class BenchmarkRunner:
         if baseline_count == 0:
             verdict = ScenarioVerdict.WEAK
             explanation = (
-                "Baseline response had no violations — scenario fixtures may be too weak. "
+                "Baseline response had no violations - scenario fixtures may be too weak. "
                 "Strengthen without_mneme.txt to include more explicit failure terms."
             )
         elif enhanced_count > 0:

--- a/mneme-project-memory/mneme/benchmark_report.py
+++ b/mneme-project-memory/mneme/benchmark_report.py
@@ -2,7 +2,7 @@
 benchmark_report.py — Format BenchmarkRunner results for terminal, Markdown, and JSON.
 
 Three formatters:
-  format_terminal(results) -> str   Pretty terminal table with emoji verdicts
+  format_terminal(results) -> str   Plain-text terminal table (ASCII-only, Windows-safe)
   format_markdown(results) -> str   GitHub-flavoured Markdown table + summary
   format_json(results)     -> str   JSON with summary + per-scenario detail
 """
@@ -14,13 +14,6 @@ from dataclasses import dataclass
 
 from mneme.benchmark import ScenarioResult, ScenarioVerdict
 
-
-_VERDICT_EMOJI = {
-    ScenarioVerdict.PASS: "✅",
-    ScenarioVerdict.FAIL: "❌",
-    ScenarioVerdict.WEAK: "⚠️",
-    ScenarioVerdict.WEAK_RETRIEVAL: "⚠️",
-}
 
 _WIDTH = 72
 
@@ -81,8 +74,7 @@ def format_terminal(results: list[ScenarioResult]) -> str:
     lines.append("")
 
     for r in results:
-        emoji = _VERDICT_EMOJI.get(r.verdict, "?")
-        lines.append(f"  {emoji} {r.verdict.value:<5}  {r.name}")
+        lines.append(f"  {r.verdict.value:<5}  {r.name}")
         lines.append(f"         {r.explanation}")
         if r.baseline_triggers:
             lines.append(
@@ -122,10 +114,9 @@ def format_markdown(results: list[ScenarioResult]) -> str:
     lines.append("|---|---|---|---|---|")
 
     for r in results:
-        emoji = _VERDICT_EMOJI.get(r.verdict, "?")
-        triggers = ", ".join(r.baseline_triggers[:3]) or "—"
+        triggers = ", ".join(r.baseline_triggers[:3]) or "--"
         lines.append(
-            f"| {r.name} | {emoji} {r.verdict.value} "
+            f"| {r.name} | {r.verdict.value} "
             f"| {r.baseline_violation_count} "
             f"| {r.enhanced_violation_count} "
             f"| {triggers} |"

--- a/mneme-project-memory/mneme/cli.py
+++ b/mneme-project-memory/mneme/cli.py
@@ -134,7 +134,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
     if result.violations:
         for v in result.violations:
             kind = "anti_pattern" if v.severity == Severity.FAIL else "constraint"
-            print(f"{v.severity.value:4}  [{v.decision_id}] {kind} \"{v.rule}\" — trigger: {v.trigger}")
+            print(f"{v.severity.value:4}  [{v.decision_id}] {kind} \"{v.rule}\" -- trigger: {v.trigger}")
             print(f"      {v.decision_text}")
         print()
 
@@ -241,7 +241,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.add_argument("--top", type=int, default=DEFAULT_MAX_DECISIONS)
     p_check.add_argument(
         "--mode", choices=["warn", "strict"], default="strict",
-        help="warn: all verdicts exit 0; strict (default): WARN→1, FAIL→2",
+        help="warn: all verdicts exit 0; strict (default): WARN->1, FAIL->2",
     )
     p_check.set_defaults(func=_cmd_check)
 


### PR DESCRIPTION
## Summary

Replaces non-ASCII characters in user-facing CLI output paths so
`mneme` can run from Windows terminals (cp1252) without
`UnicodeEncodeError` or rendering as replacement glyphs (`�`).

Net diff: **+7/-16** across 3 files.

## What changes

- **`cli.py` `_cmd_check`**: violation line em-dash `—` → `--`
  (this was the source of the `�` we observed in earlier session
  logs from `mneme check` runs).
- **`cli.py` `--mode` help text**: `WARN→1, FAIL→2` → `WARN->1, FAIL->2`
  (the `→` previously crashed `mneme check --help` on Windows
  with `'charmap' codec can't encode character '→'`).
- **`benchmark_report.py`**: drop the `_VERDICT_EMOJI` dict and the
  emoji prefix in both `format_terminal` and `format_markdown`. The
  verdict label itself (`PASS`/`FAIL`/`WEAK`) already carries the
  meaning, so the emoji was redundant. Empty-triggers placeholder
  in markdown table changed from `—` to `--`.
- **`benchmark.py`** runtime warning message: em-dash `—` → `-`.

## Out of scope

Source-comment / docstring em-dashes and box-drawing characters
(in section headers like `# ── Validation ──────`) are intentionally
**left alone** — they never hit stdout, and the cleanup would
balloon the diff for no Windows-safety benefit.

## Verification

- Full test suite: `218 passed, 2 skipped` (no test changes needed —
  existing assertions check verdict substrings like `"PASS"`, not
  emoji glyphs).
- Ran `mneme check` against a violating fixture on this branch —
  output is now pure ASCII (verified byte-by-byte).
- Ran `mneme check --help` — no longer raises `UnicodeEncodeError`
  on Windows cp1252 stdout.
- Ran `format_terminal` and `format_markdown` against synthetic
  results with `PASS`/`FAIL`/`WEAK` verdicts — both pure ASCII.

## Independence

This PR is independent of #8, #9, and #10. It only touches package
source under `mneme-project-memory/mneme/`.