### PR TITLE
site(insights): add long-running-agents-need-governance article

### DIFF
--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -1,0 +1,868 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Long-Running Agents Need More Than Memory — Mneme HQ</title>
+  <meta name="description" content="Anthropic's managed-agent harness solves continuity: progress logs, feature lists, git checkpoints. But continuity is not governance. As agents work across sessions, codebases need enforceable architectural contracts that define what must remain true." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0c0c0d" />
+  <link rel="canonical" href="https://mnemehq.com/insights/long-running-agents-need-governance/" />
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Mneme HQ" />
+  <meta property="og:title" content="Long-Running Agents Need More Than Memory" />
+  <meta property="og:description" content="Agent harnesses preserve continuity. Governance preserves intent. The missing layer in long-running agent workflows." />
+  <meta property="og:url" content="https://mnemehq.com/insights/long-running-agents-need-governance/" />
+  <meta property="og:image" content="https://mnemehq.com/insights/long-running-agents-need-governance/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Long-Running Agents Need More Than Memory" />
+  <meta name="twitter:description" content="Agent harnesses preserve continuity. Governance preserves intent. The missing layer in long-running agent workflows." />
+  <meta name="twitter:image" content="https://mnemehq.com/insights/long-running-agents-need-governance/og.png" />
+  <meta name="author" content="Theo Valmis" />
+  <meta property="article:published_time" content="2026-05-15T00:00:00Z" />
+  <meta property="article:author" content="https://mnemehq.com/founder/" />
+  <meta property="article:section" content="Engineering" />
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
+  <!-- End Google Tag Manager -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0c0c0d; --surface: #141416; --surface2: #1a1a1d;
+      --border: #222226; --border2: #2e2e34;
+      --text: #e8e8ec; --muted: #88889a;
+      --accent: #c8f060; --accent-dim: #a8d040; --teal: #8be0c8;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; min-height: 100vh; }
+    nav { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 2.5rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(12,12,13,0.95); backdrop-filter: blur(12px); z-index: 100; }
+    .logo { display: flex; align-items: center; text-decoration: none; }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.82rem; transition: color 0.15s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .btn-nav-cta { background: var(--accent); color: #0c0c0d; padding: 0.45rem 1.1rem; border-radius: 6px; font-size: 0.82rem; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+    .btn-nav-cta:hover { background: var(--accent-dim); color: #0c0c0d; }
+
+    .article-wrap { max-width: 720px; margin: 0 auto; padding: 5rem 2rem 7rem; }
+    .article-header { margin-bottom: 3.5rem; }
+    .article-eyebrow { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; }
+    .eyebrow-tag { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); font-family: 'DM Mono', monospace; }
+    .eyebrow-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--border2); }
+    .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
+    .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
+    .article-lede { font-size: 1.1rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
+
+    .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
+    .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
+    .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body p strong { color: var(--text); font-weight: 500; }
+    .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
+    .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
+    .article-body ul li strong { color: var(--text); font-weight: 500; }
+    .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
+    .article-body ol li { margin-bottom: 0.5rem; line-height: 1.8; }
+    .article-body ol li strong { color: var(--text); font-weight: 500; }
+    .article-body code { font-family: 'DM Mono', monospace; font-size: 0.82rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.4rem; color: var(--text); }
+    .article-body pre { font-family: 'DM Mono', monospace; font-size: 0.8rem; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem 1.5rem; color: var(--text); overflow-x: auto; margin: 1.5rem 0 1.75rem; line-height: 1.7; }
+    .article-body pre code { background: none; border: none; padding: 0; font-size: inherit; }
+
+    .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
+    .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
+    .callout p strong { color: var(--accent); }
+
+    .failure-stack { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 2rem; margin: 2.5rem 0; }
+    .failure-stack .stack-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .stack-row { display: flex; align-items: flex-start; gap: 1rem; padding: 0.9rem 0; border-bottom: 1px solid var(--border); }
+    .stack-row:last-child { border-bottom: none; padding-bottom: 0; }
+    .stack-row:first-of-type { padding-top: 0; }
+    .stack-num { font-family: 'DM Mono', monospace; font-size: 0.72rem; color: var(--border2); flex-shrink: 0; padding-top: 0.1rem; min-width: 1.5rem; }
+    .stack-content { flex: 1; }
+    .stack-label { font-size: 0.82rem; font-weight: 600; color: var(--text); margin-bottom: 0.25rem; }
+    .stack-desc { font-size: 0.8rem; color: var(--muted); line-height: 1.7; }
+
+    .contrast-block { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; margin: 2.5rem 0; }
+    .contrast-cell { background: var(--surface); padding: 1.75rem; }
+    .contrast-cell .label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.75rem; }
+    .contrast-cell .tool { font-size: 0.95rem; font-weight: 600; color: var(--text); margin-bottom: 0.5rem; }
+    .contrast-cell .desc { font-size: 0.82rem; color: var(--muted); line-height: 1.65; }
+    .contrast-cell.accent-left { border-left: 3px solid var(--border2); }
+    .contrast-cell.accent-right { border-left: 3px solid var(--accent); }
+    @media (max-width: 540px) { .contrast-block { grid-template-columns: 1fr; } }
+
+    .article-footer { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .back-link { color: var(--muted); font-size: 0.82rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; }
+    .back-link:hover { color: var(--text); }
+    .cta-block { margin-top: 2.5rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 2rem; }
+    .cta-block h3 { font-family: 'Inter', sans-serif; font-size: 1.1rem; font-weight: 600; margin-bottom: 0.6rem; }
+    .cta-block p { font-size: 0.85rem; color: var(--muted); margin-bottom: 1.25rem; }
+    .btn-primary { display: inline-block; background: var(--accent); color: #0c0c0d; padding: 0.65rem 1.5rem; border-radius: 8px; font-size: 0.85rem; font-weight: 600; font-family: 'DM Mono', monospace; text-decoration: none; transition: background 0.15s; }
+    .btn-primary:hover { background: var(--accent-dim); }
+
+    footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+
+    .breadcrumb-nav { max-width: 720px; margin: 0 auto; padding: 1.75rem 2rem 0.85rem; }
+    .breadcrumb { display: flex; align-items: center; gap: 0.5rem; list-style: none; font-size: 0.82rem; flex-wrap: wrap; }
+    .breadcrumb li + li::before { content: '/'; color: var(--border2); margin-right: 0.5rem; }
+    .breadcrumb a { color: var(--muted); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--text); }
+    .breadcrumb [aria-current="page"] { color: var(--text); }
+
+    .toc { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.75rem; margin: 0 0 3rem; }
+    .toc .toc-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.9rem; }
+    .toc ol { list-style: none; counter-reset: toc; margin: 0; padding: 0; display: grid; grid-template-columns: 1fr; gap: 0.45rem; }
+    .toc ol li { counter-increment: toc; font-size: 0.85rem; padding-left: 2.2rem; position: relative; line-height: 1.5; }
+    .toc ol li::before { content: counter(toc, decimal-leading-zero); position: absolute; left: 0; top: 0.05rem; font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--border2); letter-spacing: 0.05em; }
+    .toc a { color: var(--muted); text-decoration: none; transition: color 0.15s; }
+    .toc a:hover { color: var(--accent); }
+    @media (min-width: 720px) { .toc ol { grid-template-columns: 1fr 1fr; gap: 0.55rem 1.5rem; } }
+
+    .figure { margin: 2.5rem 0; }
+    .figure svg { display: block; width: 100%; height: auto; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }
+    .figure figcaption { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); margin-top: 0.75rem; padding-left: 0.25rem; }
+
+    .axis-table { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.75rem; margin: 2.5rem 0; overflow-x: auto; }
+    .axis-table .ax-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1rem; }
+    .axis-table table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    .axis-table th, .axis-table td { text-align: left; padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: top; }
+    .axis-table th { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+    .axis-table td:first-child { color: var(--text); font-weight: 500; min-width: 8rem; }
+    .axis-table tr:last-child td { border-bottom: none; }
+    .axis-table tr.accent-row td { color: var(--accent); }
+    .axis-table tr.accent-row td:first-child { color: var(--accent); }
+
+    .faq-list { margin: 2rem 0 0; }
+    .faq-item { border-top: 1px solid var(--border); padding: 1.1rem 0; }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; transition: transform 0.15s; }
+    .faq-item[open] summary::after { content: '\2212'; }
+    .faq-body { padding-top: 0.9rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
+    .faq-body a { color: var(--accent); text-decoration: none; }
+    .faq-body a:hover { color: var(--accent-dim); }
+
+    .article-body a.ext { color: var(--accent); text-decoration: none; border-bottom: 1px dotted rgba(200,240,96,0.4); }
+    .article-body a.ext:hover { color: var(--accent-dim); border-bottom-color: rgba(200,240,96,0.7); }
+
+    .nav-hamburger {
+      display: none;
+      background: none;
+      border: 1px solid var(--border2);
+      color: var(--text);
+      width: 40px;
+      height: 40px;
+      border-radius: 8px;
+      cursor: pointer;
+      padding: 0;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 4px;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .nav-hamburger:hover { border-color: var(--accent); }
+    .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .nav-hamburger span {
+      display: block;
+      width: 18px;
+      height: 2px;
+      background: currentColor;
+      border-radius: 1px;
+      transition: transform 0.25s ease, opacity 0.18s ease;
+      transform-origin: center;
+    }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+    @media (max-width: 900px) {
+      html, body { overflow-x: hidden; }
+      body.menu-open { overflow: hidden; }
+      nav, nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+      .nav-hamburger { display: flex; }
+      .nav-links {
+        display: flex !important;
+        flex-direction: column;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        gap: 0;
+        background: rgba(12,12,13,0.98);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid var(--border);
+        padding: 0 1.25rem;
+        z-index: 99;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        visibility: hidden;
+        transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s;
+      }
+      .nav-links.open {
+        max-height: 80vh;
+        opacity: 1;
+        visibility: visible;
+        padding: 0.5rem 1.25rem 1.25rem;
+        transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s;
+        overflow-y: auto;
+      }
+      .nav-links a:not(.btn-nav-cta) {
+        display: block;
+        color: var(--text);
+        font-size: 0.92rem;
+        padding: 0.85rem 0;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
+      .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
+      .article-wrap { padding: 3rem 1.25rem 5rem; }
+    }
+
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+
+    h2#related-reading { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 400; margin-top: 3.5rem; margin-bottom: 0.75rem; }
+    h2#related-reading + ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    h2#related-reading + ul li { margin: 0; }
+    h2#related-reading + ul li a { display: flex; justify-content: space-between; align-items: center; padding: 0.9rem 1.1rem; background: var(--surface); color: var(--text); text-decoration: none; font-size: 0.85rem; font-weight: 500; transition: background 0.15s, color 0.15s; }
+    h2#related-reading + ul li a::after { content: '\2192'; opacity: 0.35; transition: opacity 0.15s, transform 0.15s; display: inline-block; margin-left: 0.5rem; }
+    h2#related-reading + ul li a:hover { background: var(--surface2); color: var(--accent); }
+    h2#related-reading + ul li a:hover::after { opacity: 1; transform: translateX(3px); }
+
+    .pull-quote { font-family: 'Instrument Serif', serif; font-size: 1.5rem; line-height: 1.45; color: var(--text); border-left: 2px solid var(--accent); padding: 0.25rem 0 0.25rem 1.25rem; margin: 2.5rem 0; font-style: italic; }
+    .pull-quote em { font-style: normal; color: var(--accent); }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Insights", "item": "https://mnemehq.com/insights/"},
+          {"@type": "ListItem", "position": 3, "name": "Long-Running Agents Need More Than Memory", "item": "https://mnemehq.com/insights/long-running-agents-need-governance/"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Long-Running Agents Need More Than Memory",
+        "description": "Anthropic's managed-agent harness solves continuity: progress logs, feature lists, git checkpoints. But continuity is not governance. As agents work across sessions, codebases need enforceable architectural contracts that define what must remain true.",
+        "url": "https://mnemehq.com/insights/long-running-agents-need-governance/",
+        "datePublished": "2026-05-15",
+        "dateModified": "2026-05-15",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
+        "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
+        "image": "https://mnemehq.com/insights/long-running-agents-need-governance/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/insights/long-running-agents-need-governance/"
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {"@type": "Question", "name": "Is this a criticism of Anthropic's harness?", "acceptedAnswer": {"@type": "Answer", "text": "No. Anthropic's managed-agent harness solves the continuity problem well. Progress logs, feature lists, git checkpoints, and E2E tests are the right operational primitives for long-running work. The article's point is that continuity and governance are two different problems, and solving the first does not automatically solve the second."}},
+          {"@type": "Question", "name": "Can't a progress file just describe architectural rules?", "acceptedAnswer": {"@type": "Answer", "text": "It can record them as text. But text in a progress file has no enforcement authority. The next agent session can read that text and then do something else. Governance requires a deterministic resolver and an enforcement point that output must pass through. A progress note is advisory; a governance check is blocking."}},
+          {"@type": "Question", "name": "What happens without governance in a long-running agent loop?", "acceptedAnswer": {"@type": "Answer", "text": "The loop drifts. Each session adds sensible local changes. Over dozens of sessions, the codebase drifts from its architectural intent without any single session making an obviously wrong decision. The problem is cumulative, and no individual progress log captures it."}},
+          {"@type": "Question", "name": "Where exactly does Mneme fit in this workflow?", "acceptedAnswer": {"@type": "Answer", "text": "Mneme is the governance layer that runs alongside the harness. At session start, mneme check --mode warn tells the incoming agent which architectural constraints apply and whether any are already violated. Before commit or PR, mneme check --mode strict enforces them. Mneme does not replace the progress log, git, or tests. It enforces the constraints those artifacts cannot enforce."}},
+          {"@type": "Question", "name": "Why is governance harder when agents run longer?", "acceptedAnswer": {"@type": "Answer", "text": "Because the surface area for drift grows with each session. A single prompt session makes a bounded set of changes. A long-running loop makes changes across many files, services, and sessions. Each change is locally plausible but collectively drifts from architectural intent. The harness ensures the agent knows what happened. Governance ensures it knows what must remain true."}}
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<nav>
+  <a href="/" class="logo"><img src="/logo-v2.png" alt="Mneme HQ" height="36" style="display:block;"></a>
+  <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
+  <div class="nav-links">
+    <a href="/#how-it-works">How it works</a>
+    <a href="/use-cases/">Use cases</a>
+    <a href="/insights/" class="active">Insights</a>
+    <a href="/roadmap/">Roadmap</a>
+    <a href="/demo/">Demo</a>
+    <a href="/benchmark/">Benchmark</a>
+    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/TheoV823/mneme" class="btn-nav-cta">Get started</a>
+  </div>
+</nav>
+
+<main>
+<nav aria-label="Breadcrumb" class="breadcrumb-nav">
+  <ol class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/insights/">Insights</a></li>
+    <li aria-current="page">Long-Running Agents Need More Than Memory</li>
+  </ol>
+</nav>
+<article class="article-wrap">
+  <header class="article-header">
+    <div class="article-eyebrow">
+      <span class="eyebrow-tag">Thought Leadership</span>
+      <span class="eyebrow-dot"></span>
+      <span class="eyebrow-meta">10 min read &nbsp;&middot;&nbsp; May 2026</span>
+    </div>
+    <h1>Long-running agents need more than memory</h1>
+    <p class="article-lede">Anthropic's managed-agent harness solves one hard problem: continuity. Progress logs, feature lists, git checkpoints, and startup scripts give each new session a map of what happened. But continuity is not governance. As agents work across more sessions, the question changes from <em>did the agent remember?</em> to <em>did the agent stay within its architectural constraints?</em></p>
+    <p class="byline">
+      By <a href="/founder/">Theo Valmis</a>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-15">Published May 2026</time>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-15">Updated May 2026</time>
+    </p>
+  </header>
+
+  <div class="article-body">
+
+    <nav class="toc" aria-label="Table of contents">
+      <div class="toc-title">In this article</div>
+      <ol>
+        <li><a href="#shift-workers">Agents as shift workers</a></li>
+        <li><a href="#harness">What Anthropic's harness gets right</a></li>
+        <li><a href="#gap">The remaining gap: continuity is not governance</a></li>
+        <li><a href="#harder">Why this gets harder as agents run longer</a></li>
+        <li><a href="#governance">The role of governance</a></li>
+        <li><a href="#adrs">ADRs as durable intent, not documentation</a></li>
+        <li><a href="#checkpoints">Where governance checkpoints belong</a></li>
+        <li><a href="#conclusion">Conclusion</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ol>
+    </nav>
+
+    <p>In May 2026, Anthropic published a detailed look at how their internal engineering teams use <a href="https://www.anthropic.com/engineering/managed-agents" class="ext" target="_blank" rel="noopener">Claude Code as a long-running managed agent</a>. The infrastructure pattern they describe is worth reading carefully: initializer agents that prepare the workspace, feature lists that define remaining work, progress files that record what happened, git commits that preserve recoverable state, startup checks that orient each new session, and end-to-end tests that stop agents from declaring victory prematurely.</p>
+
+    <p>This is not prompt engineering. It is operational infrastructure for agents working across many sessions on the same codebase. The problems it solves are real, and the solutions are well-reasoned.</p>
+
+    <p>But the pattern solves continuity. It does not solve governance. Those are two different problems, and conflating them is the most expensive mistake a team can make when designing long-running agent workflows.</p>
+
+    <h2 id="shift-workers">Agents as shift workers</h2>
+
+    <p>The framing that makes the managed-agent pattern click is the relay team metaphor. A long-running agent workflow looks less like one developer with a prompt and more like a team of engineers handing work across shifts.</p>
+
+    <p>Each shift worker arrives, reads the handoff notes, picks up where the last person stopped, makes progress, and leaves a record for the next person. The work continues across interruptions. The codebase evolves across sessions. No single session owns the full context.</p>
+
+    <p>That framing makes the continuity infrastructure obvious. You need:</p>
+
+    <ul>
+      <li><strong>Handoff notes</strong> that are authoritative, not just descriptive (progress files)</li>
+      <li><strong>A work queue</strong> that persists across shifts (feature lists)</li>
+      <li><strong>Recoverable state</strong> at every checkpoint (git commits)</li>
+      <li><strong>Orientation scripts</strong> so each shift starts correctly (startup checks)</li>
+      <li><strong>Pass/fail criteria</strong> that the work must satisfy (E2E tests)</li>
+    </ul>
+
+    <p>Anthropic's harness provides all five. What it does not provide is the architectural contract that defines what kind of work each shift is allowed to do.</p>
+
+    <p>In a real engineering team, that contract exists in ADRs, architecture review boards, code review standards, and the accumulated institutional knowledge of senior engineers. In a long-running agent loop, none of that is automatically present. The harness tells the agent what happened. It does not tell the agent what must remain true.</p>
+
+    <h2 id="harness">What Anthropic's managed-agent harness gets right</h2>
+
+    <p>Before addressing the gap, it is worth being precise about what the harness actually solves, because it solves real problems well.</p>
+
+    <div class="failure-stack">
+      <div class="stack-title">Continuity infrastructure from Anthropic's harness</div>
+
+      <div class="stack-row">
+        <div class="stack-num">01</div>
+        <div class="stack-content">
+          <div class="stack-label">Initializer agent</div>
+          <div class="stack-desc">Prepares the workspace before the main agent session begins. Ensures the environment is in a known state, dependencies are resolved, and relevant context is loaded. Removes a class of session-start failures that otherwise compound across a long loop.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">02</div>
+        <div class="stack-content">
+          <div class="stack-label">Feature list</div>
+          <div class="stack-desc">A durable queue of remaining work, written as discrete, completable items. Prevents sessions from re-litigating scope, duplicating work, or missing items that were already planned. The feature list is authoritative about what remains; the progress file is authoritative about what happened.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">03</div>
+        <div class="stack-content">
+          <div class="stack-label">Progress file</div>
+          <div class="stack-desc">A running record of what each session changed, decided, and left incomplete. The next session reads the progress file before touching code. This is the handoff note that makes the relay team metaphor operational.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">04</div>
+        <div class="stack-content">
+          <div class="stack-label">Git commits as checkpoints</div>
+          <div class="stack-desc">Every meaningful unit of work lands as a recoverable commit. If a session goes sideways, the codebase can be restored to the last known-good state without losing all prior progress. Git history becomes the audit trail for what the agent loop actually did.</div>
+        </div>
+      </div>
+
+      <div class="stack-row">
+        <div class="stack-num">05</div>
+        <div class="stack-content">
+          <div class="stack-label">E2E tests as the victory condition</div>
+          <div class="stack-desc">Agents cannot declare a feature complete until the tests pass. This prevents the most common long-running-agent failure mode: partial implementations marked done because no local signal caught the gap. Tests enforce a floor on output quality that subjective progress notes cannot.</div>
+        </div>
+      </div>
+
+    </div>
+
+    <p>The pattern is good engineering. Each piece of infrastructure corresponds to a real failure mode that long-running agents encounter in practice. Anthropic's teams built this because they hit these failures, and the solutions are worth adopting.</p>
+
+    <h2 id="gap">The remaining gap: continuity is not governance</h2>
+
+    <p>A progress file can tell the next agent: <em>"Here is what I changed."</em></p>
+
+    <p>It cannot reliably tell the agent: <em>"This architecture boundary must not be crossed. This dependency is forbidden. This ADR supersedes that older decision. This pattern is allowed only in this scope. This change conflicts with the repository's architectural intent."</em>
+
+    <p>That distinction matters in practice because the questions a progress file answers and the questions a governance layer answers are different in kind, not just degree.</p>
+
+    <div class="axis-table">
+      <div class="ax-title">Continuity vs governance &middot; what each layer answers</div>
+      <table>
+        <thead>
+          <tr><th>Layer</th><th>Question it answers</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Progress log</td><td>What happened?</td></tr>
+          <tr><td>Feature list</td><td>What remains?</td></tr>
+          <tr><td>Git history</td><td>What changed?</td></tr>
+          <tr><td>Test harness</td><td>Does it work?</td></tr>
+          <tr class="accent-row"><td>Governance layer</td><td>Is this allowed?</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>The first four layers are all answered by the managed-agent harness. The fifth is not. A test suite can verify that the output is functionally correct. It cannot verify that the output is architecturally compliant. Those are different properties, and a codebase can be full of passing tests while being full of architectural violations.</p>
+
+    <p class="pull-quote"><em>Agent harnesses preserve continuity.</em> Governance preserves intent.</p>
+
+    <h2 id="harder">Why this gets harder as agents run longer</h2>
+
+    <p>The governance gap is not specific to long-running agents. Any AI coding workflow can produce architecturally non-compliant output. But long-running agents increase the surface area for drift in ways that matter.</p>
+
+    <p>Over many sessions, a long-running agent loop may:</p>
+
+    <ul>
+      <li><strong>Infer outdated patterns from old code.</strong> A session reads existing files as examples of how things are done. If earlier sessions used a deprecated pattern, the new session infers that pattern is correct and continues it.</li>
+      <li><strong>Reintroduce forbidden dependencies.</strong> A dependency was removed for a documented architectural reason. A later session adds it back because it solves the immediate problem and the prohibition is not in any artifact the agent reads.</li>
+      <li><strong>Bypass undocumented conventions.</strong> Architecture that exists in institutional memory but not in enforceable documents is invisible to the agent. The agent makes the locally sensible decision that violates the convention.</li>
+      <li><strong>Mark incomplete work as complete.</strong> A session finishes the functional layer of a feature and marks it done in the feature list. The non-functional architectural constraints&mdash;error handling conventions, logging standards, security requirements&mdash;are not captured in any test and are not enforced.</li>
+      <li><strong>Optimize locally while violating system-level constraints.</strong> Each session makes a locally reasonable change. The cumulative effect crosses an architectural boundary that no single session was responsible for maintaining.</li>
+    </ul>
+
+    <p>None of these failures show up in a progress file. None of them cause a test suite to fail. They accumulate silently across sessions and become visible only when the codebase is far enough from its architectural intent that the cost of correction is high.</p>
+
+    <p>The longer the loop, the more important invariant preservation becomes. The problem is not that agents forget. The problem is that they improvise when authority is unclear.</p>
+
+    <h2 id="governance">The role of governance</h2>
+
+    <p>Governance sits beside the harness. It does not replace progress logs, tests, or git. It gives the agent a deterministic way to check architectural compatibility at each session boundary and at each commit boundary.</p>
+
+    <p>The managed-agent startup sequence, extended with governance, looks like this:</p>
+
+    <pre><code>pwd
+git log --oneline -20
+cat claude-progress.txt
+cat feature_list.json
+mneme check --mode warn</code></pre>
+
+    <p>Before commit or PR:</p>
+
+    <pre><code>mneme check --mode strict</code></pre>
+
+    <p>In CI, on every push:</p>
+
+    <pre><code>mneme check --mode strict --ci</code></pre>
+
+    <p>The framing is important: the harness tells the agent where it is. Governance tells it what boundaries it must respect. Both are necessary. Neither substitutes for the other.</p>
+
+    <figure class="figure" aria-labelledby="fig1-cap">
+      <svg viewBox="0 0 720 480" role="img" aria-label="Diagram showing a long-running agent session flow with both continuity infrastructure and governance checkpoints">
+        <defs>
+          <marker id="arr1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="#88889a"/>
+          </marker>
+          <marker id="arr1Acc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="#c8f060"/>
+          </marker>
+        </defs>
+
+        <!-- Title row -->
+        <g font-family="DM Mono, monospace" font-size="10" letter-spacing="0.08em">
+          <text x="32" y="28" fill="#88889a">SESSION FLOW</text>
+          <text x="388" y="28" fill="#c8f060">+ GOVERNANCE</text>
+        </g>
+
+        <!-- Left column: Harness (continuity) -->
+        <g font-family="Inter, sans-serif" font-size="12">
+          <!-- Block 1: Session start -->
+          <rect x="24" y="48" width="300" height="54" rx="8" fill="#141416" stroke="#222226"/>
+          <text x="40" y="70" fill="#e8e8ec" font-weight="500">Agent session starts</text>
+          <text x="40" y="88" fill="#88889a" font-size="11">git log &middot; progress.txt &middot; feature_list.json</text>
+
+          <!-- Arrow down -->
+          <line x1="174" y1="102" x2="174" y2="126" stroke="#88889a" stroke-width="1" marker-end="url(#arr1)"/>
+
+          <!-- Block 2: Continuity -->
+          <rect x="24" y="128" width="300" height="54" rx="8" fill="#141416" stroke="#222226"/>
+          <text x="40" y="150" fill="#e8e8ec" font-weight="500">Agent reads continuity artifacts</text>
+          <text x="40" y="168" fill="#88889a" font-size="11">understands what happened &middot; what remains</text>
+
+          <!-- Arrow down -->
+          <line x1="174" y1="182" x2="174" y2="206" stroke="#88889a" stroke-width="1" marker-end="url(#arr1)"/>
+
+          <!-- Block 3: Work -->
+          <rect x="24" y="208" width="300" height="54" rx="8" fill="#141416" stroke="#222226"/>
+          <text x="40" y="230" fill="#e8e8ec" font-weight="500">Agent performs work</text>
+          <text x="40" y="248" fill="#88889a" font-size="11">code changes &middot; commits &middot; progress updates</text>
+
+          <!-- Arrow down -->
+          <line x1="174" y1="262" x2="174" y2="286" stroke="#88889a" stroke-width="1" marker-end="url(#arr1)"/>
+
+          <!-- Block 4: Tests -->
+          <rect x="24" y="288" width="300" height="54" rx="8" fill="#141416" stroke="#222226"/>
+          <text x="40" y="310" fill="#e8e8ec" font-weight="500">Tests pass</text>
+          <text x="40" y="328" fill="#88889a" font-size="11">functional quality enforced &middot; victory condition</text>
+
+          <!-- Arrow down -->
+          <line x1="174" y1="342" x2="174" y2="366" stroke="#88889a" stroke-width="1" marker-end="url(#arr1)"/>
+
+          <!-- Block 5: Handoff -->
+          <rect x="24" y="368" width="300" height="54" rx="8" fill="#141416" stroke="#222226"/>
+          <text x="40" y="390" fill="#e8e8ec" font-weight="500">Session ends &middot; handoff written</text>
+          <text x="40" y="408" fill="#88889a" font-size="11">next session inherits progress &middot; loop continues</text>
+        </g>
+
+        <!-- Right column: Governance overlays -->
+        <g font-family="Inter, sans-serif" font-size="12">
+          <!-- Governance label -->
+          <text x="400" y="68" fill="#c8f060" font-family="DM Mono, monospace" font-size="10" letter-spacing="0.08em">GOVERNANCE CHECKPOINTS</text>
+
+          <!-- Check 1: Session start -->
+          <rect x="392" y="80" width="300" height="68" rx="8" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.2"/>
+          <text x="408" y="102" fill="#c8f060" font-weight="500" font-size="12">Session-start check</text>
+          <text x="408" y="120" fill="#88889a" font-size="11">mneme check --mode warn</text>
+          <text x="408" y="136" fill="#88889a" font-size="11">load constraints before any code is written</text>
+
+          <!-- Arrow connecting to block 2 -->
+          <line x1="392" y1="148" x2="328" y2="155" stroke="#c8f060" stroke-opacity="0.5" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr1Acc)"/>
+
+          <!-- Check 2: Pre-commit -->
+          <rect x="392" y="248" width="300" height="68" rx="8" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.2"/>
+          <text x="408" y="270" fill="#c8f060" font-weight="500" font-size="12">Pre-commit check</text>
+          <text x="408" y="288" fill="#88889a" font-size="11">mneme check --mode strict</text>
+          <text x="408" y="304" fill="#88889a" font-size="11">catch local drift before branch history</text>
+
+          <!-- Arrow connecting to block 3 -->
+          <line x1="392" y1="268" x2="328" y2="250" stroke="#c8f060" stroke-opacity="0.5" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr1Acc)"/>
+
+          <!-- Check 3: Handoff -->
+          <rect x="392" y="380" width="300" height="40" rx="8" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.2"/>
+          <text x="408" y="398" fill="#c8f060" font-weight="500" font-size="12">Governance state preserved</text>
+          <text x="408" y="414" fill="#88889a" font-size="11">next session inherits constraints, not just progress</text>
+
+          <!-- Arrow connecting to block 5 -->
+          <line x1="392" y1="395" x2="328" y2="395" stroke="#c8f060" stroke-opacity="0.5" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr1Acc)"/>
+        </g>
+
+        <!-- Bottom caption -->
+        <text x="360" y="464" text-anchor="middle" fill="#55555f" font-family="DM Mono, monospace" font-size="10">harness (left) gives the agent its map &middot; governance (right) gives it its boundaries</text>
+      </svg>
+      <figcaption id="fig1-cap">Fig 1 &middot; Long-running agent session flow extended with governance checkpoints. The harness ensures the agent knows what happened. Governance ensures it knows what is allowed.</figcaption>
+    </figure>
+
+    <h2 id="adrs">ADRs as durable intent, not documentation</h2>
+
+    <p>The governance layer requires a source of architectural authority. In well-run engineering teams, that source is the ADR corpus: Architecture Decision Records that capture not just what was decided, but why, what alternatives were rejected, and what constraints the decision implies.</p>
+
+    <p>ADRs are the canonical form of architectural intent. But for most teams, they sit in <code>/docs/adr</code> and are read only when someone thinks to look. They are documentation, not enforcement. A long-running agent will not read them at session start. A commit hook will not check against them. They accumulate as an increasingly stale record of decisions that no longer govern anything.</p>
+
+    <p>The Mneme approach makes ADRs into enforceable inputs. Rather than reading the ADR folder as a documentation corpus, a governance layer compiles the ADR corpus into a decision graph with declared properties:</p>
+
+    <ul>
+      <li>Which decisions are active, superseded, or deprecated?</li>
+      <li>Which decision applies to which file, service, or scope?</li>
+      <li>Which decision is newer and overrides an older one?</li>
+      <li>Which dependencies or patterns does each decision forbid or require?</li>
+      <li>When two decisions conflict on the same scope, which one wins?</li>
+    </ul>
+
+    <p>A long-running agent operating under that system can answer: <em>which decision applies to this change, and am I compliant with it?</em> That is a different question from <em>what did the progress file say?</em> and it requires a different infrastructure to answer.</p>
+
+    <p>The underlying work is the <a href="/insights/why-architectural-governance-needs-precedence-semantics/" class="ext">precedence semantics problem</a>: given a set of architectural decisions with declared supersedes relationships, scope constraints, and status fields, compute the single decision that governs any given code location. That is the deterministic resolver that governance requires. Without it, ADRs are documents. With it, they are enforceable contracts.</p>
+
+    <h2 id="checkpoints">Where governance checkpoints belong</h2>
+
+    <p>Governance is not a single check at a single moment. It is a layer with enforcement points distributed across the agent's workflow. The right enforcement points correspond to the moments of highest leverage:</p>
+
+    <figure class="figure" aria-labelledby="fig2-cap">
+      <svg viewBox="0 0 720 320" role="img" aria-label="Diagram showing five governance checkpoint positions in the agent workflow">
+        <defs>
+          <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="#c8f060"/>
+          </marker>
+        </defs>
+
+        <!-- horizontal flow line -->
+        <line x1="60" y1="160" x2="660" y2="160" stroke="#222226" stroke-width="1.5"/>
+
+        <!-- Checkpoint nodes -->
+        <!-- 1: Session start -->
+        <circle cx="100" cy="160" r="10" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.5"/>
+        <text x="100" y="140" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9" letter-spacing="0.05em">01</text>
+        <text x="100" y="200" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="11" font-weight="500">Session</text>
+        <text x="100" y="215" text-anchor="middle" fill="#88889a" font-family="Inter, sans-serif" font-size="10">start</text>
+        <text x="100" y="232" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">warn mode</text>
+
+        <!-- 2: Pre-tool -->
+        <circle cx="220" cy="160" r="10" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.5"/>
+        <text x="220" y="140" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9" letter-spacing="0.05em">02</text>
+        <text x="220" y="200" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="11" font-weight="500">Pre-tool</text>
+        <text x="220" y="215" text-anchor="middle" fill="#88889a" font-family="Inter, sans-serif" font-size="10">execution</text>
+        <text x="220" y="232" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">block early</text>
+
+        <!-- 3: Pre-commit -->
+        <circle cx="360" cy="160" r="10" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.5"/>
+        <text x="360" y="140" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9" letter-spacing="0.05em">03</text>
+        <text x="360" y="200" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="11" font-weight="500">Pre-commit</text>
+        <text x="360" y="215" text-anchor="middle" fill="#88889a" font-family="Inter, sans-serif" font-size="10">&nbsp;</text>
+        <text x="360" y="232" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">strict mode</text>
+
+        <!-- 4: Pre-PR -->
+        <circle cx="500" cy="160" r="10" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.5"/>
+        <text x="500" y="140" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9" letter-spacing="0.05em">04</text>
+        <text x="500" y="200" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="11" font-weight="500">Pre-PR</text>
+        <text x="500" y="215" text-anchor="middle" fill="#88889a" font-family="Inter, sans-serif" font-size="10">&nbsp;</text>
+        <text x="500" y="232" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">explainable</text>
+
+        <!-- 5: CI -->
+        <circle cx="630" cy="160" r="10" fill="#0c0c0d" stroke="#c8f060" stroke-width="1.5"/>
+        <text x="630" y="140" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9" letter-spacing="0.05em">05</text>
+        <text x="630" y="200" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="11" font-weight="500">CI gate</text>
+        <text x="630" y="215" text-anchor="middle" fill="#88889a" font-family="Inter, sans-serif" font-size="10">&nbsp;</text>
+        <text x="630" y="232" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">team-level</text>
+
+        <!-- Benefit annotations (above the line) -->
+        <text x="100" y="106" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">Load constraints</text>
+        <text x="100" y="119" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">before work starts</text>
+
+        <text x="220" y="106" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">Block obviously</text>
+        <text x="220" y="119" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">forbidden actions</text>
+
+        <text x="360" y="106" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">Catch drift before</text>
+        <text x="360" y="119" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">branch history</text>
+
+        <text x="500" y="106" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">Explainable</text>
+        <text x="500" y="119" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">warnings/failures</text>
+
+        <text x="630" y="106" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">Enforce team-level</text>
+        <text x="630" y="119" text-anchor="middle" fill="#55555f" font-family="Inter, sans-serif" font-size="10">architectural contracts</text>
+
+        <!-- caption -->
+        <text x="360" y="300" text-anchor="middle" fill="#55555f" font-family="DM Mono, monospace" font-size="10">five enforcement points &middot; each catches a different class of drift</text>
+      </svg>
+      <figcaption id="fig2-cap">Fig 2 &middot; Governance enforcement points in a long-running agent workflow. Each checkpoint catches drift at a different cost. Earlier checkpoints are cheaper to enforce; later checkpoints catch what slipped through.</figcaption>
+    </figure>
+
+    <p><strong>Session start</strong> is the cheapest checkpoint. Before any code is written, the incoming agent loads the current architectural constraints, learns which decisions are active, and understands which scopes they cover. A warn-mode check at session start surfaces existing violations without blocking work, and primes the agent to avoid introducing new ones.</p>
+
+    <p><strong>Pre-tool execution</strong> blocks actions that are obviously forbidden before they happen. If the agent is about to add a dependency that a governance rule prohibits, stopping it before the write is cheaper than detecting and reverting after.</p>
+
+    <p><strong>Pre-commit</strong> is the primary enforcement gate in the agent's own workflow. A strict-mode check before commit catches architectural drift in the agent's output before it becomes branch history. This is the equivalent of a developer running linters locally before pushing.</p>
+
+    <p><strong>Pre-PR</strong> produces an explainable report: which rules applied, which passed, which failed, and why. This is the output that a human reviewer can read to understand what architectural decisions the agent was operating under, and where it deviated.</p>
+
+    <p><strong>CI</strong> enforces team-level architectural contracts on every push, regardless of whether the agent ran its local governance checks. This is the backstop that catches violations that the agent introduced without triggering its own enforcement points, and the gate that catches changes made by humans after an agent session.</p>
+
+    <div class="callout">
+      <p><strong>The harness ensures the agent knows where it is.</strong> Governance ensures the agent knows where it must not go. Both are infrastructure. Neither is a nice-to-have for long-running loops.</p>
+    </div>
+
+    <h2 id="conclusion">Conclusion: memory is not enough</h2>
+
+    <p>Anthropic's managed-agent harness is well-designed infrastructure for a real problem. Progress logs, feature lists, git checkpoints, and E2E tests are the right primitives for keeping a long-running agent loop coherent across sessions. Teams building on Claude Code or similar agent systems should study and adopt this pattern.</p>
+
+    <p>But a progress file is descriptive, not prescriptive. It records what happened. It does not enforce what must remain true. And as agent loops grow longer, the gap between those two things grows wider.</p>
+
+    <p>The next phase of agent infrastructure needs a governance layer. Not a memory layer with architectural content indexed into it&mdash;that is still a recall system, still probabilistic, still without an enforcement hook. A governance layer: one that resolves competing ADRs deterministically, produces explainable audit traces, and enforces architectural contracts at the boundaries where agents make consequential changes.</p>
+
+    <p>Long-running agents need memory to continue work.<br>
+    They need governance to continue work safely.</p>
+
+    <p>The next generation of agent infrastructure will not just preserve context. It will preserve intent.</p>
+
+    <h2 id="faq">FAQ</h2>
+
+    <div class="faq-list">
+      <details class="faq-item">
+        <summary>Is this a criticism of Anthropic's harness?</summary>
+        <div class="faq-body">No. Anthropic's <a href="https://www.anthropic.com/engineering/managed-agents" target="_blank" rel="noopener">managed-agent harness</a> solves the continuity problem well. Progress logs, feature lists, git checkpoints, and E2E tests are the right operational primitives for long-running work. The article's point is that continuity and governance are two different problems, and solving the first does not automatically solve the second.</div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Can't a progress file just describe architectural rules?</summary>
+        <div class="faq-body">It can record them as text. But text in a progress file has no enforcement authority. The next agent session can read that text and then do something else. Governance requires a deterministic resolver and an enforcement point that output must pass through. A progress note is advisory; a governance check is blocking.</div>
+      </details>
+
+      <details class="faq-item">
+        <summary>What happens without governance in a long-running agent loop?</summary>
+        <div class="faq-body">The loop drifts. Each session adds sensible local changes. Over dozens of sessions, the codebase drifts from its architectural intent without any single session making an obviously wrong decision. The problem is cumulative, and no individual progress log captures it. The symptom is a codebase that passes its tests but violates its architecture.</div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Where exactly does Mneme fit in this workflow?</summary>
+        <div class="faq-body">Mneme is the governance layer that runs alongside the harness. At session start, <code>mneme check --mode warn</code> tells the incoming agent which architectural constraints apply and whether any are already violated. Before commit or PR, <code>mneme check --mode strict</code> enforces them. Mneme does not replace the progress log, git, or tests. It enforces the constraints those artifacts cannot enforce. See the <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Why is governance harder when agents run longer?</summary>
+        <div class="faq-body">Because the surface area for drift grows with each session. A single prompt session makes a bounded set of changes. A long-running loop makes changes across many files, services, and sessions. Each change is locally plausible but collectively drifts from architectural intent. The harness ensures the agent knows what happened. Governance ensures it knows what must remain true.</div>
+      </details>
+    </div>
+
+  </div>
+
+  <h2 id="related-reading">Related reading</h2>
+  <ul>
+    <li><a href="/insights/memory-is-not-governance/">Memory Is Not Governance</a></li>
+    <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/">Why AI Architectural Governance Needs Precedence Semantics</a></li>
+    <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
+    <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
+  </ul>
+
+  <footer class="article-footer">
+    <a href="/insights/" class="back-link">&larr; Back to Insights</a>
+
+    <div class="cta-block">
+      <h3>The governance layer your agent harness is missing.</h3>
+      <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent workflow. Progress logs tell the agent what happened. Mneme tells it what must remain true. Open source, MIT licensed.</p>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+    </div>
+  </footer>
+</article>
+</main>
+
+<footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">
+  <div style="max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 2.5rem 2rem;">
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Product</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/use-cases/">Use cases</a></li>
+        <li><a href="/works-with/">Works with</a></li>
+        <li><a href="/platforms/">Platforms</a></li>
+        <li><a href="/integrations/">Integrations</a></li>
+        <li><a href="/compare/">Compare</a></li>
+        <li><a href="/demo/">Demo</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Learn</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/concepts/">Concepts</a></li>
+        <li><a href="/architecture/">Architecture</a></li>
+        <li><a href="/insights/">Insights</a></li>
+        <li><a href="/standards/">Standards</a></li>
+        <li><a href="/benchmark/">Benchmark</a></li>
+        <li><a href="/docs/">Docs</a></li>
+        <li><a href="/docs/cli/">CLI reference</a></li>
+        <li><a href="/docs/governance-violations/">Governance violations</a></li>
+        <li><a href="/supported-languages/">Supported languages</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Company</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/pilot/" style="color:var(--accent);">Request pilot</a></li>
+        <li><a href="/for/">For teams</a></li>
+        <li><a href="/founder/">Founder</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/roadmap/">Roadmap</a></li>
+        <li><a href="/contact/">Contact</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Code</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
+        <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
+      </ul>
+    </div>
+  </div>
+  <div style="max-width: 1080px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
+    <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
+    <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
+      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+      </a>
+      <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"/></svg>
+      </a>
+      <a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener" aria-label="YouTube" style="color: var(--muted); display: inline-flex;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.12C19.55 3.5 12 3.5 12 3.5s-7.55 0-9.4.58A3 3 0 0 0 .5 6.2 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.12c1.85.58 9.4.58 9.4.58s7.55 0 9.4-.58a3 3 0 0 0 2.1-2.12A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.8zM9.6 15.57V8.43L15.82 12 9.6 15.57z"/></svg>
+      </a>
+      <a href="https://dev.to/mnemehq" target="_blank" rel="noopener" aria-label="DEV.to" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true"><path d="M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35 3.88-2.9 5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.36 47.28l.02 70.93zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19l-.01 29.52zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58l-38.46 144.8z"/></svg>
+      </a>
+    </nav>
+    <span>&copy; 2026</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var btn = document.querySelector('.nav-hamburger');
+  var links = document.querySelector('.nav-links');
+  if (!btn || !links) return;
+  function setOpen(open){
+    links.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', String(open));
+    document.body.classList.toggle('menu-open', open);
+  }
+  btn.addEventListener('click', function(e){
+    e.stopPropagation();
+    setOpen(!links.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e){
+    if (!links.classList.contains('open')) return;
+    if (links.contains(e.target) || btn.contains(e.target)) return;
+    setOpen(false);
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && links.classList.contains('open')) setOpen(false);
+  });
+  links.addEventListener('click', function(e){
+    if (e.target.tagName === 'A') setOpen(false);
+  });
+  window.addEventListener('resize', function(){
+    if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false);
+  });
+})();
+</script>
+<script>
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `/insights/long-running-agents-need-governance/` insight article
- Triggered by Anthropic's managed-agents engineering post; argues that continuity infrastructure (progress logs, feature lists, git checkpoints) does not substitute for architectural governance
- Core thesis: *Agent harnesses preserve continuity. Governance preserves intent.*

## Content

- 8 sections + FAQ (~10 min read)
- Two hand-crafted SVG diagrams matching site design: session flow with governance checkpoints overlaid, and a five-point enforcement timeline
- Continuity-vs-governance layer table (highlighted governance row in accent)
- External link to Anthropic's managed-agents post; internal cross-links to related insight articles
- CTA block linking to GitHub repo

## Test plan

- [ ] Publishing script generates OG image and adds insights index card
- [ ] Canonical URL resolves: `https://mnemehq.com/insights/long-running-agents-need-governance/`
- [ ] External link to Anthropic article opens correctly
- [ ] SVG diagrams render on mobile (responsive via viewBox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)