### PR TITLE
Benchmark hardening and governance regression expansion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,12 @@
 - Keep GTM/pricing/customer/internal strategy content out of this repo.
 - Run `mneme check --mode warn` before finalizing governance-related changes.
 - Keep PRs narrowly scoped.
+
+## Tag Policy
+
+Tags in this repo mark **durable milestones only**:
+
+- `v0.x.y` — product/runtime releases
+- `benchmark-vX.Y-stepN` — citeable benchmark methodology milestones (when public)
+
+**Never tag** for: site deployments, cache purges, SEO/content ops, retro notes, or CI/infra housekeeping. Use GitHub Actions run history or the private `mneme-growth-ops` repo for operational tracking instead.

--- a/mneme-project-memory/examples/benchmarks/feature_boundary_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/feature_boundary_violation/scenario.json
@@ -3,5 +3,11 @@
   "category": "scope",
   "description": "LLM recommends multi-agent loops which are explicitly ruled out in v1.",
   "expected_failure_terms": ["multi-agent", "tool-use", "function calling", "autonomous"],
-  "expected_protected_decision_ids": ["anti-002"]
+  "expected_protected_decision_ids": ["anti-002"],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "autogen"},
+    {"type": "forbidden_dependency", "value": "crewai"},
+    {"type": "forbidden_path_pattern", "value": "agents/"},
+    {"type": "forbidden_path_pattern", "value": "coordinator"}
+  ]
 }

--- a/mneme-project-memory/examples/benchmarks/feature_boundary_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/feature_boundary_violation/scenario.json
@@ -7,7 +7,6 @@
   "assertions": [
     {"type": "forbidden_dependency", "value": "autogen"},
     {"type": "forbidden_dependency", "value": "crewai"},
-    {"type": "forbidden_path_pattern", "value": "agents/"},
-    {"type": "forbidden_path_pattern", "value": "coordinator"}
+    {"type": "forbidden_path_pattern", "value": "agents/"}
   ]
 }

--- a/mneme-project-memory/examples/benchmarks/feature_boundary_violation/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/feature_boundary_violation/with_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": true,
+  "files_changed": [],
+  "dependencies_added": []
+}

--- a/mneme-project-memory/examples/benchmarks/feature_boundary_violation/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/feature_boundary_violation/without_mneme.json
@@ -1,0 +1,9 @@
+{
+  "refused": false,
+  "files_changed": [
+    "src/agents/coordinator.py",
+    "src/agents/worker.py",
+    "src/tools/mneme_tool.py"
+  ],
+  "dependencies_added": ["autogen", "crewai"]
+}

--- a/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/scenario.json
@@ -3,5 +3,10 @@
   "category": "anti_pattern",
   "description": "LLM recommends LangChain orchestration which is an explicit anti-pattern.",
   "expected_failure_terms": ["langchain", "llamaindex", "chain"],
-  "expected_protected_decision_ids": ["anti-001"]
+  "expected_protected_decision_ids": ["anti-001"],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "langchain"},
+    {"type": "forbidden_dependency", "value": "llama-index"},
+    {"type": "forbidden_path_pattern", "value": "chains/"}
+  ]
 }

--- a/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/with_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": true,
+  "files_changed": [],
+  "dependencies_added": []
+}

--- a/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/framework_abstraction_violation/without_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": false,
+  "files_changed": ["src/chains/main.py", "src/chains/retrieval_chain.py"],
+  "dependencies_added": ["langchain", "langchain-anthropic"]
+}

--- a/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/scenario.json
@@ -3,5 +3,11 @@
   "category": "scope",
   "description": "LLM recommends agentic workers, tool-use loops, and multi-agent orchestration which are explicitly ruled out in v1.",
   "expected_failure_terms": ["agentic", "agent workers", "tool-use", "function calling", "multi-turn"],
-  "expected_protected_decision_ids": ["anti-002"]
+  "expected_protected_decision_ids": ["anti-002"],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "redis"},
+    {"type": "forbidden_dependency", "value": "celery"},
+    {"type": "forbidden_path_pattern", "value": "agents/"},
+    {"type": "forbidden_path_pattern", "value": "orchestration/"}
+  ]
 }

--- a/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/with_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": true,
+  "files_changed": [],
+  "dependencies_added": []
+}

--- a/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/infra_scope_creep_violation/without_mneme.json
@@ -1,0 +1,9 @@
+{
+  "refused": false,
+  "files_changed": [
+    "src/agents/worker.py",
+    "src/orchestration/coordinator.py",
+    "k8s/agent-deployment.yaml"
+  ],
+  "dependencies_added": ["redis", "celery", "kombu"]
+}

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/query.txt
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/query.txt
@@ -1,0 +1,1 @@
+Can we add OpenAI's GPT-4o as an alternative LLM provider alongside Anthropic?

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/scenario.json
@@ -1,0 +1,12 @@
+{
+  "name": "openai_provider_violation",
+  "category": "scope",
+  "description": "LLM proposes adding OpenAI as a provider; dec-005 defers second-provider work to v2 and fact-002 keeps v1 Anthropic-only.",
+  "expected_failure_terms": ["openai", "gpt"],
+  "expected_protected_decision_ids": [],
+  "acceptable_decision_ids": [],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "openai"},
+    {"type": "forbidden_path_pattern", "value": "providers/openai"}
+  ]
+}

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/with_mneme.json
@@ -1,0 +1,1 @@
+{"refused": true, "files_changed": [], "dependencies_added": []}

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/with_mneme.txt
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/with_mneme.txt
@@ -1,0 +1,3 @@
+Project decision dec-005 defers a second LLM provider to v2 (fact-002 keeps v1
+on Anthropic only). Add the abstraction layer when the second provider is
+actually requested by a partner, not speculatively in v1.

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/without_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": false,
+  "files_changed": ["mneme/llm_adapter.py", "mneme/providers/openai.py"],
+  "dependencies_added": ["openai"]
+}

--- a/mneme-project-memory/examples/benchmarks/openai_provider_violation/without_mneme.txt
+++ b/mneme-project-memory/examples/benchmarks/openai_provider_violation/without_mneme.txt
@@ -1,0 +1,2 @@
+Sure. Add openai as a dependency and create a thin LLMAdapter subclass that
+routes by provider name. Most of the existing call sites won't need to change.

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/query.txt
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/query.txt
@@ -1,0 +1,1 @@
+Should we use Pydantic for validating the project memory schema?

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/scenario.json
@@ -7,6 +7,6 @@
   "acceptable_decision_ids": [],
   "assertions": [
     {"type": "forbidden_dependency", "value": "pydantic"},
-    {"type": "forbidden_path_pattern", "value": "mneme/schemas.py"}
+    {"type": "forbidden_path_pattern", "value": "mneme/schemas"}
   ]
 }

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/scenario.json
@@ -1,0 +1,12 @@
+{
+  "name": "pydantic_dependency_creep",
+  "category": "anti_pattern",
+  "description": "LLM proposes Pydantic for schema validation; project preference pref-001 keeps schemas on stdlib dataclasses to avoid the runtime dependency.",
+  "expected_failure_terms": ["pydantic", "BaseModel"],
+  "expected_protected_decision_ids": [],
+  "acceptable_decision_ids": [],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "pydantic"},
+    {"type": "forbidden_path_pattern", "value": "mneme/schemas.py"}
+  ]
+}

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/with_mneme.json
@@ -1,0 +1,1 @@
+{"refused": true, "files_changed": [], "dependencies_added": []}

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/with_mneme.txt
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/with_mneme.txt
@@ -1,0 +1,4 @@
+Project preference pref-001 keeps the schema layer on stdlib dataclasses to
+avoid adding a runtime dependency and keep the install surface minimal. If
+runtime validation is needed later, add it explicitly at the boundary rather
+than swapping the model layer wholesale.

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/without_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": false,
+  "files_changed": ["mneme/schemas.py"],
+  "dependencies_added": ["pydantic"]
+}

--- a/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/without_mneme.txt
+++ b/mneme-project-memory/examples/benchmarks/pydantic_dependency_creep/without_mneme.txt
@@ -1,0 +1,4 @@
+Pydantic is a great fit here. I'd add pydantic as a dependency and replace the
+dataclass models in mneme/schemas.py with Pydantic BaseModel subclasses. You
+get runtime validation, JSON schema generation, and ergonomic .model_dump()
+serialization out of the box. Migrating is a small refactor.

--- a/mneme-project-memory/examples/benchmarks/reports/RESULTS.md
+++ b/mneme-project-memory/examples/benchmarks/reports/RESULTS.md
@@ -2,20 +2,22 @@
 
 | Scenario | Verdict | Baseline | Enhanced | Recall@K | Precision@K | Irrelevant | Notes |
 |---|---|---|---|---|---|---|---|
-| feature_boundary_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | tool, function, multi |
-| framework_abstraction_violation | PASS | 1 | 0 | 1.00 | 0.33 | yes | langchain |
-| infra_scope_creep_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | agentic, tool, function |
-| retrieval_complexity_violation | PASS | 3 | 0 | 1.00 | 0.33 | yes | sentence, vector, embeddings |
+| feature_boundary_violation | PASS | 3 | 0 | 1.00 | 0.33 | yes | autogen, crewai, src/agents/coordinator.py |
+| framework_abstraction_violation | PASS | 2 | 0 | 1.00 | 0.33 | yes | langchain, langchain-anthropic, src/chains/main.py |
+| infra_scope_creep_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | redis, celery, src/agents/worker.py |
+| openai_provider_violation | PASS | 2 | 0 | -- | -- | -- | openai, mneme/providers/openai.py |
+| pydantic_dependency_creep | PASS | 2 | 0 | -- | -- | -- | pydantic, mneme/schemas.py |
+| retrieval_complexity_violation | PASS | 4 | 0 | 1.00 | 0.33 | yes | sentence-transformers, chromadb, src/embeddings/encoder.py |
 | storage_backend_violation | PASS | 5 | 0 | 1.00 | 0.33 | yes | sqlalchemy, alembic, psycopg2-binary |
 
 ## Summary
 
-**Layer 2 (enforcement)** — 5/5 violations caught (100% pass rate).
+**Layer 2 (enforcement)** — 7/7 violations caught (100% pass rate).
 
 **Layer 1 (retrieval, n=5)** — mean Recall@3 1.00, mean Precision@3 0.33, irrelevant injection rate 100%.
 
 **By category:**
 
-- **anti_pattern**: 1/1 PASS
+- **anti_pattern**: 2/2 PASS
 - **architecture**: 2/2 PASS
-- **scope**: 2/2 PASS
+- **scope**: 3/3 PASS

--- a/mneme-project-memory/examples/benchmarks/reports/results.json
+++ b/mneme-project-memory/examples/benchmarks/reports/results.json
@@ -1,21 +1,21 @@
 {
   "summary": {
-    "total": 5,
-    "passed": 5,
+    "total": 7,
+    "passed": 7,
     "failed": 0,
     "weak": 0,
     "weak_retrieval": 0,
     "pass_rate": 1.0,
     "by_category": {
       "scope": {
+        "pass": 3,
+        "fail": 0,
+        "total": 3
+      },
+      "anti_pattern": {
         "pass": 2,
         "fail": 0,
         "total": 2
-      },
-      "anti_pattern": {
-        "pass": 1,
-        "fail": 0,
-        "total": 1
       },
       "architecture": {
         "pass": 2,
@@ -31,7 +31,7 @@
       "scored_count": 5
     },
     "layer2": {
-      "passed": 5,
+      "passed": 7,
       "failed": 0,
       "weak": 0,
       "weak_retrieval": 0,
@@ -42,16 +42,16 @@
     {
       "name": "feature_boundary_violation",
       "verdict": "PASS",
-      "baseline_violation_count": 4,
+      "baseline_violation_count": 3,
       "enhanced_violation_count": 0,
       "baseline_triggers": [
-        "tool",
-        "function",
-        "multi",
-        "between"
+        "autogen",
+        "crewai",
+        "src/agents/coordinator.py",
+        "src/agents/worker.py"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (tool, function, multi); enhanced response had none. Retrieved: anti-002.",
+      "explanation": "Mneme prevented the violation. Baseline triggered 3 violation(s) (autogen, crewai, src/agents/coordinator.py); enhanced response had none. Retrieved: anti-002.",
       "layer1": {
         "k": 3,
         "retrieved_ids": [
@@ -69,13 +69,13 @@
       },
       "layer2": {
         "verdict": "PASS",
-        "baseline_violation_count": 4,
+        "baseline_violation_count": 3,
         "enhanced_violation_count": 0,
         "baseline_triggers": [
-          "tool",
-          "function",
-          "multi",
-          "between"
+          "autogen",
+          "crewai",
+          "src/agents/coordinator.py",
+          "src/agents/worker.py"
         ],
         "enhanced_triggers": [],
         "protected_decision_ids_hit": [
@@ -86,13 +86,16 @@
     {
       "name": "framework_abstraction_violation",
       "verdict": "PASS",
-      "baseline_violation_count": 1,
+      "baseline_violation_count": 2,
       "enhanced_violation_count": 0,
       "baseline_triggers": [
-        "langchain"
+        "langchain",
+        "langchain-anthropic",
+        "src/chains/main.py",
+        "src/chains/retrieval_chain.py"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (langchain); enhanced response had none. Retrieved: anti-001.",
+      "explanation": "Mneme prevented the violation. Baseline triggered 2 violation(s) (langchain, langchain-anthropic, src/chains/main.py); enhanced response had none. Retrieved: anti-001.",
       "layer1": {
         "k": 3,
         "retrieved_ids": [
@@ -110,10 +113,13 @@
       },
       "layer2": {
         "verdict": "PASS",
-        "baseline_violation_count": 1,
+        "baseline_violation_count": 2,
         "enhanced_violation_count": 0,
         "baseline_triggers": [
-          "langchain"
+          "langchain",
+          "langchain-anthropic",
+          "src/chains/main.py",
+          "src/chains/retrieval_chain.py"
         ],
         "enhanced_triggers": [],
         "protected_decision_ids_hit": [
@@ -127,13 +133,13 @@
       "baseline_violation_count": 4,
       "enhanced_violation_count": 0,
       "baseline_triggers": [
-        "agentic",
-        "tool",
-        "function",
-        "multi"
+        "redis",
+        "celery",
+        "src/agents/worker.py",
+        "src/orchestration/coordinator.py"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (agentic, tool, function); enhanced response had none. Retrieved: anti-002.",
+      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (redis, celery, src/agents/worker.py); enhanced response had none. Retrieved: anti-002.",
       "layer1": {
         "k": 3,
         "retrieved_ids": [
@@ -154,10 +160,10 @@
         "baseline_violation_count": 4,
         "enhanced_violation_count": 0,
         "baseline_triggers": [
-          "agentic",
-          "tool",
-          "function",
-          "multi"
+          "redis",
+          "celery",
+          "src/agents/worker.py",
+          "src/orchestration/coordinator.py"
         ],
         "enhanced_triggers": [],
         "protected_decision_ids_hit": [
@@ -166,17 +172,86 @@
       }
     },
     {
-      "name": "retrieval_complexity_violation",
+      "name": "openai_provider_violation",
       "verdict": "PASS",
-      "baseline_violation_count": 3,
+      "baseline_violation_count": 2,
       "enhanced_violation_count": 0,
       "baseline_triggers": [
-        "sentence",
-        "vector",
-        "embeddings"
+        "openai",
+        "mneme/providers/openai.py"
       ],
       "enhanced_triggers": [],
-      "explanation": "Mneme prevented the violation. Baseline triggered 3 violation(s) (sentence, vector, embeddings); enhanced response had none. Retrieved: mneme_retrieval_deterministic.",
+      "explanation": "Mneme prevented the violation. Baseline triggered 2 violation(s) (openai, mneme/providers/openai.py); enhanced response had none. Retrieved: .",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 1.0,
+        "irrelevant_injection": false
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 2,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "openai",
+          "mneme/providers/openai.py"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      }
+    },
+    {
+      "name": "pydantic_dependency_creep",
+      "verdict": "PASS",
+      "baseline_violation_count": 2,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [
+        "pydantic",
+        "mneme/schemas.py"
+      ],
+      "enhanced_triggers": [],
+      "explanation": "Mneme prevented the violation. Baseline triggered 2 violation(s) (pydantic, mneme/schemas.py); enhanced response had none. Retrieved: .",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "rule-003",
+          "rule-002",
+          "rule-005"
+        ],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.0,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 2,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "pydantic",
+          "mneme/schemas.py"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      }
+    },
+    {
+      "name": "retrieval_complexity_violation",
+      "verdict": "PASS",
+      "baseline_violation_count": 4,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [
+        "sentence-transformers",
+        "chromadb",
+        "src/embeddings/encoder.py",
+        "src/vector_store/chroma_index.py"
+      ],
+      "enhanced_triggers": [],
+      "explanation": "Mneme prevented the violation. Baseline triggered 4 violation(s) (sentence-transformers, chromadb, src/embeddings/encoder.py); enhanced response had none. Retrieved: mneme_retrieval_deterministic.",
       "layer1": {
         "k": 3,
         "retrieved_ids": [
@@ -194,12 +269,13 @@
       },
       "layer2": {
         "verdict": "PASS",
-        "baseline_violation_count": 3,
+        "baseline_violation_count": 4,
         "enhanced_violation_count": 0,
         "baseline_triggers": [
-          "sentence",
-          "vector",
-          "embeddings"
+          "sentence-transformers",
+          "chromadb",
+          "src/embeddings/encoder.py",
+          "src/vector_store/chroma_index.py"
         ],
         "enhanced_triggers": [],
         "protected_decision_ids_hit": [

--- a/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/scenario.json
+++ b/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/scenario.json
@@ -3,5 +3,12 @@
   "category": "architecture",
   "description": "LLM recommends embeddings + vector DB when deterministic keyword retrieval is required.",
   "expected_failure_terms": ["embeddings", "sentence-transformers", "vector", "semantic"],
-  "expected_protected_decision_ids": ["mneme_retrieval_deterministic"]
+  "expected_protected_decision_ids": ["mneme_retrieval_deterministic"],
+  "assertions": [
+    {"type": "forbidden_dependency", "value": "sentence-transformers"},
+    {"type": "forbidden_dependency", "value": "chromadb"},
+    {"type": "forbidden_dependency", "value": "faiss"},
+    {"type": "forbidden_path_pattern", "value": "embeddings/"},
+    {"type": "forbidden_path_pattern", "value": "vector_store/"}
+  ]
 }

--- a/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/with_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/with_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": true,
+  "files_changed": [],
+  "dependencies_added": []
+}

--- a/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/without_mneme.json
+++ b/mneme-project-memory/examples/benchmarks/retrieval_complexity_violation/without_mneme.json
@@ -1,0 +1,5 @@
+{
+  "refused": false,
+  "files_changed": ["src/embeddings/encoder.py", "src/vector_store/chroma_index.py"],
+  "dependencies_added": ["sentence-transformers", "chromadb"]
+}

--- a/mneme-project-memory/mneme/benchmark.py
+++ b/mneme-project-memory/mneme/benchmark.py
@@ -16,7 +16,9 @@ provide:
 
 Each side (with / without) is evaluated independently: structured if a
 .json file is present and parses, TXT otherwise. Missing .json files
-silently fall back to TXT — no warning, no MALFORMED.
+fall back to TXT and emit a UserWarning (no MALFORMED). All shipped
+scenarios carry both JSON siblings; a fired warning means an unmigrated
+or accidentally-deleted fixture.
 
 Verdict logic (Layer 2 — enforcement):
   PASS            — baseline has >= 1 violation; enhanced has 0 violations
@@ -34,6 +36,7 @@ recorded on every ScenarioResult regardless of Layer 2 verdict.
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -100,8 +103,19 @@ def _load_optional_structured(json_path: Path) -> tuple[StructuredOutput | None,
     Returns (parsed, reason). Reason is non-empty only when the file exists
     but failed to parse — in which case parsed is None and the caller should
     surface ScenarioVerdict.MALFORMED.
+
+    When the sibling is missing, emit a UserWarning (the loader falls back
+    to the TXT keyword path; no MALFORMED). All shipped scenarios as of
+    Step 3B carry both JSON siblings, so a fired warning means a fixture
+    is missing a structured payload.
     """
     if not json_path.exists():
+        warnings.warn(
+            f"Benchmark scenario {json_path.parent.name}: missing structured "
+            f"sibling '{json_path.name}' — falling back to TXT keyword path.",
+            UserWarning,
+            stacklevel=3,
+        )
         return None, ""
     try:
         return StructuredOutput.from_json(

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -559,3 +559,29 @@ def test_runner_infra_scope_creep_uses_structured_path():
         or "agents/" in joined
         or "orchestration/" in joined
     )
+
+
+def test_pydantic_dependency_creep_uses_structured_path():
+    """pydantic_dependency_creep runs through the structured Layer 2 path —
+    triggers come from forbidden_dependency on `pydantic`, not from TXT
+    keyword fallback."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "pydantic_dependency_creep"
+    scenario = load_scenario(fixture)
+
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    # 'pydantic' is the only structured trigger; the TXT path on this fixture's
+    # without_mneme.txt would also produce keyword matches on 'pydantic', so
+    # also assert on the structured-only path entry.
+    assert "pydantic" in joined
+    assert "mneme/schemas.py" in joined

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -535,3 +535,27 @@ def test_runner_feature_boundary_uses_structured_path():
         or "agents/" in joined
         or "coordinator" in joined
     )
+
+
+def test_runner_infra_scope_creep_uses_structured_path():
+    """infra_scope_creep_violation runs through structured Layer 2 path."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "infra_scope_creep_violation"
+    scenario = load_scenario(fixture)
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions, "scenario.json must declare assertions"
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    assert (
+        "redis" in joined
+        or "celery" in joined
+        or "agents/" in joined
+        or "orchestration/" in joined
+    )

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -332,8 +332,10 @@ def test_runner_existing_fixtures_still_pass():
     # Each scenario that declares expected protected IDs must achieve
     # recall = 1.0 (the PASS verdict already proves the expected ID was
     # retrieved). Scenarios with empty expected_protected_decision_ids
-    # have vacuous-true recall = 1.0 by definition.
+    # are excluded — vacuous-true recall would mask a real regression.
     for r in results:
+        if not r.layer1_expected_ids:
+            continue
         assert r.layer1_recall == 1.0, (
             f"{r.name} recall@{r.layer1_k}={r.layer1_recall}, expected 1.0"
         )

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -141,7 +141,7 @@ def test_run_suite_loads_all_benchmark_scenarios():
     store.load()
     runner = BenchmarkRunner(store)
     results = runner.run_suite(BENCHMARKS_DIR)
-    assert len(results) == 5
+    assert len(results) == 7
     names = {r.name for r in results}
     assert "storage_backend_violation" in names
     assert "retrieval_complexity_violation" in names
@@ -317,22 +317,23 @@ def test_runner_weak_retrieval_when_layer1_recall_incomplete(tmp_path):
     assert "nonexistent_decision_id" in result.layer1_expected_ids
 
 
-def test_runner_existing_5_fixtures_still_pass():
-    """Regression guard: layered scoring must not change the 5 v1.0 verdicts."""
+def test_runner_existing_fixtures_still_pass():
+    """Regression guard: layered scoring must not change the shipped verdicts."""
     store = MemoryStore(EXAMPLE_MEMORY)
     store.load()
     runner = BenchmarkRunner(store)
     results = runner.run_suite(BENCHMARKS_DIR)
-    # Same shape as before: 5 scenarios, all PASS.
-    assert len(results) == 5
+    # All shipped scenarios must PASS.
+    assert len(results) == 7
     assert all(r.verdict == ScenarioVerdict.PASS for r in results), (
         "Layer 1 introduction changed an existing verdict: "
         + ", ".join(f"{r.name}={r.verdict}" for r in results)
     )
-    # All 5 declare expected protected IDs; recall should be 1.0 for each
-    # (the v1.0 PASS already proved the expected ID was retrieved).
+    # Each scenario that declares expected protected IDs must achieve
+    # recall = 1.0 (the PASS verdict already proves the expected ID was
+    # retrieved). Scenarios with empty expected_protected_decision_ids
+    # have vacuous-true recall = 1.0 by definition.
     for r in results:
-        assert r.layer1_expected_ids, f"{r.name} missing layer1_expected_ids"
         assert r.layer1_recall == 1.0, (
             f"{r.name} recall@{r.layer1_k}={r.layer1_recall}, expected 1.0"
         )
@@ -585,3 +586,27 @@ def test_pydantic_dependency_creep_uses_structured_path():
     # also assert on the structured-only path entry.
     assert "pydantic" in joined
     assert "mneme/schemas.py" in joined
+
+
+def test_openai_provider_violation_uses_structured_path():
+    """openai_provider_violation runs through the structured Layer 2 path —
+    triggers come from forbidden_dependency / forbidden_path_pattern, not from
+    TXT keyword fallback."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "openai_provider_violation"
+    scenario = load_scenario(fixture)
+
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    # The structured-only file path is the strict signal; bare 'openai' would
+    # also be produced by the TXT keyword path.
+    assert "mneme/providers/openai" in joined

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -511,3 +511,27 @@ def test_runner_retrieval_complexity_uses_structured_path():
         or "embeddings/" in joined
         or "vector_store/" in joined
     )
+
+
+def test_runner_feature_boundary_uses_structured_path():
+    """feature_boundary_violation runs through structured Layer 2 path."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "feature_boundary_violation"
+    scenario = load_scenario(fixture)
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions, "scenario.json must declare assertions"
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    assert (
+        "autogen" in joined
+        or "crewai" in joined
+        or "agents/" in joined
+        or "coordinator" in joined
+    )

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -717,3 +717,214 @@ def test_runner_malformed_concatenates_both_sides(tmp_path):
     assert "with_mneme.json" in result.explanation
     assert "without_mneme.json" in result.explanation
     assert "; " in result.explanation
+
+
+# ── Group B: governance-integrity adversarial coverage ────────────────────
+
+
+def test_layer1_irrelevant_injection_stress_at_default_k():
+    """At K=DEFAULT_MAX_DECISIONS, K-1 irrelevant retrievals drop precision to
+    1/K, recall stays 1.0, and the irrelevant_injection flag fires.
+
+    Stress shape: one expected ID at top score, K-1 noise IDs in the next
+    slots, one further expected ID just below K (proving the K cutoff is
+    enforced and outside-K relevant decisions don't rescue precision)."""
+    scored = _scored(
+        ("d1", 5.0),         # expected, in top-K
+        ("noise1", 4.0),
+        ("noise2", 3.0),     # K=3 cutoff falls here
+        ("d2_offcut", 2.0),  # expected but outside top-K
+    )
+    s = score_layer1(
+        scored,
+        expected_ids=["d1", "d2_offcut"],
+        acceptable_ids=[],
+        k=DEFAULT_MAX_DECISIONS,
+    )
+    assert s.k == DEFAULT_MAX_DECISIONS == 3
+    assert s.retrieved_ids == ["d1", "noise1", "noise2"]
+    assert s.recall == 0.5  # 1 of 2 expected made the cut
+    assert abs(s.precision - (1 / DEFAULT_MAX_DECISIONS)) < 1e-9
+    assert s.irrelevant_injection is True
+
+
+def test_layer1_handles_empty_id_decision_robustly():
+    """A retrieval result whose Decision has an empty id is treated as a
+    distinct id (empty string). It does not crash scoring; it is included
+    in retrieved_ids and counted toward irrelevant_injection if not
+    expected. Documents current robustness — score_layer1 makes no
+    well-formedness assumptions about Decision.id beyond hashability."""
+    valid = _decision("d1")
+    corrupted = _decision("")
+    scored = [
+        ScoredDecision(decision=valid, score=5.0, matches={}),
+        ScoredDecision(decision=corrupted, score=4.0, matches={}),
+    ]
+    s = score_layer1(
+        scored, expected_ids=["d1"], acceptable_ids=[], k=DEFAULT_MAX_DECISIONS,
+    )
+    assert "d1" in s.retrieved_ids
+    assert "" in s.retrieved_ids
+    assert s.recall == 1.0
+    assert s.irrelevant_injection is True  # empty id is not in expected ∪ acceptable
+
+
+def test_layer1_dedups_decisions_with_duplicate_ids_first_seen_wins():
+    """When the same id appears multiple times with different scores, the
+    higher-score occurrence is retained (it appears first in the sorted-desc
+    list passed by the runner). Documents score_layer1's seen-set dedup
+    behavior at benchmark.py:213."""
+    scored = _scored(
+        ("d1", 5.0),  # higher-score d1, retained
+        ("d1", 4.0),  # duplicate id, dropped
+        ("d2", 3.0),
+    )
+    s = score_layer1(
+        scored, expected_ids=["d1", "d2"], acceptable_ids=[],
+        k=DEFAULT_MAX_DECISIONS,
+    )
+    assert s.retrieved_ids == ["d1", "d2"]
+    assert len(s.retrieved_ids) == 2
+    assert s.recall == 1.0
+    assert s.precision == 1.0
+
+
+def test_runner_handles_contradictory_decisions_in_retrieval(tmp_path):
+    """When memory contains two decisions with overlapping scope and
+    conflicting anti_patterns, the runner surfaces BOTH in retrieved_ids
+    and lets the scenario's own assertions drive the Layer 2 verdict.
+
+    Governance-integrity property: the runner does NOT silently drop one
+    decision to resolve the contradiction — that is an ADR-precedence
+    concern, intentionally deferred per the v1.1 methodology. The runner
+    is faithful to what was retrieved."""
+    memory_data = {
+        "meta": {
+            "name": "contradictory-memory", "description": "test",
+            "version": "0.1.0", "owner": "test", "created": "2026-05-09",
+        },
+        "items": [],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "policy_json_only",
+                "decision": "Use JSON storage only",
+                "rationale": "Local-first, zero-setup install.",
+                "scope": ["storage", "backend"],
+                "constraints": ["no postgres"],
+                "anti_patterns": ["sqlalchemy", "alembic"],
+                "created_at": "2026-04-24T00:00:00Z",
+                "updated_at": "2026-04-24T00:00:00Z",
+            },
+            {
+                "id": "policy_postgres_required",
+                "decision": "Use Postgres storage",
+                "rationale": "Relational integrity and transactions.",
+                "scope": ["storage", "backend"],
+                "constraints": ["no json file storage"],
+                "anti_patterns": ["json file storage", "flat file"],
+                "created_at": "2026-04-24T00:00:00Z",
+                "updated_at": "2026-04-24T00:00:00Z",
+            },
+        ],
+    }
+    memory_file = tmp_path / "contradictory_memory.json"
+    memory_file.write_text(json.dumps(memory_data))
+
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    (fixture_dir / "query.txt").write_text(
+        "How should we handle storage backend persistence?"
+    )
+    (fixture_dir / "without_mneme.txt").write_text(
+        "Use Postgres with SQLAlchemy."
+    )
+    (fixture_dir / "with_mneme.txt").write_text(
+        "Two contradicting policies retrieved; deferring."
+    )
+    (fixture_dir / "scenario.json").write_text(json.dumps({
+        "name": "contradictory_scenario",
+        "category": "architecture",
+        "description": "Memory has contradictory storage decisions.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": [
+            "policy_json_only", "policy_postgres_required",
+        ],
+    }))
+
+    store = MemoryStore(memory_file)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(fixture_dir))
+
+    # BOTH contradictory decisions are retrieved — runner does not pick a winner.
+    assert "policy_json_only" in result.layer1_retrieved_ids
+    assert "policy_postgres_required" in result.layer1_retrieved_ids
+    # Recall is 1.0 because both expected IDs are retrieved.
+    assert result.layer1_recall == 1.0
+    # Verdict still resolves deterministically (verdict semantics depend on
+    # whether the TXT enforcer caught the violation in this constructed
+    # scenario — assert only on the governance-integrity property: the
+    # scenario completes without crashing and both contradictory decisions
+    # are visible in the retrieved set for the operator to resolve).
+    assert result.verdict in {
+        ScenarioVerdict.PASS, ScenarioVerdict.FAIL, ScenarioVerdict.WEAK,
+    }
+
+
+def test_runner_dedups_decisions_with_duplicate_ids_via_memory_file(tmp_path):
+    """MemoryStore.load() preserves duplicate-id decisions in the
+    decisions[] array (no load-time uniqueness check). The runner's
+    score_layer1 dedups via its seen-set, so the retrieved_ids list never
+    contains duplicates regardless of upstream input quality.
+
+    Governance-integrity property: a buggy or merged memory file with
+    duplicate decision IDs does not produce inflated retrieval counts."""
+    memory_data = {
+        "meta": {
+            "name": "duplicate-id-memory", "description": "test",
+            "version": "0.1.0", "owner": "test", "created": "2026-05-09",
+        },
+        "items": [], "examples": [],
+        "decisions": [
+            {
+                "id": "dupe_id", "decision": "First copy",
+                "scope": ["storage"], "constraints": [],
+                "anti_patterns": ["postgres"],
+                "created_at": "", "updated_at": "",
+            },
+            {
+                "id": "dupe_id", "decision": "Second copy with different content",
+                "scope": ["storage"], "constraints": [],
+                "anti_patterns": ["sqlalchemy"],
+                "created_at": "", "updated_at": "",
+            },
+        ],
+    }
+    memory_file = tmp_path / "dupe_memory.json"
+    memory_file.write_text(json.dumps(memory_data))
+
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    (fixture_dir / "query.txt").write_text("How should we handle storage backend?")
+    (fixture_dir / "without_mneme.txt").write_text("Use Postgres with SQLAlchemy.")
+    (fixture_dir / "with_mneme.txt").write_text("Use JSON storage only.")
+    (fixture_dir / "scenario.json").write_text(json.dumps({
+        "name": "duplicate_id_scenario",
+        "category": "architecture",
+        "description": "Memory has two decisions sharing the same id.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["dupe_id"],
+    }))
+
+    store = MemoryStore(memory_file)
+    store.load()
+    # MemoryStore is honest about what it loaded.
+    assert len(store.decisions()) == 2
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(fixture_dir))
+
+    # Despite two decisions with id="dupe_id" in memory, retrieved_ids
+    # contains "dupe_id" exactly once.
+    assert result.layer1_retrieved_ids.count("dupe_id") == 1
+    assert result.layer1_recall == 1.0

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -612,3 +612,108 @@ def test_openai_provider_violation_uses_structured_path():
     # The structured-only file path is the strict signal; bare 'openai' would
     # also be produced by the TXT keyword path.
     assert "mneme/providers/openai" in joined
+
+
+# ── Group A: parser-trivia MALFORMED coverage ─────────────────────────────
+
+
+def test_runner_returns_malformed_on_invalid_without_mneme_json(tmp_path):
+    """Broken JSON in without_mneme.json => MALFORMED, explanation names file."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "without_mneme.json").write_text("{not valid json}")
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "malformed_baseline",
+        "category": "architecture",
+        "description": "Broken JSON in without_mneme.json.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+    }))
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(tmp_path))
+    assert result.verdict == ScenarioVerdict.MALFORMED
+    assert "without_mneme.json" in result.explanation
+
+
+def test_runner_malformed_on_type_mismatch_refused_not_bool(tmp_path):
+    """refused: 'no' (string, not bool) => MALFORMED."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "with_mneme.json").write_text(
+        '{"refused": "no", "files_changed": [], "dependencies_added": []}'
+    )
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "type_mismatch_refused",
+        "category": "architecture",
+        "description": "refused must be bool.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+    }))
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(tmp_path))
+    assert result.verdict == ScenarioVerdict.MALFORMED
+    assert "refused" in result.explanation
+
+
+def test_runner_malformed_on_assertions_not_a_list(tmp_path):
+    """scenario.json assertions: a dict (not a list) => MALFORMED."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "assertions_not_list",
+        "category": "architecture",
+        "description": "assertions must be a list.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+        "assertions": {"type": "forbidden_dependency", "value": "sqlalchemy"},
+    }))
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(tmp_path))
+    assert result.verdict == ScenarioVerdict.MALFORMED
+    assert "assertions" in result.explanation
+
+
+def test_runner_malformed_on_unknown_assertion_type_via_fixture(tmp_path):
+    """An unknown assertion type at scenario level => MALFORMED with index."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "unknown_assertion_type",
+        "category": "architecture",
+        "description": "forbidden_function is not a known assertion type.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+        "assertions": [
+            {"type": "forbidden_function", "value": "create_engine"},
+        ],
+    }))
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(tmp_path))
+    assert result.verdict == ScenarioVerdict.MALFORMED
+    assert "assertions[0]" in result.explanation
+
+
+def test_runner_malformed_concatenates_both_sides(tmp_path):
+    """Both sides broken => explanation lists both filenames separated by '; '."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "with_mneme.json").write_text("{not json}")
+    (tmp_path / "without_mneme.json").write_text("{also not json}")
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "both_sides_malformed",
+        "category": "architecture",
+        "description": "Both sides have broken JSON.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+    }))
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    result = runner.run_scenario(load_scenario(tmp_path))
+    assert result.verdict == ScenarioVerdict.MALFORMED
+    assert "with_mneme.json" in result.explanation
+    assert "without_mneme.json" in result.explanation
+    assert "; " in result.explanation

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -148,7 +148,7 @@ def test_run_suite_loads_all_benchmark_scenarios():
 
 
 def test_run_suite_all_scenarios_pass():
-    """All 5 shipped benchmark scenarios should pass."""
+    """All shipped benchmark scenarios should pass."""
     store = MemoryStore(EXAMPLE_MEMORY)
     store.load()
     runner = BenchmarkRunner(store)

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -749,11 +749,13 @@ def test_layer1_irrelevant_injection_stress_at_default_k():
 
 
 def test_layer1_handles_empty_id_decision_robustly():
-    """A retrieval result whose Decision has an empty id is treated as a
-    distinct id (empty string). It does not crash scoring; it is included
-    in retrieved_ids and counted toward irrelevant_injection if not
-    expected. Documents current robustness — score_layer1 makes no
-    well-formedness assumptions about Decision.id beyond hashability."""
+    """Documents one corruption mode (empty Decision.id) of the broader
+    "partial retrieval corruption" category: an empty id is treated as a
+    distinct hashable key by the seen-set, included in retrieved_ids, and
+    counted toward irrelevant_injection if not expected. score_layer1 makes
+    no well-formedness assumptions about Decision.id beyond hashability.
+    Other corruption modes (None decision, invalid scoring) are not
+    covered here."""
     valid = _decision("d1")
     corrupted = _decision("")
     scored = [
@@ -772,8 +774,9 @@ def test_layer1_handles_empty_id_decision_robustly():
 def test_layer1_dedups_decisions_with_duplicate_ids_first_seen_wins():
     """When the same id appears multiple times with different scores, the
     higher-score occurrence is retained (it appears first in the sorted-desc
-    list passed by the runner). Documents score_layer1's seen-set dedup
-    behavior at benchmark.py:213."""
+    list passed by the runner). Documents the seen-set dedup behavior in
+    score_layer1. Tied-score dedup is not exercised here — input order
+    would tie-break, which is non-deterministic across retrievers."""
     scored = _scored(
         ("d1", 5.0),  # higher-score d1, retained
         ("d1", 4.0),  # duplicate id, dropped
@@ -862,14 +865,15 @@ def test_runner_handles_contradictory_decisions_in_retrieval(tmp_path):
     assert "policy_postgres_required" in result.layer1_retrieved_ids
     # Recall is 1.0 because both expected IDs are retrieved.
     assert result.layer1_recall == 1.0
-    # Verdict still resolves deterministically (verdict semantics depend on
-    # whether the TXT enforcer caught the violation in this constructed
-    # scenario — assert only on the governance-integrity property: the
-    # scenario completes without crashing and both contradictory decisions
-    # are visible in the retrieved set for the operator to resolve).
-    assert result.verdict in {
-        ScenarioVerdict.PASS, ScenarioVerdict.FAIL, ScenarioVerdict.WEAK,
-    }
+    # Verdict resolves deterministically: without_mneme.txt ("Use Postgres
+    # with SQLAlchemy") matches anti_patterns of both retrieved decisions
+    # (sqlalchemy and postgres), so baseline_count >= 1. with_mneme.txt
+    # ("Two contradicting policies retrieved; deferring") trips no
+    # forbidden term, so enhanced_count == 0. Both expected ids retrieved
+    # → PASS. The governance-integrity property is that the runner
+    # surfaces both contradictory decisions for operator review without
+    # silently picking one.
+    assert result.verdict == ScenarioVerdict.PASS
 
 
 def test_runner_dedups_decisions_with_duplicate_ids_via_memory_file(tmp_path):

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -468,3 +468,22 @@ def test_runner_storage_backend_uses_structured_path():
     # Triggers come from the asserted dep/path values, not enforcer keywords.
     joined = " ".join(result.baseline_triggers).lower()
     assert "sqlalchemy" in joined or "alembic" in joined or "migrations/" in joined
+
+
+def test_runner_framework_abstraction_uses_structured_path():
+    """framework_abstraction_violation runs through structured Layer 2 path."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "framework_abstraction_violation"
+    scenario = load_scenario(fixture)
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions, "scenario.json must declare assertions"
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    assert "langchain" in joined or "chains/" in joined

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -486,7 +486,7 @@ def test_runner_framework_abstraction_uses_structured_path():
     result = runner.run_scenario(scenario)
     assert result.verdict == ScenarioVerdict.PASS
     joined = " ".join(result.baseline_triggers).lower()
-    assert "langchain" in joined or "chains/" in joined
+    assert "langchain-anthropic" in joined or "src/chains/" in joined
 
 
 def test_runner_retrieval_complexity_uses_structured_path():

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -487,3 +487,27 @@ def test_runner_framework_abstraction_uses_structured_path():
     assert result.verdict == ScenarioVerdict.PASS
     joined = " ".join(result.baseline_triggers).lower()
     assert "langchain" in joined or "chains/" in joined
+
+
+def test_runner_retrieval_complexity_uses_structured_path():
+    """retrieval_complexity_violation runs through structured Layer 2 path."""
+    store = MemoryStore(EXAMPLE_MEMORY)
+    store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "retrieval_complexity_violation"
+    scenario = load_scenario(fixture)
+    assert scenario.with_mneme_structured is not None
+    assert scenario.with_mneme_structured.refused is True
+    assert scenario.without_mneme_structured is not None
+    assert scenario.without_mneme_structured.refused is False
+    assert scenario.assertions, "scenario.json must declare assertions"
+
+    result = runner.run_scenario(scenario)
+    assert result.verdict == ScenarioVerdict.PASS
+    joined = " ".join(result.baseline_triggers).lower()
+    assert (
+        "sentence-transformers" in joined
+        or "chromadb" in joined
+        or "embeddings/" in joined
+        or "vector_store/" in joined
+    )

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -1,5 +1,6 @@
 """Tests for BenchmarkRunner — scenario loading and PASS/FAIL/WEAK verdicts."""
 import json
+import warnings
 from pathlib import Path
 
 import pytest
@@ -932,3 +933,85 @@ def test_runner_dedups_decisions_with_duplicate_ids_via_memory_file(tmp_path):
     # contains "dupe_id" exactly once.
     assert result.layer1_retrieved_ids.count("dupe_id") == 1
     assert result.layer1_recall == 1.0
+
+
+# ── Task 4: TXT-fallback warning ──────────────────────────────────────────
+
+
+def test_load_scenario_warns_when_txt_only_no_json_siblings(tmp_path):
+    """When a scenario has TXT but no JSON siblings, a UserWarning is
+    emitted once per missing side. Behaviour is otherwise identical:
+    scenario still loads, no MALFORMED, TXT keyword path still drives
+    Layer 2."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "txt_only_warning",
+        "category": "architecture",
+        "description": "TXT only — should produce a UserWarning per side.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+    }))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        scenario = load_scenario(tmp_path)
+    msgs = [str(w.message) for w in caught
+            if issubclass(w.category, UserWarning)]
+    assert any("with_mneme.json" in m for m in msgs), (
+        f"Expected with_mneme.json warning; got: {msgs}"
+    )
+    assert any("without_mneme.json" in m for m in msgs), (
+        f"Expected without_mneme.json warning; got: {msgs}"
+    )
+    # Behaviour preserved: structured payloads None, malformed_reason empty.
+    assert scenario.malformed_reason == ""
+    assert scenario.with_mneme_structured is None
+    assert scenario.without_mneme_structured is None
+
+
+def test_load_scenario_no_warning_when_both_json_present(tmp_path):
+    """When both JSON siblings exist and parse, no UserWarning is emitted."""
+    _write_minimal_txt_pair(tmp_path)
+    (tmp_path / "with_mneme.json").write_text(json.dumps({
+        "refused": True, "files_changed": [], "dependencies_added": [],
+    }))
+    (tmp_path / "without_mneme.json").write_text(json.dumps({
+        "refused": False,
+        "files_changed": ["alembic/env.py"],
+        "dependencies_added": ["sqlalchemy"],
+    }))
+    (tmp_path / "scenario.json").write_text(json.dumps({
+        "name": "both_json_no_warning",
+        "category": "architecture",
+        "description": "Both JSON sides present — no warning.",
+        "expected_failure_terms": ["postgres"],
+        "expected_protected_decision_ids": ["mneme_storage_json"],
+    }))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_scenario(tmp_path)
+    user_warnings = [w for w in caught
+                     if issubclass(w.category, UserWarning)]
+    assert user_warnings == [], (
+        f"Expected no UserWarning; got {[str(w.message) for w in user_warnings]}"
+    )
+
+
+def test_run_suite_on_shipped_fixtures_emits_no_warnings():
+    """Regression guard: every shipped fixture now has both JSON siblings,
+    so a clean suite run must emit no UserWarning. If this fires, someone
+    removed a JSON sibling from an examples/benchmarks/ fixture."""
+    store = MemoryStore(EXAMPLE_MEMORY); store.load()
+    runner = BenchmarkRunner(store)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        runner.run_suite(BENCHMARKS_DIR)
+    txt_fallback = [
+        w for w in caught
+        if issubclass(w.category, UserWarning)
+        and ("with_mneme.json" in str(w.message)
+             or "without_mneme.json" in str(w.message))
+    ]
+    assert txt_fallback == [], (
+        f"Shipped fixtures should not trigger TXT-fallback warnings. "
+        f"Got: {[str(w.message) for w in txt_fallback]}"
+    )

--- a/mneme-project-memory/tests/test_cli_benchmark.py
+++ b/mneme-project-memory/tests/test_cli_benchmark.py
@@ -43,7 +43,7 @@ def test_benchmark_json_flag(capsys, tmp_path):
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert "summary" in data
-    assert data["summary"]["total"] == 5
+    assert data["summary"]["total"] == 7
 
 
 def test_benchmark_markdown_flag(capsys, tmp_path):


### PR DESCRIPTION
## Summary

Step 3B benchmark hardening — no retrieval optimization, no scoring redesign, no methodology drift. All changes scoped to `mneme-project-memory/`. Locked schema (`{refused, files_changed, dependencies_added}`) and locked assertion DSL (`forbidden_dependency`, `forbidden_path_pattern`) preserved exactly.

**What landed**

- **Structured-JSON migration finished** for the 4 remaining TXT-only fixtures (`framework_abstraction_violation`, `retrieval_complexity_violation`, `feature_boundary_violation`, `infra_scope_creep_violation`). Each got refused-true `with_mneme.json`, plausible `without_mneme.json` with realistic `files_changed` + `dependencies_added`, and an `assertions` array. New regression tests assert structured-only triggers (substrings the legacy TXT path cannot produce).
- **Two new governance-regression scenarios** sourced from real recorded items in `examples/project_memory.json`: `pydantic_dependency_creep` (covers `pref-001`) and `openai_provider_violation` (covers `dec-005` / `fact-002`). Suite goes 5 → 7 fixtures, all PASS. By-category: `anti_pattern` 1→2, `architecture` 2→2, `scope` 2→3.
- **Adversarial coverage** — Group A (5 parser-trivia tests: invalid `without_mneme.json`, type mismatches, malformed assertions, unknown assertion type via fixture, both-sides-malformed concat). Group B (5 governance-integrity tests: irrelevant-injection stress at K=`DEFAULT_MAX_DECISIONS`, partial-corruption empty-id, dup-id dedup unit + integration, contradictory governance packets). All document existing behavior; no prod-code changes.
- **`UserWarning` on silent TXT fallback** — `_load_optional_structured` now warns per missing JSON sibling (no `MALFORMED`, no behavior change otherwise). Shipped 7-fixture suite is silent under `python -W error::UserWarning`. Three regression tests guard the new behavior.
- **Reports regenerated** via the benchmark CLI only (`RESULTS.md`, `results.json`).
- **One stale CLI test count** (`test_benchmark_json_flag` hard-coded `total == 5`) caught and fixed during validation.

## Validation

- `pytest mneme-project-memory/tests/`: **285 passed**, 52 informational warnings (intentional TXT-fallback emissions from tmp_path tests; no escalation)
- `pytest tests/` (repo root): **107 passed**
- `python -m mneme benchmark examples/benchmarks/ --memory examples/project_memory.json`: **7/7 PASS**, Layer 2 100%, Layer 1 (governed n=5) mean recall@3=1.00 / mean precision@3=0.33 / irrelevant injection 100% (all unchanged from baseline — retrieval optimization deferred per scope)
- `mneme check --memory .mneme/project_memory.json --input mneme-project-memory/mneme/benchmark.py --query "..." --mode warn`: exit 0. One pre-existing FAIL trigger (the bare word "only" matching "Anthropic SDK only" anti-pattern) confirmed to fire on the pre-change file from `origin/main` too — not introduced by this branch

## Note on inherited commit

This branch also includes `fb99ae3 docs: add tag policy to CLAUDE.md`, a small CLAUDE.md tag-policy governance note that was already present on the branch before Step 3B execution. It is included in the squash-merge for convenience; tonally compatible with hardening (governance hygiene) but distinct from the benchmark work.

## Test plan

- [x] Package suite green (285 passed)
- [x] Repo-root suite green (107 passed)
- [x] Benchmark CLI 7/7 PASS
- [x] `mneme check --mode warn` clean (no new triggers)
- [ ] Re-run all four after squash-merge to `main`

## Out of scope

No retrieval optimization. No benchmark scoring redesign. No ADR scan pipeline. No methodology redesign. No dashboard / live-LLM mode. No assertion DSL expansion. Step 3C work intentionally deferred until benchmark stabilizes against the hardened suite.