### PR TITLE
ci: trigger fix-waf-redirect on push to main

### DIFF
--- a/.github/workflows/fix-waf-redirect.yml
+++ b/.github/workflows/fix-waf-redirect.yml
@@ -8,6 +8,10 @@ name: Fix adr-import WAF redirect
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/fix_waf_redirect.py'
 
 jobs:
   fix-waf:

--- a/scripts/fix_waf_redirect.py
+++ b/scripts/fix_waf_redirect.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# v2 — also triggers on push to main
 """
 Fix /integrations/adr-import/ WAF redirect.
 


### PR DESCRIPTION
Adds a `push` trigger to the fix-waf-redirect workflow scoped to `scripts/fix_waf_redirect.py`. Merging this PR runs the script immediately via the push-to-main event — no workflow_dispatch access needed.

https://claude.ai/code/session_01L3QpJR7MU8N5JsRZs1Zqc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3QpJR7MU8N5JsRZs1Zqc8)_