### PR TITLE
fix(site): strip Vary: User-Agent to enable Cloudflare caching

### DIFF
--- a/site/.htaccess
+++ b/site/.htaccess
@@ -45,6 +45,12 @@ ErrorDocument 404 /404.html
 </IfModule>
 
 <IfModule mod_headers.c>
+    # Strip any server-injected Vary: User-Agent (added by mod_deflate/mod_brotli
+    # on some cPanel stacks). Cloudflare refuses to cache responses with
+    # Vary: User-Agent, so we unset it and pin exactly what we want.
+    Header unset Vary
+    Header set Vary "Accept-Encoding"
+
     # HTML
     <FilesMatch "\.(html|htm)$">
         Header set Cache-Control "public, max-age=3600"


### PR DESCRIPTION
## Summary

- Apache mod_deflate/mod_brotli on cPanel automatically injects `Vary: User-Agent` (appears twice: `Vary: Accept-Encoding,User-Agent,User-Agent`)
- Cloudflare refuses to cache any response with `Vary: User-Agent`, causing `cf-cache-status: DYNAMIC` on all pages
- Zone analytics confirmed: 3% cache hit rate, 108 MB origin bandwidth over 7 days
- Fix: `Header unset Vary` + `Header set Vary "Accept-Encoding"` in `.htaccess` — strips the injected value and pins exactly what CF needs

## Test plan

After merge, run `python scripts/deploy_site.py` from main, then:

- [ ] `curl -sI https://mnemehq.com/ | grep -i "vary\|cf-cache"` → `Vary: Accept-Encoding`, `cf-cache-status: MISS`
- [ ] Second identical request → `cf-cache-status: HIT`
- [ ] `curl -sI https://mnemehq.com/demo/ | grep -i "vary\|cf-cache"` → same pattern
- [ ] If `Vary: User-Agent` still appears: server-level config is overriding `.htaccess`; fallback is a CF Cache Rule scoped to public HTML only

🤖 Generated with [Claude Code](https://claude.com/claude-code)