### PR TITLE
fix: resolve /integrations/adr-import/ WAF redirect and llms.txt entry

### DIFF
--- a/site/integrations/adr-import/.htaccess
+++ b/site/integrations/adr-import/.htaccess
@@ -1,0 +1,7 @@
+# Suppress WAF false-positives triggered by "import" in the URL path.
+# Imunify360 / ModSecurity injection-detection rules flag "import" as a
+# potential SQL/code injection keyword and intercept the request, then
+# fail to redirect back to the original URL (falling through to /).
+<IfModule security2_module>
+    SecRuleEngine Off
+</IfModule>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -37,6 +37,7 @@ How Mneme HQ fits into the tools engineering teams already use.
 - [Claude Code integration](https://mnemehq.com/integrations/claude-code/): Hook-level enforcement for every Edit, Write, and MultiEdit Claude Code attempts.
 - [Cursor integration](https://mnemehq.com/integrations/cursor/): Mneme HQ as the authoritative corpus behind Cursor Rules sessions.
 - [GitHub Actions integration](https://mnemehq.com/integrations/github-actions/): CI enforcement gate — block PRs that violate architectural decisions before they merge.
+- [ADR import integration](https://mnemehq.com/integrations/adr-import/): Import an existing ADR corpus into Mneme's enforcement pipeline. Add a Constraints section to any ADR, run one command to preview, one to apply — decisions become live guardrails without rewriting your ADRs.
 
 ## Key pages
 


### PR DESCRIPTION
## Summary

- **WAF redirect fix**: Imunify360/ModSecurity flags `"import"` in the URL path as a potential injection keyword, intercepts with a JS challenge, then fails to redirect back — falling through to `/` (homepage). A directory-level `.htaccess` with `SecRuleEngine Off` suppresses the false positive for `/integrations/adr-import/` only.
- **llms.txt entry**: The ADR import integration page was missing from `site/llms.txt`, so AI systems couldn't discover it. Added alongside the other three integration pages (confirmed clean by `seo_check.py`).

## Test plan

- [ ] Merge to main and deploy
- [ ] Visit `https://mnemehq.com/integrations/adr-import/` — page should load directly, no challenge or homepage redirect
- [ ] Confirm `seo_check.py` still returns `OK` for `integrations/adr-import/index.html`

https://claude.ai/code/session_01L3QpJR7MU8N5JsRZs1Zqc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3QpJR7MU8N5JsRZs1Zqc8)_