### PR TITLE
feat(benchmark): Step 3A.ii — benchmark/runtime K alignment

### DIFF
--- a/mneme-project-memory/examples/benchmarks/reports/RESULTS.md
+++ b/mneme-project-memory/examples/benchmarks/reports/RESULTS.md
@@ -1,16 +1,18 @@
 ## Mneme Benchmark Results
 
-| Scenario | Verdict | Baseline violations | Enhanced violations | Notes |
-|---|---|---|---|---|
-| feature_boundary_violation | ✅ PASS | 4 | 0 | tool, function, multi |
-| framework_abstraction_violation | ✅ PASS | 1 | 0 | langchain |
-| infra_scope_creep_violation | ✅ PASS | 4 | 0 | agentic, tool, function |
-| retrieval_complexity_violation | ✅ PASS | 3 | 0 | sentence, vector, embeddings |
-| storage_backend_violation | ✅ PASS | 5 | 0 | orm, layer, sqlalchemy |
+| Scenario | Verdict | Baseline | Enhanced | Recall@K | Precision@K | Irrelevant | Notes |
+|---|---|---|---|---|---|---|---|
+| feature_boundary_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | tool, function, multi |
+| framework_abstraction_violation | PASS | 1 | 0 | 1.00 | 0.33 | yes | langchain |
+| infra_scope_creep_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | agentic, tool, function |
+| retrieval_complexity_violation | PASS | 3 | 0 | 1.00 | 0.33 | yes | sentence, vector, embeddings |
+| storage_backend_violation | PASS | 5 | 0 | 1.00 | 0.33 | yes | sqlalchemy, alembic, psycopg2-binary |
 
 ## Summary
 
-**5/5** violations caught by Mneme (100% pass rate).
+**Layer 2 (enforcement)** — 5/5 violations caught (100% pass rate).
+
+**Layer 1 (retrieval, n=5)** — mean Recall@3 1.00, mean Precision@3 0.33, irrelevant injection rate 100%.
 
 **By category:**
 

--- a/mneme-project-memory/examples/benchmarks/reports/results.json
+++ b/mneme-project-memory/examples/benchmarks/reports/results.json
@@ -22,6 +22,20 @@
         "fail": 0,
         "total": 2
       }
+    },
+    "layer1": {
+      "k": 3,
+      "mean_recall_at_k": 1.0,
+      "mean_precision_at_k": 0.333,
+      "irrelevant_injection_rate": 1.0,
+      "scored_count": 5
+    },
+    "layer2": {
+      "passed": 5,
+      "failed": 0,
+      "weak": 0,
+      "weak_retrieval": 0,
+      "pass_rate": 1.0
     }
   },
   "results": [
@@ -37,7 +51,37 @@
         "between"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (tool, function, multi); enhanced response had none. Retrieved: anti-002."
+      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (tool, function, multi); enhanced response had none. Retrieved: anti-002.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "mneme_no_agents_v1",
+          "anti-003",
+          "anti-002"
+        ],
+        "expected_ids": [
+          "anti-002"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.3333333333333333,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 4,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "tool",
+          "function",
+          "multi",
+          "between"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "anti-002"
+        ]
+      }
     },
     {
       "name": "framework_abstraction_violation",
@@ -48,7 +92,34 @@
         "langchain"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (langchain); enhanced response had none. Retrieved: anti-001."
+      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (langchain); enhanced response had none. Retrieved: anti-001.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "anti-001",
+          "mneme_storage_json",
+          "anti-002"
+        ],
+        "expected_ids": [
+          "anti-001"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.3333333333333333,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 1,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "langchain"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "anti-001"
+        ]
+      }
     },
     {
       "name": "infra_scope_creep_violation",
@@ -62,7 +133,37 @@
         "multi"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (agentic, tool, function); enhanced response had none. Retrieved: anti-002."
+      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (agentic, tool, function); enhanced response had none. Retrieved: anti-002.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "anti-002",
+          "mneme_no_agents_v1",
+          "rule-004"
+        ],
+        "expected_ids": [
+          "anti-002"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.3333333333333333,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 4,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "agentic",
+          "tool",
+          "function",
+          "multi"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "anti-002"
+        ]
+      }
     },
     {
       "name": "retrieval_complexity_violation",
@@ -75,7 +176,36 @@
         "embeddings"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 3 violation(s) (sentence, vector, embeddings); enhanced response had none. Retrieved: mneme_retrieval_deterministic."
+      "explanation": "Mneme prevented the violation. Baseline triggered 3 violation(s) (sentence, vector, embeddings); enhanced response had none. Retrieved: mneme_retrieval_deterministic.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "mneme_retrieval_deterministic",
+          "rule-002",
+          "rule-005"
+        ],
+        "expected_ids": [
+          "mneme_retrieval_deterministic"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.3333333333333333,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 3,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "sentence",
+          "vector",
+          "embeddings"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "mneme_retrieval_deterministic"
+        ]
+      }
     },
     {
       "name": "storage_backend_violation",
@@ -83,14 +213,45 @@
       "baseline_violation_count": 5,
       "enhanced_violation_count": 0,
       "baseline_triggers": [
-        "orm",
-        "layer",
         "sqlalchemy",
-        "postgres",
-        "orm"
+        "alembic",
+        "psycopg2-binary",
+        "migrations/0001_initial.py",
+        "alembic/env.py"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 5 violation(s) (orm, layer, sqlalchemy); enhanced response had none. Retrieved: mneme_storage_json."
+      "explanation": "Mneme prevented the violation. Baseline triggered 5 violation(s) (sqlalchemy, alembic, psycopg2-binary); enhanced response had none. Retrieved: mneme_storage_json.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "mneme_storage_json",
+          "rule-003",
+          "rule-002"
+        ],
+        "expected_ids": [
+          "mneme_storage_json"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.3333333333333333,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 5,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "sqlalchemy",
+          "alembic",
+          "psycopg2-binary",
+          "migrations/0001_initial.py",
+          "alembic/env.py"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "mneme_storage_json"
+        ]
+      }
     }
   ]
 }

--- a/mneme-project-memory/mneme/benchmark.py
+++ b/mneme-project-memory/mneme/benchmark.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from mneme.benchmark_schemas import Assertion, StructuredOutput
 from mneme.benchmark_verifier import verify
+from mneme.context_builder import DEFAULT_MAX_DECISIONS
 from mneme.decision_retriever import DecisionRetriever, ScoredDecision
 from mneme.enforcer import check_prompt
 from mneme.memory_store import MemoryStore
@@ -84,7 +85,7 @@ class ScenarioResult:
     # Layer 1 — retrieval scoring (v1.1, §03 of methodology page).
     # Defaults are vacuously "perfect" so callers that build ScenarioResult by
     # hand (e.g. report-formatter unit tests) are unaffected.
-    layer1_k: int = 5
+    layer1_k: int = DEFAULT_MAX_DECISIONS
     layer1_retrieved_ids: list[str] = field(default_factory=list)
     layer1_expected_ids: list[str] = field(default_factory=list)
     layer1_acceptable_ids: list[str] = field(default_factory=list)
@@ -251,7 +252,7 @@ class BenchmarkRunner:
     per the v1.1 methodology.
     """
 
-    def __init__(self, store: MemoryStore, top: int = 5) -> None:
+    def __init__(self, store: MemoryStore, top: int = DEFAULT_MAX_DECISIONS) -> None:
         self.store = store
         self.retriever = DecisionRetriever(store.decisions())
         self.top = top

--- a/mneme-project-memory/mneme/benchmark_report.py
+++ b/mneme-project-memory/mneme/benchmark_report.py
@@ -13,6 +13,7 @@ import json
 from dataclasses import dataclass
 
 from mneme.benchmark import ScenarioResult, ScenarioVerdict
+from mneme.context_builder import DEFAULT_MAX_DECISIONS
 
 
 _WIDTH = 72
@@ -41,7 +42,7 @@ class BenchmarkSummary:
     mean_precision_at_k: float = 0.0
     irrelevant_injection_rate: float = 0.0
     layer1_scored_count: int = 0
-    k: int = 5
+    k: int = DEFAULT_MAX_DECISIONS
 
 
 def compute_summary(results: list[ScenarioResult]) -> BenchmarkSummary:
@@ -82,7 +83,7 @@ def compute_summary(results: list[ScenarioResult]) -> BenchmarkSummary:
         injection_rate = 0.0
 
     k_values = {r.layer1_k for r in results if r.layer1_k}
-    k = next(iter(k_values)) if len(k_values) == 1 else (max(k_values) if k_values else 5)
+    k = next(iter(k_values)) if len(k_values) == 1 else (max(k_values) if k_values else DEFAULT_MAX_DECISIONS)
 
     return BenchmarkSummary(
         total=len(results),

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -13,6 +13,7 @@ from mneme.benchmark import (
     load_scenario,
     score_layer1,
 )
+from mneme.context_builder import DEFAULT_MAX_DECISIONS
 from mneme.decision_retriever import ScoredDecision
 from mneme.memory_store import MemoryStore
 from mneme.schemas import Decision
@@ -284,7 +285,7 @@ def test_runner_records_layer1_on_result():
     store.load()
     runner = BenchmarkRunner(store)
     result = runner.run_scenario(load_scenario(FIXTURE_SCENARIO))
-    assert result.layer1_k == 5
+    assert result.layer1_k == DEFAULT_MAX_DECISIONS
     assert result.layer1_expected_ids == ["mneme_storage_json"]
     assert "mneme_storage_json" in result.layer1_retrieved_ids
     assert result.layer1_recall == 1.0


### PR DESCRIPTION
## Summary

- **Benchmark / runtime alignment.** The harness was hardcoded to `top=5` while the production runtime retrieves up to `DEFAULT_MAX_DECISIONS = 3` per query (defined at `mneme-project-memory/mneme/context_builder.py:126`). After this PR they share the same constant.
- **Measurement integrity, not behaviour change.** No retrieval logic touched, no scoring weights, no fixtures, no thresholds, no assertion DSL. Only what the harness counts as "the top-K window." Honors `rule-bench-retrieval-coupling`.
- **Production and benchmark K now aligned at 3.** Recall@K, Precision@K, and irrelevant-injection rate now reflect what the live LLM actually sees.

## Honest metric shift

| Metric | K=5 (pre-PR) | K=3 (post-PR) | Notes |
|---|---|---|---|
| Layer 2 pass rate | 5/5 (100%) | 5/5 (100%) | Unchanged — enforcement still catches every seeded violation. |
| Mean recall@K | 1.00 | 1.00 | Unchanged — every expected ID is still in the top-3. |
| Mean precision@K | 0.24 | 0.333 | Rises because the K denominator shrinks from 5 → 3. Mathematically forced (1 expected ID per scenario, K=3 → 1/3). |
| Irrelevant injection rate | 100% | 100% | **Still 100%.** Retrieval noise is an open problem; this PR aligns measurement, it does not solve it. |

The 100% irrelevant-injection rate is **acknowledged and out of scope** here. Reducing it is tracked separately under future Step 3A work and will need a retrieval-side change in its own PR.

## What changed

- `mneme-project-memory/mneme/benchmark.py`: import `DEFAULT_MAX_DECISIONS`; `BenchmarkRunner(top=5)` → `top=DEFAULT_MAX_DECISIONS`; `ScenarioResult.layer1_k = 5` → `= DEFAULT_MAX_DECISIONS`. (commit `12ad697`)
- `mneme-project-memory/mneme/benchmark_report.py`: import `DEFAULT_MAX_DECISIONS`; `BenchmarkSummary.k = 5` → `= DEFAULT_MAX_DECISIONS`; `compute_summary` empty-results fallback `else 5)` → `else DEFAULT_MAX_DECISIONS)`. (commit `5c0b6f1`)
- `mneme-project-memory/tests/test_benchmark.py`: the single default-path assertion (`test_runner_records_layer1_on_result`) now reads `result.layer1_k == DEFAULT_MAX_DECISIONS` instead of `== 5`, importing the constant rather than hardcoding `3` so it tracks production. (commit `1163aa3`)
- `mneme-project-memory/examples/benchmarks/reports/{results.json,RESULTS.md}`: regenerated by running the CLI at the new default. (commit `6f9f754`)

Production-code change is 6 lines across 3 files. The 11 explicit `score_layer1(..., k=5)` override-path tests and the `_result_with_layer1(k: int = 5)` helper default in `test_benchmark_report.py` are intentionally preserved — they exercise the override API at an arbitrary K, not the runtime default.

## Why the artifact diff looks large

The committed artifacts (`results.json` 162 net inserts, `RESULTS.md` 11 net inserts) account for nearly all the line count, but **most of that is one-time v1.1 schema/report migration, not metric churn**. The previous artifacts predated v1.1 entirely — no `summary.layer1`/`summary.layer2` namespacing, no `weak_retrieval` field, no per-result `layer1`/`layer2` blocks, no `Recall@K`/`Precision@K`/`Irrelevant` columns in the Markdown table. v1.1 Step 1 and Step 2 added those fields to the writer code but the artifacts were never regenerated. This PR's K change is the natural occasion to do that regeneration.

The artifacts are pure CLI output — re-running `python -m mneme.cli benchmark examples/benchmarks --memory examples/project_memory.json --json examples/benchmarks/reports/results.json --markdown examples/benchmarks/reports/RESULTS.md` from `mneme-project-memory/` produces a byte-identical tree.

## What this PR explicitly does NOT do

- No changes to retrieval modules: `decision_retriever.py`, `pipeline.py`, `context_builder.py` (other than referencing the existing constant), `enforcer.py`. Verified with `git diff d73e8f7..HEAD --name-only`.
- No scoring-weight, stopword, or fallback-score changes.
- No fixture, threshold, or assertion-DSL edits.
- No methodology page (`site/benchmark/`) updates — no copy currently hardcodes `K=5`.
- No ADR scan pipeline work, no live LLM mode, no dashboard changes.
- Does not solve retrieval signal-to-noise (the 100% irrelevant-injection rate).

## Test plan

- [x] `python -m pytest mneme-project-memory/tests/` — **266 passed**, 0 failed
- [x] `python -m mneme.cli benchmark examples/benchmarks --memory examples/project_memory.json` — exit 0, 5/5 PASS
- [x] `python -m mneme.cli check --mode warn ...` against the regenerated `RESULTS.md` — `Result: PASS`, exit 0
- [x] Per-task spec-compliance reviews — all clean
- [x] Per-task code-quality reviews — no Critical or Important issues across all four tasks
- [x] Final cumulative review against `d73e8f7..HEAD` — production-ready, ship it
- [x] Artifact authenticity check — re-running the regeneration CLI produces a byte-identical working tree

Plan: [`docs/plans/2026-05-09-benchmark-k-alignment.md`](https://github.com/TheoV823/mneme/blob/claude/nervous-feynman-6691b9/docs/plans/2026-05-09-benchmark-k-alignment.md)

Step 3A.i (PR #15, retrieval-side groundwork) merged immediately before this PR was started, per the audit-trail discipline that retrieval and benchmark changes land in separate PRs.