### PR TITLE
fix: align anti-pattern migration with retrieval constraints

### DIFF
--- a/mneme-project-memory/examples/benchmarks/reports/results.json
+++ b/mneme-project-memory/examples/benchmarks/reports/results.json
@@ -55,9 +55,9 @@
       "layer1": {
         "k": 3,
         "retrieved_ids": [
+          "anti-002",
           "mneme_no_agents_v1",
-          "anti-003",
-          "anti-002"
+          "anti-003"
         ],
         "expected_ids": [
           "anti-002"
@@ -100,8 +100,8 @@
         "k": 3,
         "retrieved_ids": [
           "anti-001",
-          "mneme_storage_json",
-          "anti-002"
+          "anti-002",
+          "mneme_storage_json"
         ],
         "expected_ids": [
           "anti-001"

--- a/mneme-project-memory/mneme/memory_store.py
+++ b/mneme-project-memory/mneme/memory_store.py
@@ -111,12 +111,17 @@ class MemoryStore:
                     )
                 )
             elif item.type == "anti_pattern":
+                # Step 3C Stage 1: mirror the rule migration (content ->
+                # constraints). Previously anti_pattern.content landed in
+                # rationale, leaving migrated anti-patterns invisible to the
+                # constraints-weighted retrieval signal (1.5x vs 0.5x).
                 migrated.append(
                     Decision(
                         id=item.id,
                         decision=f"Avoid: {item.title}",
-                        rationale=item.content,
+                        rationale="",
                         scope=["general"],
+                        constraints=[item.content] if item.content else [],
                         anti_patterns=[item.title],
                     )
                 )

--- a/mneme-project-memory/tests/test_benchmark.py
+++ b/mneme-project-memory/tests/test_benchmark.py
@@ -996,6 +996,27 @@ def test_load_scenario_no_warning_when_both_json_present(tmp_path):
     )
 
 
+def test_feature_boundary_violation_retrieves_anti_002_at_rank_1():
+    """Step 3C Stage 1 regression: with anti_pattern.content migrated into
+    `constraints` (1.5x weight) instead of `rationale` (0.5x weight), the
+    feature_boundary_violation scenario must retrieve anti-002 ("Do not
+    add agentic loops in v1") at rank 1 — its content includes "tool-use,
+    function calling, multi-turn agent loops" which directly answers the
+    "Should we add multi-agent support" query.
+
+    Before the fix anti-002 ranked behind mneme_no_agents_v1 because its
+    content lived only in rationale. Locking rank 1 here prevents silent
+    re-introduction of the migration asymmetry."""
+    store = MemoryStore(EXAMPLE_MEMORY); store.load()
+    runner = BenchmarkRunner(store)
+    fixture = BENCHMARKS_DIR / "feature_boundary_violation"
+    result = runner.run_scenario(load_scenario(fixture))
+    assert result.layer1_retrieved_ids[0] == "anti-002", (
+        f"Expected anti-002 at rank 1 after Stage 1 migration symmetry fix; "
+        f"got retrieved_ids={result.layer1_retrieved_ids}"
+    )
+
+
 def test_run_suite_on_shipped_fixtures_emits_no_warnings():
     """Regression guard: every shipped fixture now has both JSON siblings,
     so a clean suite run must emit no UserWarning. If this fires, someone

--- a/mneme-project-memory/tests/test_memory_store_decisions.py
+++ b/mneme-project-memory/tests/test_memory_store_decisions.py
@@ -60,3 +60,54 @@ def test_legacy_anti_pattern_migration_does_not_dump_content_into_anti_patterns(
         "Migration is dumping content prose into anti_patterns; "
         "every word in the content becomes a forbidden term."
     )
+
+
+# ── Step 3C Stage 1: anti_pattern.content migration symmetry ──────────────
+
+
+def test_legacy_anti_pattern_migration_lands_content_in_constraints():
+    """Stage 1 fix: anti_pattern.content must land in `constraints`.
+
+    Symmetry with the rule migration (rule.content -> constraints). Without
+    this, content prose for migrated anti-patterns is invisible to the
+    constraints-weighted retrieval signal and only appears at the
+    rationale weight (0.5x), making migrated anti-patterns systematically
+    under-rank native Decisions on equivalent queries.
+    """
+    store = MemoryStore(FIXTURES / "memory_legacy_only.json")
+    memory = store.load()
+    anti_dec = next(d for d in memory.decisions if d.id == "anti-001")
+    expected_content = "langchain adds weight and abstracts the API surface."
+    assert expected_content in anti_dec.constraints, (
+        f"anti_pattern.content must migrate into constraints; "
+        f"got constraints={anti_dec.constraints}"
+    )
+
+
+def test_legacy_anti_pattern_migration_leaves_rationale_empty():
+    """Stage 1 fix: anti_pattern.content must NOT remain in `rationale`.
+
+    Mirror of the rule migration which sets rationale="". Keeping content
+    in both `constraints` and `rationale` would double-count it under
+    retrieval weights.
+    """
+    store = MemoryStore(FIXTURES / "memory_legacy_only.json")
+    memory = store.load()
+    anti_dec = next(d for d in memory.decisions if d.id == "anti-001")
+    assert anti_dec.rationale == "", (
+        f"Legacy anti_pattern migration must leave rationale empty; "
+        f"got rationale={anti_dec.rationale!r}"
+    )
+
+
+def test_legacy_anti_pattern_migration_preserves_id_type_and_anti_patterns():
+    """Stage 1 fix must not regress the existing migration shape:
+    Decision.id, Decision.decision (Avoid: <title>), scope=['general'],
+    and anti_patterns=[<title>] all still hold."""
+    store = MemoryStore(FIXTURES / "memory_legacy_only.json")
+    memory = store.load()
+    anti_dec = next(d for d in memory.decisions if d.id == "anti-001")
+    assert anti_dec.id == "anti-001"
+    assert anti_dec.decision == "Avoid: Do not use langchain"
+    assert anti_dec.scope == ["general"]
+    assert anti_dec.anti_patterns == ["Do not use langchain"]


### PR DESCRIPTION
## Summary

Step 3C **Stage 1** — first behavioral change after the tie-break baseline ([8d7a398](https://github.com/TheoV823/mneme/commit/8d7a3980142c7868a49e1e6a6f6aa8db489b2d92), PR #20). Corrects **migration asymmetry**, not retriever scoring.

Legacy `anti_pattern` items now migrate `item.content` into `Decision.constraints` (mirroring the rule migration `rule.content -> constraints`) instead of `Decision.rationale`. Previously, migrated anti-patterns were invisible to the constraints-weighted retrieval signal (1.5x) and only visible at the rationale weight (0.5x), systematically under-ranking them against native Decisions on equivalent queries.

## Scope discipline (per Step 3C charter, PR #19)

**No** changes to:
- retriever scoring, weights, tokenizer, stopwords, K
- benchmark fixtures or methodology
- schemas or DSL
- `.mneme/project_memory.json`
- retrieval universe (still 11 Decisions)
- `acceptable_decision_ids`

**Only** change: legacy anti-pattern migration writes to `constraints` instead of `rationale`.

## Benchmark delta

| Metric | Before | After |
|---|---|---|
| Suite verdict | 7/7 PASS | 7/7 PASS |
| recall@3 | 1.00 | 1.00 |
| **recall@1** (5 scoring scenarios) | **0.80 (4/5)** | **1.00 (5/5)** |
| precision@3 | 0.333 | 0.333 |
| irrelevant injection rate | 100% | 100% |

recall@1 is **not** promoted into the suite metrics surface (per the charter, it remains the sharpest tuning dial under fixed methodology, reported in PR descriptions only — not in `RESULTS.md` or `results.json` summary). Surfacing it here per charter reporting honesty.

### Per-scenario rank-1 retrieval

| Scenario | Expected | Before rank 1 | After rank 1 |
|---|---|---|---|
| `feature_boundary_violation` | anti-002 | mneme_no_agents_v1 ❌ | **anti-002** ✅ |
| `framework_abstraction_violation` | anti-001 | anti-001 ✅ | anti-001 ✅ |
| `infra_scope_creep_violation` | anti-002 | anti-002 ✅ | anti-002 ✅ |
| `retrieval_complexity_violation` | mneme_retrieval_deterministic | mneme_retrieval_deterministic ✅ | mneme_retrieval_deterministic ✅ |
| `storage_backend_violation` | mneme_storage_json | mneme_storage_json ✅ | mneme_storage_json ✅ |

The only **rank-2** noise-tail change: `framework_abstraction_violation` rank 2 swaps `mneme_storage_json` ↔ `anti-002`. Charter-anticipated.

## H1 / H2 latent risk validation

The Stage 1 plan flagged two latent risks. Both were probed directly. **Reporting both honestly:**

### H1 — enforcer `^no\s+` constraint expansion: **TRIGGERED, bounded, non-breaking**

`anti-002`'s migrated content begins with "No tool-use, function calling, or multi-turn agent loops in this module…", which matches `enforcer.check_prompt`'s `^no\s+(.+)$` regex. After migration, `anti-002` produces an additional **WARN-severity** violation on the `feature_boundary_violation` baseline text (trigger: `tool`).

**Why this is non-breaking for the shipped suite:**
- All 7 shipped fixtures route through the **structured Layer 2** path (`benchmark_verifier.verify()`), not `check_prompt`. The new WARN never reaches a benchmark verdict.
- The new WARN only fires on the **baseline** text. The enhanced text on both affected fixtures (`feature_boundary_violation`, `framework_abstraction_violation`) was probed directly — verdict remains `PASS`.

**Where it is observable:** direct `mneme check --query "...multi-agent..." --input <file>` calls, where `anti-002` is in the top-3 retrieval and the input contains tokens like `tool`, `function`, `calling`, `multi`, `agent`, `loops`, etc. This is the intended enforcement signal expanding to match the migrated decision body — not a regression.

### H2 — `conflict_detector` candidate expansion from constraints: **NOT TRIGGERED**

Direct probe: `ConflictDetector.detect()` over the `feature_boundary_violation` enhanced text against the new top-3 retrieval (`anti-002, mneme_no_agents_v1, anti-003`) returned **0 conflicts**. The new content words (anchor: `behaviour`) don't appear in the enhanced text, with or without negation context.

## Verification

- Targeted memory-store tests (anti-pattern content → constraints; rationale empty; id/decision/scope/anti_patterns shape preserved): **3 new tests, all pass**
- Targeted benchmark regression test (`feature_boundary_violation.layer1_retrieved_ids[0] == "anti-002"`): **passes**
- Full memory-store + benchmark suite: **55 / 55 pass**
- Enforcer + conflict_detector + retriever suite: **53 / 53 pass**
- Full repo suite: **288 passed, 2 skipped**
- `.mneme/project_memory.json`: **untouched**
- Benchmark fixtures: **untouched**
- `RESULTS.md`: byte-for-byte identical (it doesn't surface `retrieved_ids`; not hand-edited to avoid a reporting-methodology change)

## Test plan

- [x] All new tests fail before the migration change for the documented reasons
- [x] All new tests pass after the migration change
- [x] Full repo suite stays green (288 passed, 2 skipped)
- [x] Benchmark artifacts regenerated via `python -m mneme benchmark`
- [x] H1/H2 probed directly against shipped fixtures
- [x] Scope hygiene: only 4 files changed; no fixtures/`.mneme/`/methodology touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)