### PR TITLE
feat: add Notion to works-with ecosystem and Phase 3 roadmap

### DIFF
--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -352,6 +352,7 @@
             <li>Internal engineering agent system hooks</li>
             <li>Agent orchestration framework governance</li>
             <li>API-level constraint enforcement</li>
+            <li>Workspace execution surface governance &mdash; Notion and similar platforms where agents read, write, and trigger workflows</li>
           </ul>
         </div>
       </div>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -447,6 +447,25 @@
 
   </div>
 
+  <h2 class="group-title">Workspace execution surfaces</h2>
+  <p class="group-lede">Workspace platforms are becoming agent execution environments &mdash; places where agents don&rsquo;t just retrieve context but read, write, search, and trigger workflows. As the boundary between knowledge and execution collapses, governance extends beyond code generation into these operational surfaces.</p>
+
+  <div class="cards-grid">
+
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">Workspace platform &middot; on the roadmap</span>
+      </div>
+      <h3>Notion</h3>
+      <p>Notion is evolving into an agent execution environment &mdash; not just documentation, but a surface where agents read, write, search, and trigger workflows. Governance for ADR ingestion, decision corpus import, and invariant preservation across workspace mutations is on the roadmap.</p>
+    </div>
+
+  </div>
+
+  <div class="messaging-block">
+    <strong>The boundary between knowledge and execution is collapsing.</strong> As workspace platforms become agent execution environments, architectural governance expands beyond code generation into the operational surfaces where agents mutate state. Invariant preservation does not stop at the file-write boundary &mdash; it extends to every surface where an agent can change the system.
+  </div>
+
   <h2 class="group-title">Execution &amp; deployment environments</h2>
   <p class="group-lede">Mneme runs where engineering teams already work &mdash; the laptop, the AI-native terminal, the CI runner, the self-hosted platform &mdash; without requiring a hosted control plane.</p>
 


### PR DESCRIPTION
## Summary

- Adds a new "Workspace execution surfaces" section to `/works-with/` with Notion as the first entry (tagged "on the roadmap"), framing it as an agent execution environment rather than a documentation layer
- Includes a messaging block connecting workspace governance to Mneme's core invariant-preservation position
- Adds workspace execution surface governance as a Phase 3 capability item on `/roadmap/`

## Context

Notion's move toward agent-native execution (read, write, search, trigger workflows, orchestrate tasks, update state) validates the broader framing around execution surfaces and governance propagation. The boundary between "knowledge" and "execution" is collapsing — governance can no longer stop at the file-write boundary.

https://claude.ai/code/session_01MiP8SRCAHFu25xasapMPJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiP8SRCAHFu25xasapMPJJ)_