### PR TITLE
feat: add For curators section to about page

### DIFF
--- a/site/about/index.html
+++ b/site/about/index.html
@@ -1204,6 +1204,35 @@
       </div>
     </div>
 
+    <hr class="divider">
+
+    <h2>For curators</h2>
+
+    <p>Quick&#8209;reference copy for directories, newsletters, and tool roundups.</p>
+
+    <div class="callout">
+      <p>Mneme is an open&#8209;source architectural governance layer for AI&#8209;assisted development. It helps teams enforce architecture decisions, ADRs, and engineering constraints before AI&#8209;generated code reaches review.</p>
+    </div>
+
+    <div class="links-grid">
+      <div class="link-row">
+        <span class="link-row-label">GitHub</span>
+        <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">github.com/TheoV823/mneme</a>
+      </div>
+      <div class="link-row">
+        <span class="link-row-label">Website</span>
+        <a href="https://mnemehq.com">mnemehq.com</a>
+      </div>
+      <div class="link-row">
+        <span class="link-row-label">Category</span>
+        <span style="color:var(--muted);font-size:0.85rem;">AI coding governance &middot; architectural governance &middot; developer tools</span>
+      </div>
+      <div class="link-row">
+        <span class="link-row-label">License</span>
+        <span style="color:var(--muted);font-size:0.85rem;">MIT</span>
+      </div>
+    </div>
+
   </div>
 
 </div>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -352,6 +352,7 @@
             <li>Internal engineering agent system hooks</li>
             <li>Agent orchestration framework governance</li>
             <li>API-level constraint enforcement</li>
+            <li>Workspace execution surface governance &mdash; Notion and similar platforms where agents read, write, and trigger workflows</li>
           </ul>
         </div>
       </div>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -447,6 +447,25 @@
 
   </div>
 
+  <h2 class="group-title">Workspace execution surfaces</h2>
+  <p class="group-lede">Workspace platforms are becoming agent execution environments &mdash; places where agents don&rsquo;t just retrieve context but read, write, search, and trigger workflows. As the boundary between knowledge and execution collapses, governance extends beyond code generation into these operational surfaces.</p>
+
+  <div class="cards-grid">
+
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">Workspace platform &middot; on the roadmap</span>
+      </div>
+      <h3>Notion</h3>
+      <p>Notion is evolving into an agent execution environment &mdash; not just documentation, but a surface where agents read, write, search, and trigger workflows. Governance for ADR ingestion, decision corpus import, and invariant preservation across workspace mutations is on the roadmap.</p>
+    </div>
+
+  </div>
+
+  <div class="messaging-block">
+    <strong>The boundary between knowledge and execution is collapsing.</strong> As workspace platforms become agent execution environments, architectural governance expands beyond code generation into the operational surfaces where agents mutate state. Invariant preservation does not stop at the file-write boundary &mdash; it extends to every surface where an agent can change the system.
+  </div>
+
   <h2 class="group-title">Execution &amp; deployment environments</h2>
   <p class="group-lede">Mneme runs where engineering teams already work &mdash; the laptop, the AI-native terminal, the CI runner, the self-hosted platform &mdash; without requiring a hosted control plane.</p>
 


### PR DESCRIPTION
## Summary

- Adds a "For curators" section to `/about/` with structured listing copy for directories, newsletters, and tool roundups
- Includes the one-paragraph blurb, GitHub URL, website, category tags (AI coding governance · architectural governance · developer tools), and MIT license

https://claude.ai/code/session_01MiP8SRCAHFu25xasapMPJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiP8SRCAHFu25xasapMPJJ)_