### PR TITLE
site: Why CLAUDE.md Stops Scaling article and Warp works-with entry

### DIFF
--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -44,6 +44,7 @@
         "url": "https://mnemehq.com/insights/",
         "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
         "hasPart": [
+          {"@type": "Article", "name": "Why CLAUDE.md Stops Scaling", "url": "https://mnemehq.com/insights/why-claude-md-stops-scaling/"},
           {"@type": "Article", "name": "What Is the AI SDLC?", "url": "https://mnemehq.com/insights/what-is-the-ai-sdlc/"},
           {"@type": "Article", "name": "Quantifying GitHub Copilot's Impact: What the SPACE Framework Actually Reveals", "url": "https://mnemehq.com/insights/github-copilot-space-framework/"},
           {"@type": "Article", "name": "AI Coding Governance Should Be Reviewable", "url": "https://mnemehq.com/insights/ai-coding-governance-should-be-reviewable/"},
@@ -282,6 +283,19 @@
   <div class="cards-section">
     <div class="section-divider"><span class="section-label">The governance problem</span></div>
     <div class="cards-grid">
+
+      <div class="insight-card">
+        <div class="card-meta">
+          <span class="card-tag">Category Education</span>
+          <span class="card-dot"></span>
+          <span class="card-read-time">10 min read</span>
+        </div>
+        <h3>Why CLAUDE.md Stops Scaling</h3>
+        <p>Teams start with a small CLAUDE.md. Then the file grows into a governance system &mdash; with none of the infrastructure governance requires. Here is where the ceiling is and what comes next.</p>
+        <div class="card-footer">
+          <a href="/insights/why-claude-md-stops-scaling/" class="read-link">Read &rarr;</a>
+        </div>
+      </div>
 
       <div class="insight-card">
         <div class="card-meta">

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -1,0 +1,743 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Why CLAUDE.md Stops Scaling &mdash; Mneme HQ</title>
+  <meta name="description" content="CLAUDE.md is an instruction surface, not a governance layer. It works until teams scale, decisions evolve, and agents run autonomously. Here is where the ceiling is." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0c0c0d" />
+  <link rel="canonical" href="https://mnemehq.com/insights/why-claude-md-stops-scaling/" />
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Mneme HQ" />
+  <meta property="og:title" content="Why CLAUDE.md Stops Scaling" />
+  <meta property="og:description" content="CLAUDE.md is an instruction surface, not a governance layer. It works until teams scale, decisions evolve, and agents run autonomously. Here is where the ceiling is." />
+  <meta property="og:url" content="https://mnemehq.com/insights/why-claude-md-stops-scaling/" />
+  <meta property="og:image" content="https://mnemehq.com/insights/why-claude-md-stops-scaling/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Why CLAUDE.md Stops Scaling" />
+  <meta name="twitter:description" content="CLAUDE.md is an instruction surface, not a governance layer. It works until teams scale, decisions evolve, and agents run autonomously. Here is where the ceiling is." />
+  <meta name="twitter:image" content="https://mnemehq.com/insights/why-claude-md-stops-scaling/og.png" />
+  <meta name="author" content="Theo Valmis" />
+  <meta property="article:published_time" content="2026-05-14T00:00:00Z" />
+  <meta property="article:author" content="https://mnemehq.com/founder/" />
+  <meta property="article:section" content="Engineering" />
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
+  <!-- End Google Tag Manager -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0c0c0d; --surface: #141416; --surface2: #1a1a1d;
+      --border: #222226; --border2: #2e2e34;
+      --text: #e8e8ec; --muted: #88889a;
+      --accent: #c8f060; --accent-dim: #a8d040; --teal: #8be0c8;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; min-height: 100vh; }
+    nav { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 2.5rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(12,12,13,0.95); backdrop-filter: blur(12px); z-index: 100; }
+    .logo { display: flex; align-items: center; text-decoration: none; }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.82rem; transition: color 0.15s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .btn-nav-cta { background: var(--accent); color: #0c0c0d; padding: 0.45rem 1.1rem; border-radius: 6px; font-size: 0.82rem; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+    .btn-nav-cta:hover { background: var(--accent-dim); color: #0c0c0d; }
+
+    .article-wrap { max-width: 720px; margin: 0 auto; padding: 5rem 2rem 7rem; }
+    .article-header { margin-bottom: 3.5rem; }
+    .article-eyebrow { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; }
+    .eyebrow-tag { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); font-family: 'DM Mono', monospace; }
+    .eyebrow-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--border2); }
+    .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
+    .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
+    .article-lede { font-size: 1.1rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
+
+    .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
+    .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
+    .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body p strong { color: var(--text); font-weight: 500; }
+    .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
+    .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
+    .article-body ul li strong { color: var(--text); font-weight: 500; }
+
+    .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
+    .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
+    .callout p strong { color: var(--accent); }
+
+    /* Failure stack */
+    .failure-stack { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; margin: 2.5rem 0; }
+    .failure-stack .stack-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .stack-row { display: flex; align-items: flex-start; gap: 1rem; padding: 0.9rem 0; border-bottom: 1px solid var(--border); }
+    .stack-row:last-child { border-bottom: none; padding-bottom: 0; }
+    .stack-row:first-of-type { padding-top: 0; }
+    .stack-num { font-family: 'DM Mono', monospace; font-size: 0.72rem; color: var(--border2); flex-shrink: 0; padding-top: 0.1rem; min-width: 1.5rem; }
+    .stack-content { flex: 1; }
+    .stack-label { font-size: 0.82rem; font-weight: 600; color: var(--text); margin-bottom: 0.25rem; }
+    .stack-desc { font-size: 0.8rem; color: var(--muted); line-height: 1.7; }
+
+    /* Contrast block */
+    .contrast-block { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; margin: 2.5rem 0; }
+    .contrast-cell { background: var(--surface); padding: 1.75rem; }
+    .contrast-cell .label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.75rem; }
+    .contrast-cell .tool { font-size: 0.95rem; font-weight: 600; color: var(--text); margin-bottom: 0.5rem; }
+    .contrast-cell .desc { font-size: 0.82rem; color: var(--muted); line-height: 1.65; }
+    .contrast-cell.accent-left { border-left: 3px solid var(--border2); }
+    .contrast-cell.accent-right { border-left: 3px solid var(--accent); }
+    @media (max-width: 540px) { .contrast-block { grid-template-columns: 1fr; } }
+
+    /* Growth curve */
+    .growth-curve { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: stretch; margin: 2.5rem 0; }
+    .gc-stage { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.5rem 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
+    .gc-stage--overload { border-color: rgba(200, 96, 96, 0.4); }
+    .gc-tag { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+    .gc-stage--overload .gc-tag { color: rgba(220, 120, 120, 0.85); }
+    .gc-title { font-size: 0.88rem; font-weight: 600; color: var(--text); }
+    .gc-stage--overload .gc-title { color: rgba(240, 180, 180, 0.9); }
+    .gc-items { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.3rem; flex: 1; }
+    .gc-items li { font-size: 0.78rem; color: var(--muted); line-height: 1.5; padding-left: 0.75rem; position: relative; }
+    .gc-items li::before { content: '\00b7'; position: absolute; left: 0; color: var(--border2); }
+    .gc-stage--overload .gc-items li { color: rgba(200, 96, 96, 0.65); }
+    .gc-stage--overload .gc-items li::before { color: rgba(200, 96, 96, 0.4); }
+    .gc-size { font-family: 'DM Mono', monospace; font-size: 0.68rem; color: var(--border2); margin-top: auto; padding-top: 0.75rem; border-top: 1px solid var(--border); }
+    .gc-stage--overload .gc-size { color: rgba(200, 96, 96, 0.45); border-top-color: rgba(200, 96, 96, 0.2); }
+    .gc-arrow { display: flex; align-items: center; justify-content: center; padding: 0 0.85rem; color: var(--border2); font-size: 1.1rem; }
+    @media (max-width: 640px) {
+      .growth-curve { grid-template-columns: 1fr; gap: 0.75rem; }
+      .gc-arrow { display: none; }
+    }
+
+    /* Governance stack */
+    .gov-stack { margin: 2.5rem 0; display: flex; flex-direction: column; }
+    .gov-layer { padding: 0.9rem 1.25rem; font-size: 0.85rem; font-weight: 500; border-left: 3px solid var(--border2); background: var(--surface); border-top: 1px solid var(--border); border-right: 1px solid var(--border); border-bottom: none; display: flex; align-items: center; justify-content: space-between; }
+    .gov-layer:first-child { border-radius: 10px 10px 0 0; }
+    .gov-layer:last-child { border-bottom: 1px solid var(--border); border-radius: 0 0 10px 10px; }
+    .gov-layer--accent { border-left-color: var(--accent); background: var(--surface2); }
+    .gov-layer--bright { border-left-color: var(--accent); background: rgba(200, 240, 96, 0.06); color: var(--accent); font-weight: 600; }
+    .gov-layer--dim { color: var(--muted); }
+    .gov-layer-desc { font-family: 'DM Mono', monospace; font-size: 0.66rem; color: var(--muted); letter-spacing: 0.04em; text-align: right; }
+    .gov-layer--bright .gov-layer-desc { color: rgba(200, 240, 96, 0.55); }
+    .gov-layer--accent .gov-layer-desc { color: var(--accent); opacity: 0.65; }
+
+    /* Era table */
+    .era-table { margin: 2.5rem 0; border-radius: 10px; overflow: hidden; border: 1px solid var(--border); }
+    .era-row { display: grid; grid-template-columns: 1fr 1fr; border-bottom: 1px solid var(--border); }
+    .era-row:last-child { border-bottom: none; }
+    .era-row--header { background: var(--surface2); }
+    .era-cell { padding: 0.85rem 1.25rem; font-size: 0.82rem; color: var(--muted); }
+    .era-cell--head { font-family: 'DM Mono', monospace; font-size: 0.67rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+    .era-cell--label { font-weight: 500; color: var(--text); }
+    .era-row--accent { background: rgba(200, 240, 96, 0.05); }
+    .era-row--accent .era-cell { color: var(--accent); font-weight: 500; }
+
+    /* Article footer / FAQ */
+    .article-footer { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .article-faq { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .article-faq h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin-bottom: 1.5rem; color: var(--text); }
+    .article-faq details { margin: 0.75rem 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .article-faq summary { padding: 1rem 1.25rem; cursor: pointer; font-size: 0.88rem; color: var(--text); background: var(--surface); list-style: none; }
+    .article-faq summary::-webkit-details-marker { display: none; }
+    .article-faq summary::before { content: '+ '; color: var(--accent); }
+    .article-faq details[open] summary::before { content: '\2212 '; }
+    .article-faq details[open] summary { border-bottom: 1px solid var(--border); }
+    .article-faq .faq-body { padding: 1.25rem; font-size: 0.86rem; color: var(--muted); line-height: 1.85; }
+    .back-link { color: var(--muted); font-size: 0.82rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; }
+    .back-link:hover { color: var(--text); }
+    .cta-block { margin-top: 2.5rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; }
+    .cta-block h3 { font-family: 'Inter', sans-serif; font-size: 1.1rem; font-weight: 600; margin-bottom: 0.6rem; }
+    .cta-block p { font-size: 0.85rem; color: var(--muted); margin-bottom: 1.25rem; }
+    .btn-primary { display: inline-block; background: var(--accent); color: #0c0c0d; padding: 0.65rem 1.5rem; border-radius: 8px; font-size: 0.85rem; font-weight: 600; font-family: 'DM Mono', monospace; text-decoration: none; transition: background 0.15s; }
+    .btn-primary:hover { background: var(--accent-dim); }
+
+    footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+
+    .breadcrumb-nav { max-width: 720px; margin: 0 auto; padding: 1.75rem 2rem 0.85rem; }
+    .breadcrumb { display: flex; align-items: center; gap: 0.5rem; list-style: none; font-size: 0.82rem; flex-wrap: wrap; }
+    .breadcrumb li + li::before { content: '/'; color: var(--border2); margin-right: 0.5rem; }
+    .breadcrumb a { color: var(--muted); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--text); }
+    .breadcrumb [aria-current="page"] { color: var(--text); }
+
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+
+    /* Related reading */
+    h2#related-reading { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 400; margin-top: 3.5rem; margin-bottom: 0.75rem; }
+    h2#related-reading + ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    h2#related-reading + ul li { margin: 0; }
+    h2#related-reading + ul li a { display: flex; justify-content: space-between; align-items: center; padding: 0.9rem 1.1rem; background: var(--surface); color: var(--text); text-decoration: none; font-size: 0.85rem; font-weight: 500; transition: background 0.15s, color 0.15s; }
+    h2#related-reading + ul li a::after { content: '\2192'; opacity: 0.35; transition: opacity 0.15s, transform 0.15s; display: inline-block; margin-left: 0.5rem; }
+    h2#related-reading + ul li a:hover { background: var(--surface2); color: var(--accent); }
+    h2#related-reading + ul li a:hover::after { opacity: 1; transform: translateX(3px); }
+
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
+    /* Nav upgrade */
+    .nav-hamburger {
+      display: none;
+      background: none;
+      border: 1px solid var(--border2);
+      color: var(--text);
+      width: 40px;
+      height: 40px;
+      border-radius: 8px;
+      cursor: pointer;
+      padding: 0;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 4px;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .nav-hamburger:hover { border-color: var(--accent); }
+    .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .nav-hamburger span {
+      display: block;
+      width: 18px;
+      height: 2px;
+      background: currentColor;
+      border-radius: 1px;
+      transition: transform 0.25s ease, opacity 0.18s ease;
+      transform-origin: center;
+    }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+    @media (max-width: 900px) {
+      html, body { overflow-x: hidden; }
+      body.menu-open { overflow: hidden; }
+      nav, nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+      .nav-hamburger { display: flex; }
+      .nav-links {
+        display: flex !important;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        gap: 0;
+        background: rgba(12,12,13,0.98);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid var(--border);
+        padding: 0 1.25rem;
+        z-index: 99;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        visibility: hidden;
+        transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s;
+      }
+      .nav-links.open {
+        max-height: 80vh;
+        opacity: 1;
+        visibility: visible;
+        padding: 0.5rem 1.25rem 1.25rem;
+        transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s;
+        overflow-y: auto;
+      }
+      .nav-links a:not(.btn-nav-cta) {
+        display: block;
+        color: var(--text);
+        font-size: 0.92rem;
+        padding: 0.85rem 0;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
+      .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
+    }
+
+    @media (max-width: 640px) {
+      .article-wrap { padding: 3rem 1.25rem 5rem; }
+    }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Insights", "item": "https://mnemehq.com/insights/"},
+          {"@type": "ListItem", "position": 3, "name": "Why CLAUDE.md Stops Scaling", "item": "https://mnemehq.com/insights/why-claude-md-stops-scaling/"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Why CLAUDE.md Stops Scaling",
+        "description": "CLAUDE.md is an instruction surface, not a governance layer. It works until teams scale, decisions evolve, and agents run autonomously. Here is where the ceiling is.",
+        "url": "https://mnemehq.com/insights/why-claude-md-stops-scaling/",
+        "datePublished": "2026-05-14",
+        "dateModified": "2026-05-14",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
+        "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
+        "image": "https://mnemehq.com/insights/why-claude-md-stops-scaling/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/insights/why-claude-md-stops-scaling/"
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is CLAUDE.md going away?",
+            "acceptedAnswer": {"@type": "Answer", "text": "No. CLAUDE.md remains a useful instruction surface for behavioral steering and session context. What changes is the expectation of what it can do. At scale, it becomes one layer in a larger governance stack — the part that handles style, conventions, and task framing. The enforcement layer is different infrastructure."}
+          },
+          {
+            "@type": "Question",
+            "name": "What breaks down first in long-running autonomous agent workflows?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Instruction dilution. Context windows fill with task history, tool outputs, and intermediate results. Rules injected at session start have measurably less influence by the middle of a long run. In autonomous loops with retries and multi-step orchestration, this compounds: the model may have correctly followed a rule in step 3 and violated it by step 12, with no enforcement surface to catch the drift."}
+          },
+          {
+            "@type": "Question",
+            "name": "What does a governance layer look like alongside CLAUDE.md?",
+            "acceptedAnswer": {"@type": "Answer", "text": "CLAUDE.md handles behavioral steering: style, conventions, task framing, session context. A governance layer handles constraint enforcement: typed architectural decisions with scope and precedence, deterministic retrieval based on what is being generated, and hook-level blocking before violations reach the codebase. The two operate at different layers and are not substitutes for each other."}
+          },
+          {
+            "@type": "Question",
+            "name": "How is this different from just maintaining better CLAUDE.md hygiene?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Better hygiene addresses the maintenance problem, not the enforcement problem. A well-organized CLAUDE.md is still an advisory text file. The model can still ignore it, misinterpret it, or be overridden by stronger task signals. Governance infrastructure adds deterministic enforcement at the generation layer — something no amount of file hygiene can provide."}
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<nav>
+  <a href="/" class="logo"><img src="/logo-v2.png" alt="Mneme HQ" height="36" style="display:block;"></a>
+  <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
+  <div class="nav-links">
+    <a href="/#how-it-works">How it works</a>
+    <a href="/use-cases/">Use cases</a>
+    <a href="/insights/" class="active">Insights</a>
+    <a href="/roadmap/">Roadmap</a>
+    <a href="/demo/">Demo</a>
+    <a href="/benchmark/">Benchmark</a>
+    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/TheoV823/mneme" class="btn-nav-cta">Get started</a>
+  </div>
+</nav>
+
+<main>
+<div class="answer-capsule">
+  <strong>CLAUDE.md is an instruction surface, not a governance layer.</strong> It is one of the most useful files in modern AI-native development. It is also being stretched into a job it was never designed to do &mdash; and the stretch breaks predictably as teams scale, decisions accumulate, and agents run autonomously.
+</div>
+<nav aria-label="Breadcrumb" class="breadcrumb-nav">
+  <ol class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/insights/">Insights</a></li>
+    <li aria-current="page">Why CLAUDE.md Stops Scaling</li>
+  </ol>
+</nav>
+<article class="article-wrap">
+  <header class="article-header">
+    <div class="article-eyebrow">
+      <span class="eyebrow-tag">Category Education</span>
+      <span class="eyebrow-dot"></span>
+      <span class="eyebrow-meta">10 min read &nbsp;&middot;&nbsp; May 2026</span>
+    </div>
+    <h1>Why CLAUDE.md Stops Scaling</h1>
+    <p class="article-lede">Teams start with a small CLAUDE.md. Then the file grows. Then the team realizes it is no longer maintaining instructions &mdash; it is maintaining a governance system, with none of the infrastructure governance requires.</p>
+    <p class="byline">
+      By <a href="/founder/">Theo Valmis</a>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-14">Published May 2026</time>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-14">Updated May 2026</time>
+    </p>
+  </header>
+
+  <div class="article-body">
+
+    <p>Every engineering team that adopts an AI coding assistant goes through the same evolution. The first sessions are inconsistent. Naming conventions get ignored. Service boundaries blur. Approved dependencies get substituted. The team writes down the rules.</p>
+
+    <p>A CLAUDE.md file in the repo root. A few coding conventions. Architecture notes. Testing expectations. The AI reads them. The sessions improve.</p>
+
+    <p>For a solo developer on a six-month-old codebase, this works well enough to feel like a solution. Then the file grows. More rules. More edge cases. More exceptions. More workflows. Anti-patterns. Deployment procedures. Team-specific carve-outs.</p>
+
+    <p>Eventually something shifts. The team is no longer maintaining instructions. It is maintaining a governance system &mdash; one built on a text file, with no enforcement layer, no precedence engine, and no decision provenance. <strong>Presence of instructions is not equivalent to enforcement.</strong> That gap is invisible at small scale. It becomes structural at large scale.</p>
+
+    <h2>Why CLAUDE.md works &mdash; and why that matters</h2>
+
+    <p>It would be a mistake to dismiss what CLAUDE.md actually does well. The tool has genuine strengths, and the teams using it are solving a real problem correctly &mdash; for a while. Acknowledging this is not politeness. It is precision.</p>
+
+    <p>CLAUDE.md is frictionless. It lives in the repo alongside the code, versioned with git, visible to every engineer and every session. It requires no infrastructure, no tooling, no setup beyond writing a file that was already useful before AI was in the picture. It is human-readable and composable: any engineer can open it, update it, and understand it in minutes.</p>
+
+    <p>For behavioral steering, it works. Style conventions, naming patterns, preferred libraries, testing expectations, deployment notes &mdash; all of it can be communicated to the model at session start and meaningfully improves output consistency. A well-maintained CLAUDE.md on a small team is a real productivity asset.</p>
+
+    <p>These strengths are why the pattern spread. They are also why the ceiling is invisible until you hit it.</p>
+
+    <h2>The instruction-surface ceiling</h2>
+
+    <p>The ceiling is not about Claude. It is not about prompt quality or file organization. It is about what static instruction files can and cannot do, regardless of how well they are written or maintained.</p>
+
+    <p>A text document can describe a rule. It cannot enforce one. A CLAUDE.md can say &#8220;use the repository pattern for all data access.&#8221; It cannot prevent a model from bypassing that pattern when the task signal is strong enough. The rule is present. The enforcement is not.</p>
+
+    <p>This gap is invisible at small scale because teams compensate for it: code review catches violations, the team is small enough to remember the rules, the file is recent enough to still be accurate. As scale increases, each of those compensating factors erodes.</p>
+
+    <div class="growth-curve">
+      <div class="gc-stage">
+        <div class="gc-tag">Stage 1</div>
+        <div class="gc-title">Small file</div>
+        <ul class="gc-items">
+          <li>Coding conventions</li>
+          <li>Architecture notes</li>
+          <li>Testing expectations</li>
+          <li>A few anti-patterns</li>
+        </ul>
+        <div class="gc-size">~50&ndash;150 lines</div>
+      </div>
+      <div class="gc-arrow">&rarr;</div>
+      <div class="gc-stage">
+        <div class="gc-tag">Stage 2</div>
+        <div class="gc-title">Growing complexity</div>
+        <ul class="gc-items">
+          <li>Edge cases</li>
+          <li>Workflow rules</li>
+          <li>Exception handling</li>
+          <li>Deployment notes</li>
+          <li>Team-specific exceptions</li>
+        </ul>
+        <div class="gc-size">~300&ndash;600 lines</div>
+      </div>
+      <div class="gc-arrow">&rarr;</div>
+      <div class="gc-stage gc-stage--overload">
+        <div class="gc-tag">Stage 3</div>
+        <div class="gc-title">Governance overload</div>
+        <ul class="gc-items">
+          <li>Conflicting rules</li>
+          <li>Stale decisions</li>
+          <li>No enforcement</li>
+          <li>Unknown provenance</li>
+          <li>Unmaintainable</li>
+        </ul>
+        <div class="gc-size">1,000+ lines</div>
+      </div>
+    </div>
+
+    <h2>Five failure modes</h2>
+
+    <p>The failure modes are not random. They follow the structure of the tool. Each one is a structural property of static instruction files, not a deficiency fixable by better maintenance or more careful writing.</p>
+
+    <div class="failure-stack">
+      <div class="stack-title">Failure progression</div>
+
+      <div class="stack-row">
+        <div class="stack-num">01</div>
+        <div class="stack-content">
+          <div class="stack-label">Context accretion</div>
+          <div class="stack-desc">Rules accumulate without prioritization semantics. Every token of injected context competes with the actual task. A 3,000-token context block on a complex refactoring session degrades output quality and increases inference cost. More critically: as contradictions accumulate, the model resolves them by natural language interpretation. The important rule and the outdated footnote have equal weight. Important rules get diluted by the volume around them.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">02</div>
+        <div class="stack-content">
+          <div class="stack-label">No deterministic enforcement</div>
+          <div class="stack-desc">The model can ignore, partially follow, reinterpret, or override any instruction in the file. When task completion pressure conflicts with an architectural rule, task completion tends to win. A governance system that depends on probabilistic compliance is not a governance system. The model read the rule. The violation happened anyway. These two facts are not in contradiction &mdash; they are the expected behavior of a text-based suggestion system.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">03</div>
+        <div class="stack-content">
+          <div class="stack-label">No decision provenance</div>
+          <div class="stack-desc">Teams eventually ask: why does this rule exist? Which ADR introduced it? Is it still valid? When was it last reviewed? Was it superseded? A flat text file collapses all provenance into unstructured paragraphs. There is no way to trace a CLAUDE.md rule back to the decision record that created it, the alternatives that were rejected, or the conditions under which it should be superseded. Governance without provenance is institutional knowledge decay in progress.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">04</div>
+        <div class="stack-content">
+          <div class="stack-label">Poor scope resolution</div>
+          <div class="stack-desc">Different rules apply globally, per service, per directory, per workflow, per environment. Flat instruction files have no mechanism for precedence, specificity, or conflict resolution. An org-level rule and a team-level exception coexist as equal-weight paragraphs. The model picks one based on proximity and attention in the context window. When two rules genuinely conflict, the outcome is model interpretation, not deterministic resolution.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">05</div>
+        <div class="stack-content">
+          <div class="stack-label">Autonomous agent drift</div>
+          <div class="stack-desc">This failure mode matters most as AI workflows shift from single-response generation to iterative execution loops, autonomous retries, and multi-agent orchestration. Context windows fill with task history and tool outputs. Rules injected at session start have measurably less influence by the middle of a long run. A violation in step 12 of an autonomous workflow is invisible to a rule read in step 1. Generation scales faster than governance.</div>
+        </div>
+      </div>
+
+    </div>
+
+    <h2>The real category shift</h2>
+
+    <p>These failure modes are not surprising once you understand the era they belong to. CLAUDE.md is a context engineering tool. It solves context engineering problems well. The problem teams are actually running into is a governance infrastructure problem &mdash; a different category with different requirements.</p>
+
+    <div class="era-table">
+      <div class="era-row era-row--header">
+        <div class="era-cell era-cell--head">Era</div>
+        <div class="era-cell era-cell--head">Primary problem</div>
+      </div>
+      <div class="era-row">
+        <div class="era-cell era-cell--label">Prompt engineering</div>
+        <div class="era-cell">Better outputs</div>
+      </div>
+      <div class="era-row">
+        <div class="era-cell era-cell--label">Context engineering</div>
+        <div class="era-cell">Better retrieval</div>
+      </div>
+      <div class="era-row">
+        <div class="era-cell era-cell--label">Agent orchestration</div>
+        <div class="era-cell">Longer workflows</div>
+      </div>
+      <div class="era-row era-row--accent">
+        <div class="era-cell">Governance infrastructure</div>
+        <div class="era-cell">Architectural integrity</div>
+      </div>
+    </div>
+
+    <p>Each era solved its problem and revealed the next one. Better prompts improved output quality but could not enforce architectural invariants. Better context improved relevance but added no precedence or provenance. Longer workflows surfaced the drift that short sessions had hidden. The current problem is not a better version of the previous one. It requires different infrastructure.</p>
+
+    <h2>The memory misdiagnosis</h2>
+
+    <p>When teams hit the ceiling, the common misdiagnosis is that the model has a memory problem. The file is too long. The rules are not being retained across sessions. The context window is filling up.</p>
+
+    <p>This leads to the wrong remedies: structured retrieval, semantic search over decision documents, RAG pipelines over architectural notes. These are real tools for real problems. They are not the right tool for this one.</p>
+
+    <div class="contrast-block">
+      <div class="contrast-cell accent-left">
+        <div class="label">The misdiagnosis</div>
+        <div class="tool">Memory problem</div>
+        <div class="desc">The model forgot the rule. The context was too long. Better retrieval will solve it. A more organized file will help.</div>
+      </div>
+      <div class="contrast-cell accent-right">
+        <div class="label">The actual problem</div>
+        <div class="tool">Enforcement problem</div>
+        <div class="desc">Architectural constraints were not enforced deterministically. The model had access to the rule and violated it anyway. No retrieval system fixes probabilistic compliance.</div>
+      </div>
+    </div>
+
+    <p>Architectural integrity cannot rely on probabilistic recall alone. A system where a constraint <em>might</em> be followed, depending on context window pressure and model interpretation, is not a governance system. It is a soft suggestion that usually works.</p>
+
+    <p>For most outputs, soft suggestions are fine. For architectural invariants that protect service boundaries, dependency policies, or security requirements, &#8220;usually works&#8221; is not a viable guarantee. The difference between those two categories is the governance boundary.</p>
+
+    <h2>The governance stack</h2>
+
+    <p>The right framing is not that CLAUDE.md is obsolete. It is that CLAUDE.md is one layer in a larger stack &mdash; specifically the layer that handles behavioral steering, style, and session context. The layer it cannot be is the enforcement layer.</p>
+
+    <div class="gov-stack">
+      <div class="gov-layer gov-layer--bright">
+        <span>Architectural Decisions / ADRs</span>
+        <span class="gov-layer-desc">source of truth</span>
+      </div>
+      <div class="gov-layer gov-layer--accent">
+        <span>Governance Layer</span>
+        <span class="gov-layer-desc">deterministic enforcement</span>
+      </div>
+      <div class="gov-layer gov-layer--dim">
+        <span>Workflow Orchestration</span>
+        <span class="gov-layer-desc">execution</span>
+      </div>
+      <div class="gov-layer gov-layer--dim">
+        <span>Context / Retrieval</span>
+        <span class="gov-layer-desc">preparation &mdash; CLAUDE.md lives here</span>
+      </div>
+      <div class="gov-layer gov-layer--dim">
+        <span>LLM</span>
+        <span class="gov-layer-desc">generation</span>
+      </div>
+    </div>
+
+    <p>The governance layer above context and retrieval is what enforces constraints before generation output is accepted. It operates on structured decision records &mdash; typed, scoped, versioned, with explicit precedence &mdash; not on natural language files that the model reads and interprets. It runs before violations reach the codebase, not after a PR is opened.</p>
+
+    <p>What that layer requires:</p>
+
+    <ul>
+      <li><strong>Scoped governance.</strong> Rules that apply globally, per service, per directory, or per workflow are stored with scope metadata and resolved deterministically when triggered &mdash; not matched by attention weight.</li>
+      <li><strong>Precedence resolution.</strong> When two decisions conflict, the system resolves the conflict by explicit precedence rules. The outcome is not model interpretation of overlapping paragraphs.</li>
+      <li><strong>Enforcement checks.</strong> Decisions are validated against generated output at the hook level, before the file is written. Violations are blocked or flagged, not discovered in review.</li>
+      <li><strong>Decision provenance.</strong> Every constraint traces back to the ADR or decision record that created it, with status, rationale, and supersession history maintained.</li>
+    </ul>
+
+    <p>These are infrastructure properties. They cannot be delivered by a better-maintained text file, regardless of how well it is written. They require a system that operates at a different layer of the stack.</p>
+
+    <h2>What comes next</h2>
+
+    <p>Teams at the early stages of AI adoption have not hit this problem yet. CLAUDE.md works well, sessions are consistent enough, review catches the violations that slip through. The pattern feels like it is scaling.</p>
+
+    <p>The teams that have hit it recognize the symptoms: a CLAUDE.md that has grown into a maintenance burden, rules that conflict without resolution, enforcement that depends on reviewer attention, architectural violations that accumulate slowly and then become structural. Autonomous agents that followed architectural constraints in session 1 and drifted by session 50.</p>
+
+    <p>The solution is not a more organized CLAUDE.md. It is governance infrastructure: structured decision records with scope and precedence, deterministic retrieval based on what is being generated, and hook-level enforcement that operates before output reaches the codebase. That infrastructure is what <a href="https://github.com/TheoV823/mneme" style="color:var(--accent);text-decoration:none;">Mneme</a> is designed to provide &mdash; an architectural compiler layer that sits above the context window, not inside it.</p>
+
+    <div class="callout">
+      <p><strong>CLAUDE.md keeps your context aligned. Mneme keeps your architecture enforced.</strong> The two layers are complements, not competitors. What changes is the expectation of which one is responsible for enforcement &mdash; and the infrastructure needed to deliver on that responsibility.</p>
+    </div>
+
+    <p>AI-native SDLCs are not failing because models are weak. They are failing because instruction surfaces are being mistaken for governance systems. As agent workflows become longer-lived and more autonomous, architectural integrity becomes an infrastructure problem, not a prompting problem.</p>
+
+    <p>That is the category shift. CLAUDE.md is where it starts to show.</p>
+
+  </div>
+
+  <section class="article-faq">
+    <h2>Frequently asked questions</h2>
+    <details>
+      <summary>Is CLAUDE.md going away?</summary>
+      <div class="faq-body">No. CLAUDE.md remains a useful instruction surface for behavioral steering and session context. What changes is the expectation of what it can do. At scale, it becomes one layer in a larger governance stack &mdash; the part that handles style, conventions, and task framing. The enforcement layer is different infrastructure.</div>
+    </details>
+    <details>
+      <summary>What breaks down first in long-running autonomous agent workflows?</summary>
+      <div class="faq-body">Instruction dilution. Context windows fill with task history, tool outputs, and intermediate results. Rules injected at session start have measurably less influence by the middle of a long run. In autonomous loops with retries and multi-step orchestration, this compounds: the model may have correctly followed a rule in step 3 and violated it by step 12 &mdash; with no enforcement surface to catch the drift.</div>
+    </details>
+    <details>
+      <summary>What does a governance layer look like alongside CLAUDE.md?</summary>
+      <div class="faq-body">CLAUDE.md handles behavioral steering: style, conventions, task framing, session context. A governance layer handles constraint enforcement: typed architectural decisions with scope and precedence, deterministic retrieval based on what is being generated, and hook-level blocking before violations reach the codebase. The two operate at different layers and are not substitutes for each other.</div>
+    </details>
+    <details>
+      <summary>How is this different from just maintaining better CLAUDE.md hygiene?</summary>
+      <div class="faq-body">Better hygiene addresses the maintenance problem, not the enforcement problem. A well-organized CLAUDE.md is still an advisory text file. The model can still ignore it, misinterpret it, or be overridden by stronger task signals. Governance infrastructure adds deterministic enforcement at the generation layer &mdash; something no amount of file hygiene can provide.</div>
+    </details>
+  </section>
+
+  <h2 id="related-reading">Related reading</h2>
+  <ul>
+    <li><a href="/insights/why-prompt-memory-fails-at-scale/">Why Prompt Memory Fails at Scale</a></li>
+    <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
+    <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
+    <li><a href="/benchmark/">Mneme Benchmark &mdash; Retrieval &amp; Enforcement Methodology</a></li>
+  </ul>
+
+  <footer class="article-footer">
+    <a href="/insights/" class="back-link">&larr; Back to Insights</a>
+
+    <div class="cta-block">
+      <h3>Governance infrastructure for AI-native codebases</h3>
+      <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Open source.</p>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+    </div>
+  </footer>
+</article>
+</main>
+
+<footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">
+  <div style="max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 2.5rem 2rem;">
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Product</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/use-cases/">Use cases</a></li>
+        <li><a href="/works-with/">Works with</a></li>
+        <li><a href="/platforms/">Platforms</a></li>
+        <li><a href="/integrations/">Integrations</a></li>
+        <li><a href="/compare/">Compare</a></li>
+        <li><a href="/demo/">Demo</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Learn</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/concepts/">Concepts</a></li>
+        <li><a href="/architecture/">Architecture</a></li>
+        <li><a href="/insights/">Insights</a></li>
+        <li><a href="/standards/">Standards</a></li>
+        <li><a href="/benchmark/">Benchmark</a></li>
+        <li><a href="/docs/">Docs</a></li>
+        <li><a href="/docs/cli/">CLI reference</a></li>
+        <li><a href="/docs/governance-violations/">Governance violations</a></li>
+        <li><a href="/supported-languages/">Supported languages</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Company</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/pilot/" style="color:var(--accent);">Request pilot</a></li>
+        <li><a href="/for/">For teams</a></li>
+        <li><a href="/founder/">Founder</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/roadmap/">Roadmap</a></li>
+        <li><a href="/contact/">Contact</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Code</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
+        <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
+      </ul>
+    </div>
+  </div>
+  <div style="max-width: 1080px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
+    <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
+    <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
+      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+      </a>
+      <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"/></svg>
+      </a>
+      <a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener" aria-label="YouTube" style="color: var(--muted); display: inline-flex;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.12C19.55 3.5 12 3.5 12 3.5s-7.55 0-9.4.58A3 3 0 0 0 .5 6.2 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.12c1.85.58 9.4.58 9.4.58s7.55 0 9.4-.58a3 3 0 0 0 2.1-2.12A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.8zM9.6 15.57V8.43L15.82 12 9.6 15.57z"/></svg>
+      </a>
+      <a href="https://dev.to/mnemehq" target="_blank" rel="noopener" aria-label="DEV.to" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true"><path d="M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35 3.88-2.9 5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.36 47.28l.02 70.93zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19l-.01 29.52zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58l-38.46 144.8z"/></svg>
+      </a>
+    </nav>
+    <span>&copy; 2026</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<script>
+(function(){
+  var btn = document.querySelector('.nav-hamburger');
+  var links = document.querySelector('.nav-links');
+  if (!btn || !links) return;
+  function setOpen(open){
+    links.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', String(open));
+    document.body.classList.toggle('menu-open', open);
+  }
+  btn.addEventListener('click', function(e){
+    e.stopPropagation();
+    setOpen(!links.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e){
+    if (!links.classList.contains('open')) return;
+    if (links.contains(e.target) || btn.contains(e.target)) return;
+    setOpen(false);
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && links.classList.contains('open')) setOpen(false);
+  });
+  links.addEventListener('click', function(e){
+    if (e.target.tagName === 'A') setOpen(false);
+  });
+  window.addEventListener('resize', function(){
+    if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false);
+  });
+})();
+</script>
+</body>
+</html>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -447,8 +447,8 @@
 
   </div>
 
-  <h2 class="group-title">Deployment environments</h2>
-  <p class="group-lede">Mneme runs where engineering teams already work &mdash; the laptop, the CI runner, the self-hosted platform &mdash; without requiring a hosted control plane.</p>
+  <h2 class="group-title">Execution &amp; deployment environments</h2>
+  <p class="group-lede">Mneme runs where engineering teams already work &mdash; the laptop, the AI-native terminal, the CI runner, the self-hosted platform &mdash; without requiring a hosted control plane.</p>
 
   <div class="cards-grid">
 
@@ -458,6 +458,14 @@
       </div>
       <h3>Local developer workflows</h3>
       <p>Runs alongside the developer's editor and CLI agents; governance enforced before the file is written.</p>
+    </div>
+
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">AI-native terminal &middot; works alongside</span>
+      </div>
+      <h3>Warp</h3>
+      <p>Works alongside Warp&rsquo;s AI-native terminal and autonomous execution workflows. Warp accelerates how teams run agents and orchestrate tasks; Mneme preserves the architectural invariants underneath those execution loops.</p>
     </div>
 
     <div class="compare-card">


### PR DESCRIPTION
## Summary

- Adds `/insights/why-claude-md-stops-scaling/` — category-definition article positioning CLAUDE.md as an instruction surface vs. governance layer, with five failure-mode diagrams, growth curve visual, governance stack, era table, contrast block, FAQ section, and full schema.org markup
- Updates `/insights/` index with card and schema.org `hasPart` entry
- Adds Warp to `/works-with/` execution environments section, tagged "works alongside", framed as velocity + governance complement

## Test plan

- [ ] `/insights/why-claude-md-stops-scaling/` loads and renders correctly
- [ ] Visual components (growth curve, failure stack, era table, gov stack, contrast block) display as intended
- [ ] FAQ accordion opens/closes
- [ ] Related reading links resolve
- [ ] `/insights/` index card appears and links correctly
- [ ] `/works-with/` Warp card renders in deployment environments section

🤖 Generated with [Claude Code](https://claude.ai/claude-code)