### PR TITLE
fix: self-check no-merge-base error

### DIFF
--- a/.github/workflows/mneme-check.yml
+++ b/.github/workflows/mneme-check.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin "${{ github.base_ref }}" --depth=1 >/dev/null 2>&1
+          git fetch origin "${{ github.base_ref }}" >/dev/null 2>&1
           base_sha="$(git rev-parse "origin/${{ github.base_ref }}")"
           mkdir -p /tmp/mneme
           : > /tmp/mneme/files.txt


### PR DESCRIPTION
Removes `--depth=1` from the `git fetch origin base_ref` step.

The checkout already uses `fetch-depth: 0` (full history). The shallow fetch then overwrites `origin/main` with a single disconnected commit, so `git diff base_sha...HEAD` errors with `no merge base`.

Removing `--depth=1` lets the fetch reuse the full history already present.