### PR TITLE
site(demo): add ADR micro-primers and fix flagship next-bar labels

### DIFF
--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -429,7 +429,7 @@ Result: WARN</code></pre>
 
         <div class="next-bar">
           <a class="next-card" href="/demo/governed-python-agent/">
-            <div class="nc-label">Flagship 01 &middot; Product demo</div>
+            <div class="nc-label">Flagship 01 &middot; Centerpiece</div>
             <h4>Governed Python agent</h4>
             <p>See the full product loop: a Python agent proposes a violating import, Mneme blocks it using this compiled corpus, the agent retries with correct code.</p>
             <span class="nc-arrow">See the product demo &rarr;</span>

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -159,6 +159,14 @@
     .callout p strong { color: var(--text); font-weight: 500; }
     .callout.teal p strong { color: var(--teal); }
 
+    /* ── ADR PRIMER ── */
+    .adr-primer { background: rgba(167,139,250,0.05); border: 1px solid rgba(167,139,250,0.18); border-left: 3px solid #a78bfa; border-radius: 8px; padding: 0.85rem 1.15rem; margin: 0 0 2.5rem; }
+    .primer-key { display: block; font-family: 'DM Mono', monospace; font-size: 0.65rem; letter-spacing: 0.1em; text-transform: uppercase; color: #a78bfa; margin-bottom: 0.6rem; }
+    .primer-rules { display: flex; flex-direction: column; gap: 0.3rem; margin-bottom: 0.75rem; font-size: 0.86rem; color: var(--muted); }
+    .primer-rules code { font-family: 'DM Mono', monospace; font-size: 0.8rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.35rem; color: var(--text); }
+    .primer-what { font-size: 0.86rem; color: var(--muted); margin: 0; padding-top: 0.65rem; border-top: 1px dashed var(--border); line-height: 1.65; }
+    .primer-what strong { color: var(--text); font-weight: 500; }
+
     /* ── NEXT BAR ── */
     .next-bar { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
     @media (max-width: 640px) { .next-bar { grid-template-columns: 1fr; } }
@@ -241,6 +249,15 @@
     </header>
 
     <div class="body">
+
+      <div class="adr-primer">
+        <span class="primer-key">The decisions at stake</span>
+        <div class="primer-rules">
+          <div>&rarr; <code>ADR-001</code> prohibits external databases. Redis is forbidden.</div>
+          <div>&rarr; <code>ADR-004</code> requires all persistence to go through a Repository abstraction.</div>
+        </div>
+        <p class="primer-what">The demo shows how three agents accidentally violate these decisions over a week &mdash; and how <strong>Mneme blocks the first divergence</strong> before it propagates.</p>
+      </div>
 
       <h2>The scenario</h2>
 
@@ -428,11 +445,11 @@ python run.py</code></pre>
       <p>The drift demo is what happens when those three artifacts are missing. The convergent timeline is what happens when they are wired up.</p>
 
       <div class="next-bar">
-        <a class="next-card" href="/demo/adr-compiler/">
+        <a class="next-card" href="/demo/governed-python-agent/">
           <div class="nc-label">Flagship 01 &middot; Centerpiece</div>
-          <h4>The ADR compiler</h4>
-          <p>The artifact that produced the decision corpus the timeline reads against. Read this if you want the upstream half.</p>
-          <span class="nc-arrow">Walk the compiler &rarr;</span>
+          <h4>Governed Python agent</h4>
+          <p>The full product loop: a Python agent proposes a violating import, Mneme blocks it, the agent retries with compliant output.</p>
+          <span class="nc-arrow">See the product demo &rarr;</span>
         </a>
         <a class="next-card" href="/demo/multi-agent-governance/">
           <div class="nc-label">Flagship 03</div>

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -143,6 +143,13 @@
     .callout p a { color: var(--teal); text-decoration: none; border-bottom: 1px dotted rgba(139,224,200,0.4); }
     .callout p a:hover { border-bottom-color: rgba(139,224,200,0.7); }
 
+    /* ── ADR PRIMER ── */
+    .adr-primer { background: rgba(167,139,250,0.05); border: 1px solid rgba(167,139,250,0.18); border-left: 3px solid #a78bfa; border-radius: 8px; padding: 0.8rem 1.1rem; margin: 1.1rem 0 1.25rem; font-size: 0.87rem; color: var(--muted); line-height: 1.7; }
+    .adr-primer code { font-family: 'DM Mono', monospace; font-size: 0.8rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.35rem; color: var(--text); }
+    .primer-key { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.07em; text-transform: uppercase; color: #a78bfa; font-weight: 500; margin-right: 0.25rem; }
+    .retry-note { font-size: 0.8rem; color: var(--muted); font-family: 'DM Mono', monospace; margin-top: 0.75rem; line-height: 1.65; }
+    .retry-note code { font-size: 0.78rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.35rem; color: var(--text); }
+
     /* ── CTA / NEXT ── */
     .next-bar { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
     @media (max-width: 640px) { .next-bar { grid-template-columns: 1fr; } }
@@ -240,6 +247,8 @@
 
       <p>The animation below runs a real governance scenario: the agent writes an import that looks correct from its training data but violates ADR-005. Mneme catches it, surfaces the decision, and the agent retries with compliant code.</p>
 
+      <div class="adr-primer"><span class="primer-key">ADR-005</span> separates brand identity from package namespace. <code>MnemeHQ</code> is the GitHub org, the website, and the LinkedIn page &mdash; so an agent confidently writes <code>from MnemeHQ.memory_store import &hellip;</code>. The decision declares <code>MnemeHQ</code> a forbidden dependency; the installable package namespace is <code>mneme</code>.</div>
+
       <div class="demo-wrap">
         <div class="panel">
           <div class="panel-header bad">
@@ -270,6 +279,7 @@
         </div>
       </div>
       <button class="replay-btn" type="button" id="replay-btn" onclick="startDemo(true)">&larr; Replay</button>
+      <p class="retry-note">Retry context contains: ADR-005 decision ID &middot; forbidden token (<code>MnemeHQ</code>) &middot; compliant alternative (<code>mneme</code>) &middot; constraint rationale from the compiled corpus.</p>
 
       <h2>Why this matters</h2>
 

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -187,6 +187,12 @@
     .support-card p { font-size: 0.78rem; color: var(--muted); line-height: 1.6; margin: 0; }
     .support-card .sc-arrow { color: var(--accent); font-family: 'DM Mono', monospace; font-size: 0.74rem; margin-top: auto; }
 
+    /* ── DEMO PRIMER ── */
+    .demo-primer { background: rgba(167,139,250,0.05); border: 1px solid rgba(167,139,250,0.18); border-left: 3px solid #a78bfa; border-radius: 8px; padding: 1rem 1.4rem; margin: -3.5rem 0 5rem; max-width: 760px; }
+    .demo-primer-label { display: block; font-family: 'DM Mono', monospace; font-size: 0.65rem; letter-spacing: 0.1em; text-transform: uppercase; color: #a78bfa; margin-bottom: 0.55rem; }
+    .demo-primer p { font-size: 0.9rem; color: var(--muted); line-height: 1.7; margin: 0; }
+    .demo-primer p strong { color: var(--text); font-weight: 500; }
+
     /* ── EVIDENCE BAR ── */
     .evidence-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
     .evidence-block { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem 1.4rem; text-decoration: none; color: inherit; transition: border-color 0.15s; display: block; }
@@ -318,6 +324,11 @@
         </div>
       </div>
     </section>
+
+    <div class="demo-primer">
+      <span class="demo-primer-label">How Mneme works</span>
+      <p>Mneme compiles your <strong>Architectural Decision Records (ADRs)</strong> into an executable governance corpus. Every agent proposal is evaluated against this corpus before generation, ensuring architectural invariants hold across tools, sessions, and actors.</p>
+    </div>
 
     <!-- ───── 02 · FLAGSHIP DEMOS ───── -->
     <section class="section" id="flagships">

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -158,6 +158,14 @@
     .callout.purple { background: rgba(167,139,250,0.05); border-color: rgba(167,139,250,0.2); border-left-color: var(--agent-a); }
     .callout.purple p strong { color: var(--agent-a); }
 
+    /* ── ADR PRIMER ── */
+    .adr-primer { background: rgba(167,139,250,0.05); border: 1px solid rgba(167,139,250,0.18); border-left: 3px solid #a78bfa; border-radius: 8px; padding: 0.85rem 1.15rem; margin: 0 0 1.5rem; }
+    .primer-key { display: block; font-family: 'DM Mono', monospace; font-size: 0.65rem; letter-spacing: 0.1em; text-transform: uppercase; color: #a78bfa; margin-bottom: 0.6rem; }
+    .primer-rules { display: flex; flex-direction: column; gap: 0.3rem; margin-bottom: 0.75rem; font-size: 0.86rem; color: var(--muted); }
+    .primer-rules code { font-family: 'DM Mono', monospace; font-size: 0.8rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.35rem; color: var(--text); }
+    .primer-what { font-size: 0.86rem; color: var(--muted); margin: 0; padding-top: 0.65rem; border-top: 1px dashed var(--border); line-height: 1.65; }
+    .primer-what strong { color: var(--text); font-weight: 500; }
+
     /* ── NEXT BAR ── */
     .next-bar { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
     @media (max-width: 640px) { .next-bar { grid-template-columns: 1fr; } }
@@ -249,6 +257,16 @@
       <p>What this page <em>does</em> demonstrate is the shape of the problem those frameworks expose: <strong>once multiple actors touch the same codebase against shared architectural invariants, the governance layer becomes the coordination layer.</strong> If the invariants are encoded somewhere the actors can answer to, the system stays coherent. If they aren't, every actor reasons against its own context and drift becomes inevitable.</p>
 
       <h2>The invariants the actors share</h2>
+
+      <div class="adr-primer">
+        <span class="primer-key">The decisions at stake</span>
+        <div class="primer-rules">
+          <div>&rarr; <code>ADR-001</code> forbids external databases. Redis is forbidden.</div>
+          <div>&rarr; <code>ADR-003</code> forbids ORMs in v1.</div>
+          <div>&rarr; <code>ADR-004</code> enforces the Repository pattern for all persistence.</div>
+        </div>
+        <p class="primer-what">The demo shows how three independent actors stay aligned because they all evaluate against this same <strong>compiled corpus</strong> &mdash; not against each other.</p>
+      </div>
 
       <p>Three actors will touch the same Python service over the course of one workflow. They share exactly one thing: the compiled decision corpus emitted by the <a href="/demo/adr-compiler/">ADR compiler</a>.</p>
 
@@ -387,11 +405,11 @@ python run.py</code></pre>
       </ul>
 
       <div class="next-bar">
-        <a class="next-card" href="/demo/adr-compiler/">
+        <a class="next-card" href="/demo/governed-python-agent/">
           <div class="nc-label">Flagship 01 &middot; Centerpiece</div>
-          <h4>The ADR compiler</h4>
-          <p>The artifact that produces the corpus the actors here share. The upstream half of this loop.</p>
-          <span class="nc-arrow">Walk the compiler &rarr;</span>
+          <h4>Governed Python agent</h4>
+          <p>The full product loop: a Python agent proposes a violating import, Mneme blocks it, the agent retries with compliant output.</p>
+          <span class="nc-arrow">See the product demo &rarr;</span>
         </a>
         <a class="next-card" href="/demo/architectural-drift/">
           <div class="nc-label">Flagship 02</div>


### PR DESCRIPTION
## Summary

- Fix flagship next-bar cards: all three flagship demo pages now correctly point to Governed Python agent as Flagship 01 · Centerpiece; ADR compiler card label updated from "Product demo" to "Centerpiece"
- Add ADR micro-primers (purple left-border boxes) on `/demo/governed-python-agent/`, `/demo/architectural-drift/`, `/demo/multi-agent-governance/` — each explains the relevant decisions before the animation/timeline so readers have context without scanning ahead
- Add retry-context one-liner caption on `/demo/governed-python-agent/` below the animation
- Add "How Mneme works" primer block on `/demo/` between "The problem" section and the flagship grid — bridges ADR literacy gap for new readers

## Test plan

- [ ] Verify next-bar labels on all three flagship pages match the taxonomy
- [ ] Verify primers render correctly at desktop and mobile widths
- [ ] Verify `/demo/` primer sits correctly between sections 01 and 02

🤖 Generated with [Claude Code](https://claude.com/claude-code)