### PR TITLE
fix(insights): retarget OpenAI link to harness-engineering post

### DIFF
--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -346,7 +346,7 @@
 
     <p>Three years ago, the prevailing question was how to phrase a prompt. The model was the product, and prompt engineering was the surface where teams competed.</p>
 
-    <p>That framing no longer matches what is being built. OpenAI's recent <a href="https://openai.com/index/introducing-codex" class="ext" target="_blank" rel="noopener">harness work on Codex</a>, Anthropic's pattern for <a href="https://www.anthropic.com/engineering/managed-agents" class="ext" target="_blank" rel="noopener">long-running managed agents</a>, Cursor's background-agent runtime, Claude Code's session-aware workflow, and the open-source frameworks &mdash; LangGraph, CrewAI, AutoGen &mdash; all converge on the same architectural move: the model is wrapped inside an execution system that handles tools, memory, retries, planning, and continuity.</p>
+    <p>That framing no longer matches what is being built. OpenAI's recent <a href="https://openai.com/index/harness-engineering/" class="ext" target="_blank" rel="noopener">harness work on Codex</a>, Anthropic's pattern for <a href="https://www.anthropic.com/engineering/managed-agents" class="ext" target="_blank" rel="noopener">long-running managed agents</a>, Cursor's background-agent runtime, Claude Code's session-aware workflow, and the open-source frameworks &mdash; LangGraph, CrewAI, AutoGen &mdash; all converge on the same architectural move: the model is wrapped inside an execution system that handles tools, memory, retries, planning, and continuity.</p>
 
     <p>Single calls have given way to execution loops. Assistants have given way to autonomous workflows. The model is no longer the product boundary. The execution environment is.</p>
 


### PR DESCRIPTION
## Summary

- One-character-class fix: the "harness work on Codex" link in `/insights/harness-engineering-still-needs-governance/` pointed at `https://openai.com/index/introducing-codex` (a 404).
- Repointed to **`https://openai.com/index/harness-engineering/`** — OpenAI's actual "Harness engineering: leveraging Codex in an agent-first world" post, which is the correct citation for the surrounding sentence and a better match for both the link text and the article's argument.

The Anthropic link in the same paragraph is unchanged (it resolves to a valid "Scaling Managed Agents" post).

## Test plan

- [x] WebSearch confirms `https://openai.com/index/harness-engineering/` is a real OpenAI post (titled "Harness engineering: leveraging Codex in an agent-first world").
- [x] Diff: one file, one line, surface area zero.
- [ ] Click the link from the live `/insights/harness-engineering-still-needs-governance/` page after deploy and confirm it lands on the OpenAI harness-engineering post in a new tab.

https://claude.ai/code/session_014q14jtLkiAVwu7R8z65xh6

---
_Generated by [Claude Code](https://claude.ai/code/session_014q14jtLkiAVwu7R8z65xh6)_