### PR TITLE
fix(insights): correct breadcrumb and add intent-debt to sitemap

### DIFF
--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -528,6 +528,17 @@
       <span class="card-arrow">→</span>
     </a>
 
+    <a href="/insights/ai-native-engineering-intent-debt/" class="concept-card" role="listitem">
+      <div class="card-top">
+        <span class="card-num">11</span>
+        <div>
+          <div class="card-title">Intent Debt</div>
+        </div>
+      </div>
+      <p class="card-desc">The gap between what a system is supposed to preserve and what its AI agents are actually constrained to follow. When agents become the execution layer, intent debt becomes the primary bottleneck.</p>
+      <span class="card-arrow">→</span>
+    </a>
+
   </div>
 
   <h2 class="section-label" style="margin-top:3.5rem;">Adjacent concepts</h2>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -255,8 +255,6 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-    <li><a href="/architecture/">Architecture</a></li>
     <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">AI-Native Engineering Has an Intent Debt Problem</li>
   </ol>

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -345,6 +345,66 @@
     </div>
   </div>
 
+  <!-- Group 0: AI-native engineering cluster -->
+  <div class="cards-section">
+    <div class="section-divider"><span class="section-label">AI-native engineering &amp; intent governance</span></div>
+    <div class="cards-grid">
+
+      <div class="insight-card">
+        <div class="card-meta">
+          <span class="card-tag">Thought Leadership</span>
+          <span class="card-dot"></span>
+          <span class="card-read-time">8 min read</span>
+        </div>
+        <h3>AI-Native Engineering Has an Intent Debt Problem</h3>
+        <p>As agents write more code, the real risk is not just technical debt. It is stale, implicit, unenforced intent. The next bottleneck in AI-native engineering is intent enforcement.</p>
+        <div class="card-footer">
+          <a href="/insights/ai-native-engineering-intent-debt/" class="read-link">Read &rarr;</a>
+        </div>
+      </div>
+
+      <div class="insight-card">
+        <div class="card-meta">
+          <span class="card-tag">Thought Leadership</span>
+          <span class="card-dot"></span>
+          <span class="card-read-time">3 min read</span>
+        </div>
+        <h3>Review Is Not Governance</h3>
+        <p>CodeRabbit helps review AI-generated code. Mneme helps govern what the AI generates in the first place. Two different layers of the same problem.</p>
+        <div class="card-footer">
+          <a href="/insights/review-is-not-governance/" class="read-link">Read &rarr;</a>
+        </div>
+      </div>
+
+      <div class="insight-card">
+        <div class="card-meta">
+          <span class="card-tag">Thought Leadership</span>
+          <span class="card-dot"></span>
+          <span class="card-read-time">9 min read</span>
+        </div>
+        <h3>Memory Is Not Governance</h3>
+        <p>The category conflates memory, context, retrieval, and governance into one word. Memory systems optimize recall. Governance systems optimize constraint enforcement. Different jobs, different math, different failure modes.</p>
+        <div class="card-footer">
+          <a href="/insights/memory-is-not-governance/" class="read-link">Read &rarr;</a>
+        </div>
+      </div>
+
+      <div class="insight-card">
+        <div class="card-meta">
+          <span class="card-tag">Category Education</span>
+          <span class="card-dot"></span>
+          <span class="card-read-time">6 min read</span>
+        </div>
+        <h3>Prompt Engineering Is Not Governance</h3>
+        <p>Prompt templates can nudge an LLM toward better output. They cannot enforce architectural invariants, resolve decision conflicts, or prevent drift across a multi-engineer codebase.</p>
+        <div class="card-footer">
+          <a href="/insights/prompt-engineering-is-not-governance/" class="read-link">Read &rarr;</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
   <!-- Group 1 -->
   <div class="cards-section">
     <div class="section-divider"><span class="section-label">The governance problem</span></div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -141,6 +141,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://mnemehq.com/insights/ai-native-engineering-intent-debt/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://mnemehq.com/insights/rise-of-agentic-engineering-education/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary

- Fixes breadcrumb on `/insights/ai-native-engineering-intent-debt/` — removes spurious Concepts and Architecture crumbs, leaving the correct `Home / Insights / Article` trail
- Adds `/insights/ai-native-engineering-intent-debt/` to `sitemap.xml` (was missing from PR #95)

## Test plan

- [ ] Breadcrumb on article page shows `Home / Insights / AI-Native Engineering Has an Intent Debt Problem`
- [ ] Sitemap includes the new article URL
- [ ] Deploy verification passes all sitemap URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)