### PR TITLE
fix(site,seo): remove duplicate canonical tags from all use-cases pages

### DIFF
--- a/scripts/seo_check.py
+++ b/scripts/seo_check.py
@@ -272,6 +272,9 @@ def rule_canonical(html: str, ctx: PageContext) -> RuleResult:
     href = has_link(html, "canonical")
     if not href:
         return FAIL, "missing rel=canonical"
+    count = len(re.findall(r'<link\b[^>]*\brel\s*=\s*["\']canonical["\']', html, flags=re.I))
+    if count > 1:
+        return FAIL, f"{count} canonical tags (must be exactly 1)"
     return PASS, ""
 
 

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Coding Assistant Governance | Mneme HQ" />
   <meta name="twitter:description" content="Enforce architectural decisions for Cursor, Claude Code, and Copilot. Mneme HQ flags violations before AI-generated code reaches review." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/coding-assistant-governance/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/coding-assistant-governance/" />
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Data Platform Governance | Mneme HQ" />
   <meta name="twitter:description" content="Keep AI assistants aligned with warehouse standards, naming conventions, and pipeline constraints. Mneme HQ enforces data platform architecture at prompt time." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/data-platform-governance/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/data-platform-governance/" />
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Design System Governance | Mneme HQ" />
   <meta name="twitter:description" content="Preserve design tokens, component hierarchy rules, and accessibility requirements for AI-assisted UI development. Mneme HQ flags non-approved usage before code reaches review." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/design-system-governance/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/design-system-governance/" />
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="AI Governance Use Cases for Coding Agents — Mneme HQ" />
   <meta name="twitter:description" content="Architectural governance use cases for AI coding workflows. Enforce ADRs, security boundaries, and engineering standards across Cursor, Claude Code, Copilot, LangGraph, and CrewAI." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/" />
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Legacy Codebase Memory | Mneme HQ" />
   <meta name="twitter:description" content="Capture undocumented constraints and tribal knowledge in a structured decision store. Mneme HQ surfaces hidden rules before AI coding assistants can violate them." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/legacy-codebase-memory/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/legacy-codebase-memory/" />
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Multi-Agent Workflow Governance | Mneme HQ" />
   <meta name="twitter:description" content="A shared decision layer every agent in your pipeline can query. Mneme HQ enforces architectural rules across planner, coder, and reviewer stages of automated AI workflows." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/multi-agent-workflow-governance/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/multi-agent-workflow-governance/" />
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -19,7 +19,6 @@
   <meta name="twitter:title" content="Security &amp; Compliance Guardrails | Mneme HQ" />
   <meta name="twitter:description" content="Enforce PII handling rules, auth requirements, and secrets policies before AI-generated code reaches review. Mneme HQ is a scalable guardrail for LLM-powered development." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/security-compliance-guardrails/og.png" />
-  <link rel="canonical" href="https://mnemehq.com/use-cases/security-compliance-guardrails/" />
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->


### PR DESCRIPTION
All 7 use-cases pages had an identical `<link rel="canonical">` tag at both line 10 (correct position) and line 22 (right after twitter:image). Removed the second occurrence from each file.

Also adds a duplicate-canonical check to `rule_canonical` in `seo_check.py` so this class of issue is caught automatically in future audits.