### PR TITLE
fix: add GA4 consent defaults and key event tracking

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -11,6 +11,9 @@
   <meta name="robots" content="noindex, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/404.html" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>

--- a/site/404.html
+++ b/site/404.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page not found &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The page you were looking for does not exist on mnemehq.com. Try the homepage, the docs, or the live demo." />
   <meta name="robots" content="noindex, follow" />

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="A lightweight architectural governance layer that helps coding agents follow your project's architectural decisions." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About — Mneme HQ | Architectural Governance Layer for AI Development</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ is a lightweight architectural governance layer that helps coding agents follow your project's architectural decisions. Built for determinism and auditability." />
   <meta name="robots" content="index, follow" />

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Decision Memory vs. Documentation — Architecture Deep Dive</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Decision memory and documentation look similar but solve different problems. Documentation surfaces information. Decision memory enforces constraints. The distinction determines whether your governance system actually works." />
   <meta name="robots" content="index, follow" />

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>How Retrieval Works in Mneme — Architecture Deep Dive</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme's retrieval is deterministic keyword scoring over structured decision records — no vector store, no ML. Scope filter → weighted scorer → top-K selection → context injection → enforcement." />
   <meta name="robots" content="index, follow" />

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Technical deep dives into how Mneme works — the retrieval pipeline, decision memory, and the architectural choices behind deterministic governance." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architecture — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Technical deep dives into how Mneme works — the retrieval pipeline, decision memory, scoring mechanics, and the architectural choices behind deterministic governance." />
   <meta name="robots" content="index, follow" />

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -29,6 +29,9 @@
 
 
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governance Benchmark v1.1 Methodology — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme's architectural governance benchmark — 36 scenarios, structured-output verification, layered metrics, pre-registered thresholds. Deterministic and reproducible." />
   <meta name="robots" content="index, follow" />

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ vs Claude Code Memory &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Claude Code's CLAUDE.md provides instructions the model may follow. Mneme HQ hooks into Claude Code's Edit/Write operations and blocks violations before they happen. Instructions vs enforcement." />
   <meta name="robots" content="index, follow" />

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ vs CodeRabbit — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="CodeRabbit reviews code after it's written. Mneme HQ enforces architectural constraints before generation. A structured comparison for engineering teams choosing between the two." />
   <meta name="robots" content="index, follow" />

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ vs Cursor Rules — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Cursor Rules inject plain text into Cursor sessions. Mneme HQ is structured enforcement with a precedence engine and hook-level blocking. Here's how they compare." />
   <meta name="robots" content="index, follow" />

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compare — Mneme HQ vs Alternatives</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="See how Mneme HQ compares to CodeRabbit, Cursor Rules, Claude Code memory, and RAG-based governance. Structured comparisons for engineering teams evaluating AI governance tools." />
   <meta name="robots" content="index, follow" />

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="See how Mneme HQ compares to CodeRabbit, Cursor Rules, Claude Code memory, and RAG-based governance." />
   <meta name="twitter:image" content="https://mnemehq.com/compare/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ vs RAG-based Governance &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="RAG retrieves relevant context. Mneme HQ enforces architectural constraints. Retrieval and enforcement are different layers — and confusing them is the most common governance mistake in AI engineering." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Agentic Development — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Agentic development is a software development paradigm where AI agents are the primary code generators, operating autonomously across files and services. Architectural control becomes an operational problem, not a cultural one." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI-Native SDLC — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The AI-native SDLC designs software delivery from first principles for AI agents as primary code generators — not a retrofit of human workflows. The rate-limiting step has flipped." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Compiler — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The architectural compiler is the pipeline that converts documentation-form decisions (ADRs, design docs) into machine-evaluable constraint records through parsing, validation, conflict resolution, and scope assignment." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Drift — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Architectural drift is the compound degradation in codebase coherence caused by AI agents producing code inconsistent with established decisions, uncorrected across sessions and agents." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Architectural governance is the system that encodes team decisions as machine-evaluable constraints enforced at the point of AI code generation — before review, before drift compounds." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Decision Continuity — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Decision continuity is the property that architectural decisions remain enforced across agents, sessions, and time — regardless of which agent acts or what context it inherited. Prompt memory cannot provide it." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Deterministic Enforcement — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Deterministic enforcement means a governance check produces the same verdict for the same inputs, always — no model state, no retrieval variance, no probabilistic compliance. The precondition for governance auditability." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governance Before Generation — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Governance before generation means enforcing architectural constraints before the AI writes code, not after it reaches review. The enforcement point is the strategic variable." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governance Infrastructure — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Governance infrastructure is the dedicated engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across AI agents — a first-class reliability concern, not a process layer." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Concepts — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The foundational concepts behind architectural governance for AI coding agents — defined by the engineering team building the governance infrastructure layer." />
   <meta name="robots" content="index, follow" />

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="The foundational concepts behind architectural governance for AI coding agents." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Concepts" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Verification Contracts — Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Verification contracts are pre-registered, machine-evaluable assertions about what a governance check must prove — the structural difference between measurable governance and subjective review." />
   <meta name="robots" content="index, follow" />

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Get in touch with the Mneme HQ team. Questions about integration, enterprise use, partnership, or press — we're reachable via GitHub, LinkedIn, or email." />
   <meta name="robots" content="index, follow" />

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Questions about Mneme HQ — architectural governance for AI-assisted development. Reach us via GitHub, LinkedIn, or email." />
   <meta name="twitter:image" content="https://mnemehq.com/contact/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -24,6 +24,9 @@
   <meta name="twitter:title" content="The ADR compiler — turn architectural decisions into infrastructure" />
   <meta name="twitter:description" content="Most teams already have ADRs. They sit in docs/adr/ and are quietly ignored by every AI coding agent. The ADR compiler reads those same files and emits enforceable, precedence-aware decisions." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <script type="application/ld+json">
   {

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The ADR compiler — turn architectural decisions into infrastructure | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Most teams already have ADRs. They sit in docs/adr/ and are quietly ignored by every AI coding agent. The ADR compiler reads those same files and emits enforceable, precedence-aware decisions. No rewrite. Runnable against Mneme's own ADRs." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -153,7 +153,7 @@
     .badge-pass { background: rgba(200,240,96,0.12); color: var(--accent); border: 1px solid rgba(200,240,96,0.25); }
     .badge-warn { background: rgba(245,158,11,0.12); color: var(--warn); border: 1px solid rgba(245,158,11,0.25); }
     .badge-fail { background: rgba(239,68,68,0.12); color: var(--fail); border: 1px solid rgba(239,68,68,0.25); }
-    .hidden { display: none; }
+    .hidden { visibility: hidden; }
     .fade-in { animation: fadeIn 0.35s ease forwards; }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: none; } }
     .replay-btn { margin: 1rem 0 0; background: transparent; color: var(--muted); border: 1px solid var(--border2); padding: 0.5rem 1.2rem; border-radius: 6px; font-size: 0.78rem; font-family: 'DM Mono', monospace; cursor: pointer; display: none; transition: color 0.15s, border-color 0.15s; }
@@ -323,7 +323,7 @@
             <span class="dot d-r"></span><span class="dot d-y"></span><span class="dot d-g"></span>
             mneme check --mode strict
           </div>
-          <div class="panel-body" id="check-body" style="min-height:auto;"></div>
+          <div class="panel-body" id="check-body"></div>
         </div>
       </div>
       <button class="replay-btn" type="button" id="replay-btn" onclick="startDemo()">&larr; Replay</button>
@@ -577,8 +577,13 @@ Result: WARN</code></pre>
       }, 150));
     }
 
-    startDemo();
-  
+    if ('IntersectionObserver' in window) {
+      var _adrIo = new IntersectionObserver(function(entries) {
+        if (entries[0].isIntersecting) { _adrIo.disconnect(); startDemo(); }
+      }, { threshold: 0.15 });
+      _adrIo.observe(document.querySelector('.demo-wrap'));
+    } else { startDemo(); }
+
   });
 </script>
   <script>

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governance gates in Claude Agent SDK workflows — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A Claude Agent SDK workflow where Mneme acts as the governance layer. An autonomous agent tasked with caching introduces Redis — violating ADR-001. Mneme's pre-execution hook catches the violation before the file write executes and reroutes the agent to the compliant primitive." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:title" content="Governance gates in Claude Agent SDK workflows" />
   <meta name="twitter:description" content="An autonomous agent tasked with caching introduces Redis — violating ADR-001. Mneme catches the violation before the file write executes." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <script type="application/ld+json">
   {

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:title" content="Architectural drift prevention — the AI SDLC entropy demo" />
   <meta name="twitter:description" content="A six-step timeline showing how drift compounds without a governance layer, and how Mneme blocks the first divergence upstream." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <script type="application/ld+json">
   {

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural drift prevention — the AI SDLC entropy demo | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A six-step timeline. An agent proposes reasonable-looking code that violates an ADR. Downstream changes amplify the divergence. A reviewer would plausibly miss it. Mneme blocks the first divergence upstream and the system converges." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Dependency Policy Enforcement — Demo Scenario | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A walkthrough of how Mneme catches an unapproved dependency (sqlalchemy) when an AI coding agent introduces it during a refactor. WARN verdict in mneme check, with the exact decision ID that flagged it." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Demo" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -24,6 +24,9 @@
   <meta name="twitter:title" content="Governed Python agent — from bad code to compliant output | Mneme HQ" />
   <meta name="twitter:description" content="A Python coding agent proposes an architecturally invalid import. Mneme retrieves ADR-005, blocks the namespace violation, and the agent retries with compliant code. The full product loop in one demo." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <script type="application/ld+json">
   {

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governed Python agent — from bad code to compliant output | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A Python coding agent proposes an architecturally invalid import. Mneme retrieves ADR-005, blocks the namespace violation, and the agent retries with compliant code. The full product loop in one demo." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -129,7 +129,7 @@
     .badge-pass { background: rgba(200,240,96,0.12); color: var(--accent); border: 1px solid rgba(200,240,96,0.25); }
     .badge-warn { background: rgba(245,158,11,0.12); color: var(--warn); border: 1px solid rgba(245,158,11,0.25); }
     .badge-fail { background: rgba(239,68,68,0.12); color: var(--fail); border: 1px solid rgba(239,68,68,0.25); }
-    .hidden { display: none; }
+    .hidden { visibility: hidden; }
     .fade-in { animation: fadeIn 0.35s ease forwards; }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: none; } }
     .replay-btn { margin: 1rem 0 0; background: transparent; color: var(--muted); border: 1px solid var(--border2); padding: 0.5rem 1.2rem; border-radius: 6px; font-size: 0.78rem; font-family: 'DM Mono', monospace; cursor: pointer; display: none; transition: color 0.15s, border-color 0.15s; }
@@ -274,7 +274,7 @@
             <span class="dot d-r"></span><span class="dot d-y"></span><span class="dot d-g"></span>
             Corrected output &mdash; agent retry
           </div>
-          <div class="panel-body" id="correct-out" style="min-height:auto;"></div>
+          <div class="panel-body" id="correct-out"></div>
         </div>
       </div>
       <button class="replay-btn" type="button" id="replay-btn" onclick="startDemo(true)">&larr; Replay</button>
@@ -456,7 +456,12 @@ Result: WARN</code></pre>
         });
       }, 150));
     }
-    startDemo();
+    if ('IntersectionObserver' in window) {
+      var _agentIo = new IntersectionObserver(function(entries) {
+        if (entries[0].isIntersecting) { _agentIo.disconnect(); startDemo(); }
+      }, { threshold: 0.15 });
+      _agentIo.observe(document.querySelector('.demo-wrap'));
+    } else { startDemo(); }
 
   });
   </script>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ — AI governance in action: governed agents, drift prevention, multi-actor continuity</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Three flagship demos showing AI governance as infrastructure. A Python agent catches its own namespace violation. Architectural drift gets blocked upstream. Governance holds across multiple actors. Plus a runnable benchmark suite." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -27,6 +27,9 @@
   <meta name="twitter:description" content="Three flagship demos showing AI governance as infrastructure. A Python agent catches its own namespace violation. Architectural drift gets blocked upstream. Governance holds across multiple actors." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governance continuity across multiple actors | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="As AI execution becomes distributed and persistent, governance becomes the coordination layer. Three agents act on the same codebase. Architectural invariants stay coherent across actors, sessions, and retries — because the invariants live outside the agents." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:title" content="Governance continuity across multiple actors" />
   <meta name="twitter:description" content="As AI execution becomes distributed and persistent, governance becomes the coordination layer." />
   <meta name="twitter:image" content="https://mnemehq.com/demo/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <script type="application/ld+json">
   {

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Demo" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Repository Pattern Enforcement — Demo Scenario | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A walkthrough of how Mneme blocks an ADR-004 violation when an AI coding agent bypasses the Repository pattern in user.service.ts. FAIL verdict that hard-blocks the diff in CI." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Storage Decision Enforcement — Demo Scenario | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A walkthrough of how Mneme enforces ADR-001 — JSON-only storage, no external database — when an AI coding agent is asked to refactor a storage backend. Same prompt, same model, different answer." />
   <meta name="robots" content="index, follow" />

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Demo" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/docs/analytics/index.html
+++ b/site/docs/analytics/index.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Analytics Data Layer &mdash; mnemehq.com &mdash; Mneme HQ</title>
+  <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="/assets/css/fonts.css">
+  <meta name="description" content="Data layer and analytics tracking implementation for mnemehq.com. GTM container, GA4 property, all tracked events and properties, key events, and how to add new tracking." />
+  <meta name="robots" content="noindex, follow" />
+  <meta name="theme-color" content="#0c0c0d" />
+  <link rel="canonical" href="https://mnemehq.com/docs/analytics/" />
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Mneme HQ" />
+  <meta property="og:title" content="Analytics Data Layer &mdash; mnemehq.com" />
+  <meta property="og:description" content="GTM container, GA4 property, tracked events, key events, and how to extend tracking on mnemehq.com." />
+  <meta property="og:url" content="https://mnemehq.com/docs/analytics/" />
+  <meta property="og:image" content="https://mnemehq.com/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Analytics Data Layer &mdash; mnemehq.com" />
+  <meta name="twitter:description" content="GTM container, GA4 property, tracked events, key events, and how to extend tracking on mnemehq.com." />
+  <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
+  <!-- End Google Tag Manager -->
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Docs", "item": "https://mnemehq.com/docs/"},
+          {"@type": "ListItem", "position": 3, "name": "Analytics data layer", "item": "https://mnemehq.com/docs/analytics/"}
+        ]
+      },
+      {
+        "@type": "TechArticle",
+        "headline": "Analytics Data Layer — mnemehq.com",
+        "description": "GTM container, GA4 property, all tracked events, key events, and how to add new tracking.",
+        "url": "https://mnemehq.com/docs/analytics/",
+        "datePublished": "2026-05-17",
+        "dateModified": "2026-05-17",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
+        "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}}
+      }
+    ]
+  }
+  </script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0c0c0d; --surface: #141416; --surface2: #1a1a1d;
+      --border: #222226; --border2: #2e2e34;
+      --text: #e8e8ec; --muted: #88889a;
+      --accent: #c8f060; --accent-dim: #a8d040; --teal: #8be0c8;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; min-height: 100vh; }
+    nav.site-nav { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 2.5rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(12,12,13,0.95); backdrop-filter: blur(12px); z-index: 100; }
+    .logo { display: flex; align-items: center; text-decoration: none; }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.82rem; transition: color 0.15s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .btn-nav-cta { background: var(--accent); color: #0c0c0d; padding: 0.45rem 1.1rem; border-radius: 6px; font-size: 0.82rem; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+    .btn-nav-cta:hover { background: var(--accent-dim); color: #0c0c0d; }
+
+    .breadcrumb-nav { max-width: 880px; margin: 0 auto; padding: 1.75rem 2rem 0.85rem; }
+    .breadcrumb { display: flex; align-items: center; gap: 0.5rem; list-style: none; font-size: 0.82rem; flex-wrap: wrap; }
+    .breadcrumb li + li::before { content: '/'; color: var(--border2); margin-right: 0.5rem; }
+    .breadcrumb a { color: var(--muted); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--text); }
+    .breadcrumb [aria-current="page"] { color: var(--text); }
+
+    .hero { max-width: 880px; margin: 0 auto; padding: 4rem 2rem 2rem; }
+    .section-eyebrow { font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.75rem; font-family: 'DM Mono', monospace; }
+    .hero h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.25rem; }
+    .hero p.lede { font-size: 1.05rem; color: var(--muted); line-height: 1.75; max-width: 720px; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
+
+    .wrap { max-width: 880px; margin: 0 auto; padding: 3rem 2rem 4rem; font-size: 0.92rem; line-height: 1.8; }
+    .wrap p { color: var(--muted); margin-bottom: 1rem; }
+    .wrap p strong { color: var(--text); font-weight: 500; }
+    .wrap a.ext { color: var(--accent); text-decoration: none; border-bottom: 1px dotted rgba(200,240,96,0.4); }
+    .wrap a.ext:hover { color: var(--accent-dim); }
+
+    .toc { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.75rem; margin-bottom: 3rem; }
+    .toc-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.9rem; }
+    .toc ol { list-style: none; counter-reset: toc; margin: 0; padding: 0; display: grid; grid-template-columns: 1fr; gap: 0.45rem; }
+    .toc ol li { counter-increment: toc; font-size: 0.86rem; padding-left: 2.2rem; position: relative; line-height: 1.5; }
+    .toc ol li::before { content: counter(toc, decimal-leading-zero); position: absolute; left: 0; top: 0.05rem; font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--border2); letter-spacing: 0.05em; }
+    .toc a { color: var(--muted); text-decoration: none; }
+    .toc a:hover { color: var(--accent); }
+    @media (min-width: 720px) { .toc ol { grid-template-columns: 1fr 1fr; gap: 0.5rem 1.5rem; } }
+
+    .section { margin-top: 3.5rem; }
+    .section:first-of-type { margin-top: 0; }
+    .section h2 { font-family: 'Inter', sans-serif; font-size: 1.4rem; font-weight: 600; letter-spacing: -0.015em; margin-bottom: 0.5rem; color: var(--text); }
+    .section .sub { font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--muted); margin: 0 0 1rem; }
+
+    .infra-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.75rem; margin-bottom: 1rem; display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    @media (max-width: 640px) { .infra-card { grid-template-columns: 1fr; } }
+    .infra-item .label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.3rem; }
+    .infra-item .value { font-family: 'DM Mono', monospace; font-size: 0.9rem; color: var(--accent); }
+    .infra-item .note { font-size: 0.8rem; color: var(--muted); margin-top: 0.2rem; }
+
+    .event-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.4rem 1.75rem; margin-bottom: 1rem; }
+    .event-card .eh { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.35rem; }
+    .event-card .ename { font-family: 'DM Mono', monospace; font-size: 0.95rem; color: var(--accent); font-weight: 500; }
+    .event-card .etag { font-family: 'DM Mono', monospace; font-size: 0.62rem; color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase; border: 1px solid var(--border2); border-radius: 100px; padding: 2px 9px; }
+    .event-card .etag.key { color: var(--accent); border-color: rgba(200,240,96,0.35); background: rgba(200,240,96,0.06); }
+    .event-card .edesc { font-size: 0.88rem; color: var(--muted); margin: 0.2rem 0 0.85rem; line-height: 1.7; }
+    .event-card pre { background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: 0.85rem 1rem; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--text); overflow-x: auto; line-height: 1.6; margin: 0 0 0.85rem; }
+    .event-card .props-title { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin: 0.85rem 0 0.45rem; }
+    .event-card table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    .event-card table th, .event-card table td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border); vertical-align: top; color: var(--muted); }
+    .event-card table th { font-family: 'DM Mono', monospace; font-size: 0.68rem; color: var(--muted); letter-spacing: 0.05em; text-transform: uppercase; font-weight: 500; }
+    .event-card table td:first-child { font-family: 'DM Mono', monospace; color: var(--text); white-space: nowrap; }
+    .event-card table tr:last-child td { border-bottom: none; }
+    .event-card .src { font-size: 0.78rem; color: var(--muted); margin-top: 0.5rem; }
+    .event-card .src code { font-family: 'DM Mono', monospace; font-size: 0.75rem; color: var(--teal); background: var(--surface2); padding: 0.1rem 0.35rem; border-radius: 3px; border: 1px solid var(--border); }
+
+    .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.1rem 1.4rem; margin: 1.5rem 0; }
+    .callout p { font-size: 0.88rem; color: var(--muted); margin: 0; line-height: 1.75; }
+    .callout p strong { color: var(--accent); }
+
+    .code-block { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.4rem 1.6rem; margin: 1rem 0; }
+    .code-block h3 { font-family: 'Inter', sans-serif; font-size: 0.98rem; font-weight: 600; color: var(--text); margin-bottom: 0.4rem; }
+    .code-block p { font-size: 0.85rem; color: var(--muted); margin: 0 0 0.7rem; line-height: 1.7; }
+    .code-block pre { background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: 0.85rem 1rem; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--text); overflow-x: auto; line-height: 1.6; }
+
+    .key-events-table { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.75rem; margin: 1rem 0; }
+    .key-events-table .kt-title { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.85rem; }
+    .key-events-table table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+    .key-events-table th, .key-events-table td { text-align: left; padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: top; }
+    .key-events-table th { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+    .key-events-table td:first-child { font-family: 'DM Mono', monospace; color: var(--text); }
+    .key-events-table tr:last-child td { border-bottom: none; }
+    .star { color: var(--accent); }
+
+    .cross-links { margin-top: 3rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+    .cross-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.2rem 1.4rem; text-decoration: none; color: var(--text); display: flex; flex-direction: column; gap: 0.4rem; transition: border-color 0.15s; }
+    .cross-card:hover { border-color: rgba(200,240,96,0.4); }
+    .cross-card .cl-label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); }
+    .cross-card .cl-title { font-family: 'Inter', sans-serif; font-size: 0.95rem; font-weight: 600; }
+    .cross-card .cl-sub { font-size: 0.8rem; color: var(--muted); line-height: 1.6; }
+
+    footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+
+    .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
+    .nav-hamburger:hover { border-color: var(--accent); }
+    .nav-hamburger span { display: block; width: 18px; height: 2px; background: currentColor; border-radius: 1px; transition: transform 0.25s ease, opacity 0.18s ease; transform-origin: center; }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+    @media (max-width: 900px) {
+      html, body { overflow-x: hidden; }
+      nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+      .nav-hamburger { display: flex; }
+      .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
+      .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }
+      .nav-links a:not(.btn-nav-cta) { display: block; color: var(--text); font-size: 0.92rem; padding: 0.85rem 0; border-bottom: 1px solid var(--border); }
+      .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
+      .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
+    }
+    @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  </style>
+</head>
+<body>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+<nav class="site-nav">
+  <a href="/" class="logo"><img src="/logo-v2.png" alt="Mneme HQ" height="36" style="display:block;"></a>
+  <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
+  <div class="nav-links">
+    <a href="/#how-it-works">How it works</a>
+    <a href="/use-cases/">Use cases</a>
+    <a href="/insights/">Insights</a>
+    <a href="/roadmap/">Roadmap</a>
+    <a href="/demo/">Demo</a>
+    <a href="/benchmark/">Benchmark</a>
+    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/TheoV823/mneme" class="btn-nav-cta">Get started</a>
+  </div>
+</nav>
+
+<nav class="breadcrumb-nav" aria-label="Breadcrumb">
+  <ol class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/docs/">Docs</a></li>
+    <li aria-current="page">Analytics data layer</li>
+  </ol>
+</nav>
+
+<main>
+
+<section class="hero">
+  <div class="section-eyebrow">Internal reference</div>
+  <h1>Analytics data layer.</h1>
+  <p class="lede">GTM container, GA4 property, every tracked event with its properties, key events marked in GA4, and how to add new tracking to any page.</p>
+</section>
+
+<div class="wrap">
+
+  <div class="toc">
+    <div class="toc-title">On this page</div>
+    <ol>
+      <li><a href="#infrastructure">Infrastructure</a></li>
+      <li><a href="#consent">Consent mode</a></li>
+      <li><a href="#events">Tracked events</a></li>
+      <li><a href="#key-events">Key events in GA4</a></li>
+      <li><a href="#how-to-add">How to add new events</a></li>
+      <li><a href="#debugging">Debugging</a></li>
+    </ol>
+  </div>
+
+  <!-- INFRASTRUCTURE -->
+  <div class="section" id="infrastructure">
+    <h2>Infrastructure</h2>
+    <p class="sub">GTM container + GA4 property — all pages</p>
+
+    <div class="infra-card">
+      <div class="infra-item">
+        <div class="label">GTM container</div>
+        <div class="value">GTM-KL7FB67N</div>
+        <div class="note">Loaded on every page via inline script before <code style="font-family:'DM Mono',monospace;font-size:0.8em;">&lt;/head&gt;</code>. Manages the GA4 configuration tag and enhanced measurement triggers.</div>
+      </div>
+      <div class="infra-item">
+        <div class="label">GA4 measurement ID</div>
+        <div class="value">G-ZZ9YG12PPX</div>
+        <div class="note">Property: <strong>Mneme (392806868)</strong>, stream ID <strong>14602634596</strong>. Loaded by GTM via <code style="font-family:'DM Mono',monospace;font-size:0.8em;">gtag/js?id=G-ZZ9YG12PPX</code>.</div>
+      </div>
+      <div class="infra-item">
+        <div class="label">Event delivery</div>
+        <div class="value">gtag('event', ...)</div>
+        <div class="note">Custom events call <code style="font-family:'DM Mono',monospace;font-size:0.8em;">gtag('event', name, props)</code> directly. No GTM custom event trigger wiring needed — the GA4 library processes these natively.</div>
+      </div>
+      <div class="infra-item">
+        <div class="label">Enhanced measurement</div>
+        <div class="value">Enabled in GTM</div>
+        <div class="note">Automatically captures <code style="font-family:'DM Mono',monospace;font-size:0.8em;">scroll</code>, <code style="font-family:'DM Mono',monospace;font-size:0.8em;">click</code>, <code style="font-family:'DM Mono',monospace;font-size:0.8em;">file_download</code>, <code style="font-family:'DM Mono',monospace;font-size:0.8em;">form_start</code>, <code style="font-family:'DM Mono',monospace;font-size:0.8em;">form_submit</code>, and outbound link clicks.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- CONSENT -->
+  <div class="section" id="consent">
+    <h2>Consent mode</h2>
+    <p class="sub">Declared before GTM on every page</p>
+
+    <p>Every page declares consent defaults immediately before the GTM script tag. This ensures GA4 receives explicit <code style="font-family:'DM Mono',monospace;font-size:0.85em;">analytics_storage: granted</code> before any tags fire.</p>
+
+    <div class="code-block">
+      <h3>Consent defaults snippet (head, before GTM)</h3>
+      <pre><span style="color:var(--muted);">// Inserted on every page before the GTM script tag</span>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  'analytics_storage':    'granted',
+  'ad_storage':           'denied',
+  'ad_user_data':         'denied',
+  'ad_personalization':   'denied'
+});</pre>
+    </div>
+
+    <div class="callout">
+      <p><strong>Why this matters:</strong> Without an explicit consent default, GA4 encodes an ambiguous <code style="font-family:'DM Mono',monospace;font-size:0.85em;">_eu</code> consent parameter on every collect hit. This can cause collect requests to return 503. The explicit grant resolves the ambiguity and ensures hits are accepted.</p>
+    </div>
+  </div>
+
+  <!-- EVENTS -->
+  <div class="section" id="events">
+    <h2>Tracked events</h2>
+    <p class="sub">Custom events fired from page code + GTM enhanced measurement</p>
+
+    <!-- install_command_copied -->
+    <div class="event-card">
+      <div class="eh">
+        <span class="ename">install_command_copied</span>
+        <span class="etag">Custom · Homepage</span>
+      </div>
+      <p class="edesc">Fires when a user clicks the copy button on the install command block. Indicates install intent.</p>
+      <div class="props-title">Properties</div>
+      <table>
+        <thead><tr><th>Property</th><th>Type</th><th>Example</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>command</td><td>string</td><td><code style="font-family:'DM Mono',monospace;font-size:0.8em;">"install"</code></td><td>From <code style="font-family:'DM Mono',monospace;font-size:0.8em;">data-command</code> attribute on the button</td></tr>
+        </tbody>
+      </table>
+      <p class="src">Source: <code>site/index.html</code> — copy button click handler</p>
+    </div>
+
+    <!-- cta_clicked -->
+    <div class="event-card">
+      <div class="eh">
+        <span class="ename">cta_clicked</span>
+        <span class="etag">Custom · Homepage</span>
+      </div>
+      <p class="edesc">Fires on any click to a <code style="font-family:'DM Mono',monospace;font-size:0.85em;">/pilot</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">/demo</code>, or <code style="font-family:'DM Mono',monospace;font-size:0.85em;">.btn-primary</code> link. Captures conversion-intent CTA clicks with full context.</p>
+      <pre>gtag('event', 'cta_clicked', {
+  cta_text: 'Request pilot access',   <span style="color:var(--muted);">// button label, max 60 chars</span>
+  cta_href: '/pilot/',                <span style="color:var(--muted);">// destination href</span>
+  cta_type: 'pilot'                   <span style="color:var(--muted);">// 'pilot' | 'demo' | 'primary'</span>
+});</pre>
+      <div class="props-title">Properties</div>
+      <table>
+        <thead><tr><th>Property</th><th>Type</th><th>Values</th></tr></thead>
+        <tbody>
+          <tr><td>cta_text</td><td>string</td><td>Visible button text, truncated to 60 chars</td></tr>
+          <tr><td>cta_href</td><td>string</td><td>The <code style="font-family:'DM Mono',monospace;font-size:0.8em;">href</code> attribute of the clicked element</td></tr>
+          <tr><td>cta_type</td><td>string</td><td><code style="font-family:'DM Mono',monospace;font-size:0.8em;">"pilot"</code> | <code style="font-family:'DM Mono',monospace;font-size:0.8em;">"demo"</code> | <code style="font-family:'DM Mono',monospace;font-size:0.8em;">"primary"</code></td></tr>
+        </tbody>
+      </table>
+      <p class="src">Source: <code>site/index.html</code> — delegated click listener on <code>document</code></p>
+    </div>
+
+    <!-- pilot_form_submitted -->
+    <div class="event-card">
+      <div class="eh">
+        <span class="ename">pilot_form_submitted</span>
+        <span class="etag">Custom · /pilot/</span>
+      </div>
+      <p class="edesc">Fires when the Formspree pilot request form submits successfully (HTTP 200 from Formspree). This is the primary conversion event for mnemehq.com.</p>
+      <pre>gtag('event', 'pilot_form_submitted');
+<span style="color:var(--muted);">// No additional properties — the submission itself is the signal.</span></pre>
+      <p class="src">Source: <code>site/pilot/index.html</code> — Formspree fetch success handler (form ID: <code>meennlwj</code>)</p>
+    </div>
+
+    <!-- Enhanced measurement events -->
+    <div class="event-card">
+      <div class="eh">
+        <span class="ename">form_submit</span>
+        <span class="etag">Enhanced measurement · GTM</span>
+        <span class="etag key">★ Key event</span>
+      </div>
+      <p class="edesc">Auto-captured by GTM enhanced measurement on any native HTML form submission detected on the page. On the pilot page, this fires alongside <code style="font-family:'DM Mono',monospace;font-size:0.85em;">pilot_form_submitted</code> because the form uses a fetch intercept that still allows native form detection. Marked as a key event in GA4.</p>
+      <p class="src">Source: GTM enhanced measurement — no code change needed</p>
+    </div>
+
+    <div class="event-card">
+      <div class="eh">
+        <span class="ename">cta_demo_click</span>
+        <span class="etag">GTM tag · Site-wide</span>
+        <span class="etag key">★ Key event</span>
+      </div>
+      <p class="edesc">Fired by an existing GTM tag when a demo CTA is clicked. Predates the <code style="font-family:'DM Mono',monospace;font-size:0.85em;">cta_clicked</code> event; both coexist. Marked as a key event in GA4.</p>
+      <p class="src">Source: GTM container — GTM-KL7FB67N tag configuration</p>
+    </div>
+
+    <p>Additional events automatically captured by GTM enhanced measurement: <code style="font-family:'DM Mono',monospace;font-size:0.85em;">page_view</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">session_start</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">first_visit</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">scroll</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">scroll_depth</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">click</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">file_download</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">outbound_link_clicked</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">form_start</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">user_engagement</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">benchmark_section_viewed</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">demo_page_viewed</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">use_case_viewed</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">contact_method_clicked</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">community_engagement_click</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">insight_article_clicked</code>.</p>
+  </div>
+
+  <!-- KEY EVENTS -->
+  <div class="section" id="key-events">
+    <h2>Key events in GA4</h2>
+    <p class="sub">Events marked as key events in GA4 Admin &rarr; Events (property 534820916)</p>
+
+    <div class="key-events-table">
+      <div class="kt-title">Key events — as of 2026-05-17</div>
+      <table>
+        <thead><tr><th>Event</th><th>Status</th><th>What it represents</th></tr></thead>
+        <tbody>
+          <tr><td>form_submit</td><td><span class="star">★</span> Key event</td><td>Pilot form submission (primary conversion)</td></tr>
+          <tr><td>cta_demo_click</td><td><span class="star">★</span> Key event</td><td>Demo CTA clicks (intent signal)</td></tr>
+          <tr><td>close_convert_lead</td><td><span class="star">★</span> Key event</td><td>CRM lead conversion (legacy)</td></tr>
+          <tr><td>qualify_lead</td><td><span class="star">★</span> Key event</td><td>CRM lead qualification (legacy)</td></tr>
+          <tr><td>pilot_form_submitted</td><td>Pending deploy</td><td>Add to key events after PR #97 ships and first event appears in Recent events</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout">
+      <p><strong>To mark a new key event:</strong> GA4 Admin &rarr; Data display &rarr; Events &rarr; Recent events tab &rarr; click the star next to the event name. The event must have fired at least once in the last 28 days to appear in the list.</p>
+    </div>
+  </div>
+
+  <!-- HOW TO ADD -->
+  <div class="section" id="how-to-add">
+    <h2>How to add new events</h2>
+    <p class="sub">Pattern used across the codebase</p>
+
+    <p>All custom events use <code style="font-family:'DM Mono',monospace;font-size:0.85em;">gtag('event', ...)</code> directly. The <code style="font-family:'DM Mono',monospace;font-size:0.85em;">gtag</code> function is defined in the consent defaults snippet on every page, so it is always available. No GTM tag or trigger configuration is needed.</p>
+
+    <div class="code-block">
+      <h3>Minimal event</h3>
+      <pre>gtag('event', 'your_event_name');</pre>
+    </div>
+
+    <div class="code-block">
+      <h3>Event with properties</h3>
+      <pre>gtag('event', 'your_event_name', {
+  property_one: 'value',
+  property_two: 42
+});</pre>
+    </div>
+
+    <div class="code-block">
+      <h3>Event with defensive gtag guard (use when outside the consent snippet scope)</h3>
+      <pre>window.gtag = window.gtag || function(){
+  (window.dataLayer = window.dataLayer || []).push(arguments);
+};
+gtag('event', 'your_event_name', { ... });</pre>
+    </div>
+
+    <p><strong>Naming convention:</strong> lowercase snake_case, object-action format. Examples: <code style="font-family:'DM Mono',monospace;font-size:0.85em;">pilot_form_submitted</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">cta_clicked</code>, <code style="font-family:'DM Mono',monospace;font-size:0.85em;">demo_step_completed</code>. Avoid generic names like <code style="font-family:'DM Mono',monospace;font-size:0.85em;">button_clicked</code> — include context in the event name or a property.</p>
+
+    <p>After deploying, wait for the event to appear in GA4 Admin &rarr; Events &rarr; Recent events (can take up to 24 hours), then star it as a key event if it represents a conversion or meaningful intent signal. Update this document.</p>
+  </div>
+
+  <!-- DEBUGGING -->
+  <div class="section" id="debugging">
+    <h2>Debugging</h2>
+    <p class="sub">Verify events are firing and reaching GA4</p>
+
+    <div class="code-block">
+      <h3>Check dataLayer state in DevTools console</h3>
+      <pre>window.dataLayer
+<span style="color:var(--muted);">// Should show gtm.js, gtm.dom, gtm.load — plus any custom events fired</span></pre>
+    </div>
+
+    <div class="code-block">
+      <h3>Verify collect requests in DevTools Network tab</h3>
+      <pre><span style="color:var(--muted);">// Filter by: google-analytics.com/g/collect
+// Look for:  en=page_view, en=cta_clicked, etc. in the request URL
+// Status:    200 or 204 = success.  503 = property/stream issue.</span></pre>
+    </div>
+
+    <div class="code-block">
+      <h3>Fire a test event manually</h3>
+      <pre>gtag('event', 'test_event', { source: 'devtools' });
+<span style="color:var(--muted);">// Then check Network for a /g/collect request with en=test_event</span></pre>
+    </div>
+
+    <p>For real-time event monitoring, use <strong>GA4 Admin &rarr; DebugView</strong> (requires adding <code style="font-family:'DM Mono',monospace;font-size:0.85em;">?gtm_debug=x</code> to the page URL or enabling the Google Analytics Debugger browser extension).</p>
+  </div>
+
+  <div class="cross-links">
+    <a class="cross-card" href="/docs/">
+      <span class="cl-label">Reference</span>
+      <span class="cl-title">All docs</span>
+      <span class="cl-sub">CLI, governance violations, supported languages, benchmark methodology.</span>
+    </a>
+    <a class="cross-card" href="/docs/cli/">
+      <span class="cl-label">Reference</span>
+      <span class="cl-title">CLI reference</span>
+      <span class="cl-sub">Commands, flags, and exit codes for <code style="font-family:'DM Mono',monospace;font-size:0.85em;">mneme</code>.</span>
+    </a>
+    <a class="cross-card" href="/pilot/">
+      <span class="cl-label">Conversion</span>
+      <span class="cl-title">Request pilot</span>
+      <span class="cl-sub">The page where <code style="font-family:'DM Mono',monospace;font-size:0.85em;">pilot_form_submitted</code> fires.</span>
+    </a>
+  </div>
+
+</div>
+</main>
+
+<footer>
+  <p style="font-size:0.78rem;color:var(--muted);">Internal reference &mdash; <a href="https://mnemehq.com/">mnemehq.com</a> &mdash; Last updated 2026-05-17</p>
+</footer>
+
+<script>
+(function(){
+  var btn = document.querySelector('.nav-hamburger');
+  var links = document.querySelector('.nav-links');
+  if (!btn || !links) return;
+  btn.addEventListener('click', function(e){
+    e.stopPropagation();
+    var open = links.classList.toggle('open');
+    btn.setAttribute('aria-expanded', open);
+    document.body.classList.toggle('menu-open', open);
+  });
+  document.addEventListener('click', function(e){
+    if (!links.contains(e.target) && !btn.contains(e.target)) {
+      links.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('menu-open');
+    }
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape') {
+      links.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('menu-open');
+    }
+  });
+})();
+</script>
+<script>
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -29,6 +29,9 @@
 
 
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Benchmark Methodology Philosophy — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Why the Mneme governance benchmark is deterministic, why recall@1 is reported but not optimized, and what Mneme intentionally does not solve. Layer 1 freeze framing." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme CLI Reference &mdash; Commands, Flags, Exit Codes &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Reference for the mneme command-line interface — list_decisions, add_decision, test_query, check, cursor generate, and benchmark. Flags, exit codes, and CI usage patterns." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Commands, flags, and exit codes for the mneme CLI." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Concrete examples of architectural governance violations Mneme HQ catches before generation." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>What Mneme Prevents &mdash; Governance Violation Examples &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Twelve concrete examples of the architectural governance violations Mneme HQ enforces against, organized into five categories: architecture, security, workflow, dependency, and platform governance." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>How Enforcement Works &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme turns human-authored architectural decisions into deterministic enforcement rules checked before AI generation. ADR authoring, structured governance, explainable verdicts." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -22,6 +22,9 @@
   <meta name="twitter:title" content="How Enforcement Works &mdash; Mneme HQ" />
   <meta name="twitter:description" content="How Mneme turns human-authored architectural decisions into deterministic enforcement rules checked before AI generation." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -21,6 +21,9 @@
   <meta name="twitter:title" content="Docs &mdash; Mneme HQ" />
   <meta name="twitter:description" content="CLI reference, governance violations, supported languages, and benchmark methodology." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Docs &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Reference documentation for Mneme HQ: the CLI, governance violations Mneme catches, supported languages, and the benchmark methodology." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -174,6 +174,11 @@
       <p>How the v1.1 governance benchmark is measured: layered retrieval and enforcement scoring, structured-output verification, pre-registered thresholds, anti-gaming protocol.</p>
       <span class="read">Benchmark methodology &rarr;</span>
     </a>
+    <a class="doc-card" href="/docs/analytics/">
+      <div class="dh"><span class="dname">Analytics data layer</span><span class="dtag">Internal</span></div>
+      <p>GTM container, GA4 property, every tracked event with its properties, key events, consent mode setup, and how to add new tracking to any page on mnemehq.com.</p>
+      <span class="read">Analytics data layer &rarr;</span>
+    </a>
   </div>
 
   <h2 style="font-family:'DM Mono',monospace;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);margin:3.5rem 0 1.25rem;">How to read these docs</h2>

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Supported Programming Languages &mdash; Governance Scope &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ's architectural governance is language-agnostic by design. Repository, workflow, and CI-level enforcement across Python, TypeScript, JavaScript, Go, Java, C#, and Rust — without language-specific parsers." />
   <meta name="robots" content="index, follow" />

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Architectural governance is language-agnostic by design." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>For CTOs &amp; VP Engineering — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="AI increases code throughput. Your review capacity does not. Mneme HQ enforces architectural governance before code reaches review." />
   <meta name="robots" content="index, follow" />

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="AI increases code throughput. Your review capacity does not. Mneme HQ enforces architectural governance before code reaches review." />
   <meta name="twitter:image" content="https://mnemehq.com/for/cto/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Who Mneme Is For | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme is built for engineering teams where AI-assisted development is moving faster than architectural review. Platform engineering, data platforms, AI-native teams, and architecture guilds." />
   <meta name="robots" content="index, follow" />

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Mneme is built for engineering teams where AI-assisted development is moving faster than architectural review. Platform engineering, data platforms, AI-native teams, and architecture guilds." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Centralize architectural standards across every AI coding workflow. One decision corpus. All agents. All tools. No rules sprawl." />
   <meta name="twitter:image" content="https://mnemehq.com/for/platform/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>For Platform &amp; DevEx Teams — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Centralize architectural standards across every AI coding workflow. One decision corpus. All agents. All tools. No rules sprawl." />
   <meta name="robots" content="index, follow" />

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>For Staff &amp; Principal Engineers — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Stop repeating architectural decisions in every PR review. Record them once. Enforce them automatically." />
   <meta name="robots" content="index, follow" />

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Stop repeating architectural decisions in every PR review. Record them once. Enforce them automatically." />
   <meta name="twitter:image" content="https://mnemehq.com/for/principal-engineer/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Founder — Theo Valmis | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Theo Valmis built Mneme HQ after watching LLMs introduce architectural drift across large production codebases. Background in AI systems and technical delivery for global enterprise brands." />
   <meta name="robots" content="index, follow" />

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Theo Valmis built Mneme HQ after watching LLMs introduce architectural drift across large production codebases." />
   <meta name="twitter:image" content="https://mnemehq.com/founder/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/index.html
+++ b/site/index.html
@@ -26,6 +26,9 @@
   <meta name="twitter:description" content="Mneme HQ enforces your team's architectural decisions before AI-generated code reaches review. Prevent drift, enforce standards, and govern AI coding at the source." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
@@ -1735,6 +1738,27 @@
         done();
       }
     });
+  });
+})();
+</script>
+<script>
+(function () {
+  window.gtag = window.gtag || function(){(window.dataLayer = window.dataLayer||[]).push(arguments);};
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('a[href], button');
+    if (!el) return;
+    var href = el.getAttribute('href') || '';
+    var text = (el.innerText || el.textContent || '').trim().slice(0, 60);
+    var isPrimary = el.classList.contains('btn-primary');
+    var isDemo = href.indexOf('/demo') !== -1;
+    var isPilot = href.indexOf('/pilot') !== -1;
+    if (isPrimary || isDemo || isPilot) {
+      window.gtag('event', 'cta_clicked', {
+        cta_text: text,
+        cta_href: href,
+        cta_type: isPilot ? 'pilot' : isDemo ? 'demo' : 'primary'
+      });
+    }
   });
 })();
 </script>

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ — Architectural Governance for AI-Assisted Development</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ enforces your team's architectural decisions before AI-generated code reaches review. Prevent drift, enforce standards, and govern AI coding at the source." />
   <meta name="google-site-verification" content="eW7iETj7y-Ni_T0RYKR0cvBXhaz3y4NfEfHSwXbMlNQ" />

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Acceleration Whiplash and the Governance Gap — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The Faros AI Engineering Report 2026 measured what AI adoption actually produces. Throughput is up. So are incidents, review times, and unreviewed merges. The data names the governance problem." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Industry Analysis" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Agents of Chaos and the Governance Gap — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A new red-teaming study deployed real AI agents in a live environment for two weeks. The failures weren't about model alignment. They were about what happens when aligned agents operate without governance infrastructure." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI Code Review Does Not Scale Linearly — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="AI code generation scales nearly infinitely. Reviewer attention does not. The governance bottleneck this creates requires architectural enforcement at generation time, not more reviewers." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI Coding Governance Should Be Reviewable — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Most AI memory is opaque hidden state. Mneme treats governance as versioned engineering infrastructure — reviewable, auditable, and co-located with the code it governs." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance Across Heterogeneous AI Coding Agents — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Most engineering orgs run multiple AI coding tools — Claude Code, Cursor, Copilot, Windsurf, SDK agents — against one codebase. Per-tool memory fails at the seams." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Architecture" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Autonomous Code Remediation Requires Architectural Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Autonomous remediation loops cannot stabilise without deterministic architectural constraints. Faster generation accelerates drift. Governance must become infrastructure." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Datadog&rsquo;s State of AI Engineering Report Quietly Confirms the Governance Crisis &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Datadog surveyed 1,000+ production AI orgs and found model churn is a governance problem, context quality beats volume, and disciplined systems are the next competitive advantage." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Industry Analysis" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Deployment Quality Will Define the AI Era — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The first AI era rewarded early adoption. The next rewards operational quality. For engineering teams, that means governing what AI generates — not just shipping faster with it." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Generative AI Software Engineering Stack &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="A seven-layer reference frame for the Generative AI software engineering stack — from foundation models to human oversight. AI coding increased generation throughput. Governance and review did not scale at the same rate." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Industry Analysis" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -32,6 +32,9 @@
   <meta property="article:tag" content="github" />
   <meta property="article:tag" content="engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Quantifying GitHub Copilot's Impact: What the SPACE Framework Actually Reveals — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Most teams measure GitHub Copilot the wrong way. The SPACE Framework — developed by GitHub, Microsoft Research, and University of Victoria — forces a better question." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Insights on AI Coding Governance &amp; Architecture &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Engineering notes on architectural governance, AI coding drift, and the future of constraint enforcement in LLM-assisted development." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Engineering notes on architectural governance, AI coding drift, and the future of constraint enforcement in LLM-assisted development." />
   <meta name="twitter:image" content="https://mnemehq.com/insights/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -26,6 +26,9 @@
   <meta property="article:published_time" content="2026-05-15T00:00:00Z" />
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Long-Running Agents Need More Than Memory — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Anthropic's managed-agent harness solves continuity: progress logs, feature lists, git checkpoints. But continuity is not governance. As agents work across sessions, codebases need enforceable architectural contracts that define what must remain true." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Memory Is Not Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The AI coding category conflates memory, context, retrieval, and governance into one word. They are four different systems with four different optimization targets. Memory optimizes recall. Governance optimizes constraint enforcement. The distinction matters." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme vs Cursor Rules — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Cursor Rules are per-repo text files. Mneme HQ is a structured decision memory with a precedence engine and hook-level enforcement. The comparison that matters." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OpenAI-Compatible APIs Are Commoditizing Models &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="NVIDIA's NIM platform exposes 80+ frontier models behind a single OpenAI-compatible endpoint. Models are becoming interchangeable infrastructure. The governance layer is what survives the swap." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Industry Analysis" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OpenClaw and the Limits of Autonomous Coding — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="OpenClaw crossed 100,000 GitHub stars in its first week and became the most ambitious autonomous coding agent experiment in the ecosystem. Then it hit a wall. What it reveals about the next engineering problem." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Prompt Engineering Is Not Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Prompt templates can nudge a model toward better output. They cannot enforce architectural invariants, resolve decision conflicts, or prevent drift across a codebase." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Review Is Not Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="CodeRabbit helps review AI-generated code. Mneme helps govern what the AI generates in the first place. These are not competing tools. They are different layers of the same problem." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Industry Analysis" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Rise of Agentic Engineering Education &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Universities, hackathons, and platform vendors are racing to launch agentic engineering programs. Almost none of them teach governance. The next AI engineering discipline has a curriculum gap." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>What Is the AI SDLC? — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The AI SDLC isn't a new development methodology. It's the familiar lifecycle — redefined by the speed, scale, and autonomy of AI-native code generation, and the governance gap that creates." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -32,6 +32,9 @@
   <meta property="article:tag" content="governance" />
   <meta property="article:tag" content="engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -28,6 +28,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Why AI Architectural Governance Needs Precedence Semantics — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="When two architectural decisions overlap, prompt rules, RAG, and PR review all resolve the conflict non-deterministically. Precedence semantics — specificity, supersedes, priority, status, temporal resolution — is the missing layer that makes AI governance deterministic." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Why CLAUDE.md Stops Scaling &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="CLAUDE.md is an instruction surface, not a governance layer. It works until teams scale, decisions evolve, and agents run autonomously. Here is where the ceiling is." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Why Code Review Cannot Scale With AI Output — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="AI coding assistants generate code at 10–100× human pace. Code review is still linear. The resulting bottleneck can't be solved by hiring — it requires pre-generation enforcement." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Why Prompt Memory Fails at Scale — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Teams paste their architectural rules into CLAUDE.md and call it governance. At small scale it half-works. At large scale it collapses. Here is why context injection is not governance memory." />
   <meta name="robots" content="index, follow" />

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Engineering" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Why RAG Fails for Architectural Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="RAG retrieves similar text. Architectural governance requires authoritative, precedence-aware constraint enforcement. Here's why they're fundamentally different problems." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Import Existing ADRs — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Turn the ADRs already sitting in your docs/ into enforceable AI coding guardrails. One command to preview, one to apply — deterministic, no AI interpretation." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -26,6 +26,9 @@
   <meta property="article:published_time" content="2026-05-14T00:00:00Z" />
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Govern architectural constraints in Claude Agent SDK workflows — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Claude Agent SDK handles execution and orchestration. Mneme handles architectural invariants and enforcement. Learn how to wire a deterministic governance policy layer around your agent workflows." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Governing Claude Code Workflows — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ hooks into every Edit, Write, and MultiEdit Claude Code attempts — intercepting architectural violations before they reach your codebase. Zero setup." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ + GitHub Copilot &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="GitHub Copilot generates code in VS Code and JetBrains. Mneme HQ is the architectural constraint layer above it — a structured decision corpus for AI tools." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ + Cursor — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that .cursorrules files lack." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance in GitHub Actions — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Run Mneme HQ's checks in your CI pipeline. Block pull requests that violate architectural decisions before they merge — direct enforcement after generation." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance in GitLab CI &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Run Mneme HQ's checks in your GitLab CI pipeline. Block merge requests that violate architectural decisions before they merge — enforcement after generation." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Integrations &mdash; Claude Code, Cursor, GitHub Actions &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ fits into your existing AI coding stack. Native integration with Claude Code, Cursor, and GitHub Actions — one authoritative corpus, multiple surfaces." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Mneme HQ fits into your existing AI coding stack. Native integration with Claude Code, Cursor, and GitHub Actions — one authoritative corpus, multiple surfaces." />
   <meta name="twitter:image" content="https://mnemehq.com/integrations/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ + JetBrains IDEs &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ's decision corpus is the constraint layer for JetBrains AI Assistant across IntelliJ, PyCharm, and WebStorm — enforced via mneme check in CI." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Perplexity helps teams understand why. Mneme helps teams preserve what must remain true. Research-to-enforcement workflow for architectural decision-making." />
   <meta name="twitter:image" content="https://mnemehq.com/integrations/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Perplexity &amp; Mneme HQ &mdash; Research Rationale Meets Architectural Enforcement</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Perplexity helps teams understand why. Mneme helps teams preserve what must remain true. Research-to-enforcement workflow for architectural decision-making." />
   <meta name="robots" content="index, follow" />

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -27,6 +27,9 @@
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ + VS Code &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="VS Code is the host for Claude Code and Copilot. Mneme HQ's PreToolUse hooks govern every Edit, Write, and MultiEdit in Claude Code sessions automatically." />
   <meta name="robots" content="index, follow" />

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Request a Mneme Pilot | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Request a Mneme pilot. Mneme is working with engineering teams using AI coding tools who need deterministic architectural governance across repositories, ADRs, and agent workflows." />
   <meta name="robots" content="index, follow" />

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Request a Mneme pilot. Mneme is working with engineering teams using AI coding tools who need deterministic architectural governance." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
@@ -626,6 +629,8 @@
       if (res.ok) {
         form.style.display = 'none';
         success.style.display = 'block';
+        window.gtag = window.gtag || function(){(window.dataLayer = window.dataLayer||[]).push(arguments);};
+        window.gtag('event', 'pilot_form_submitted');
       } else {
         return res.json().then(function(data){
           throw new Error(data.error || 'error');

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -22,6 +22,9 @@
   <meta name="twitter:title" content="Mneme HQ on Enterprise Developer Platforms" />
   <meta name="twitter:description" content="Governance for AI coding agents running inside Azure & GitHub Enterprise, AWS, Google Cloud, and self-hosted environments." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mneme HQ on Enterprise Developer Platforms &mdash; Azure, AWS, Google Cloud, Self-Hosted</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ runs inside the enterprise developer platforms engineering organizations already use — Microsoft Azure & GitHub Enterprise, AWS, Google Cloud, and self-hosted environments. Governance for AI coding agents in CI/CD, runtime, and IDE surfaces." />
   <meta name="robots" content="index, follow" />

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Privacy policy for Mneme HQ — architectural governance for AI-assisted development. We collect minimal data and never sell it." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Privacy policy for Mneme HQ — architectural governance for AI-assisted development. We collect minimal data and never sell it." />
   <meta name="robots" content="index, follow" />

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Mneme HQ is evolving from local governance tooling into the governance infrastructure layer for AI-assisted software development." />
   <meta name="twitter:image" content="https://mnemehq.com/roadmap/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Roadmap &mdash; Mneme HQ Governance Layer for AI Coding</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ is evolving from local governance tooling into the governance infrastructure layer for AI-assisted software development. See our strategic direction." />
   <meta name="robots" content="index, follow" />

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="The emerging standards for AI agent governance — NIST CAISI, the Model Context Protocol, AGENTS.md — and how Mneme HQ aligns with them." />
   <meta name="twitter:image" content="https://mnemehq.com/standards/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Standards Landscape — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="The emerging standards for AI agent governance — NIST CAISI, the Model Context Protocol, AGENTS.md — and how Mneme HQ aligns with them. Verified, organizational sources only." />
   <meta name="robots" content="index, follow" />

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -21,6 +21,9 @@
   <meta name="twitter:title" content="Architectural Governance for AI-Assisted Development &mdash; Mneme HQ" />
   <meta name="twitter:description" content="Governance for AI-assisted Python, TypeScript, JavaScript, Go, Java, C#, and Rust development." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance for AI-Assisted Development &mdash; By Language &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ provides architectural governance for AI-assisted development across Python, TypeScript, JavaScript, Go, Java, C#, and Rust. Language-agnostic by design; deepest coverage where teams are shipping AI code today." />
   <meta name="robots" content="index, follow" />

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance for AI-Assisted JavaScript Development &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ provides architectural governance for AI-assisted JavaScript development. Node.js services, legacy React/Vue codebases, and Express APIs under Claude Code, Cursor, and Copilot." />
   <meta name="robots" content="index, follow" />

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -21,6 +21,9 @@
   <meta name="twitter:title" content="Architectural Governance for AI-Assisted JavaScript Development" />
   <meta name="twitter:description" content="Node.js services and legacy frontends under AI-assisted development." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -21,6 +21,9 @@
   <meta name="twitter:title" content="Architectural Governance for AI-Assisted Python Development" />
   <meta name="twitter:description" content="Native CLI, benchmark coverage, hook integration, and CI gating for Python." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance for AI-Assisted Python Development &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ provides architectural governance for AI-assisted Python development. Native CLI, benchmark coverage, Claude Code hook integration, and CI gating for FastAPI, Django, and AI/ML pipelines." />
   <meta name="robots" content="index, follow" />

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -21,6 +21,9 @@
   <meta name="twitter:title" content="Architectural Governance for AI-Assisted TypeScript Development" />
   <meta name="twitter:description" content="React, Next.js, and Node.js patterns enforced at the file-write seam." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architectural Governance for AI-Assisted TypeScript Development &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ provides architectural governance for AI-assisted TypeScript development. React, Next.js, and Node.js patterns enforced at the file-write seam — without an AST-aware engine." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Coding Assistant Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ enforces architectural decisions when using Cursor, Claude Code, or Copilot — preventing drift, repeated violations, and wasted review cycles." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Enforce architectural decisions for Cursor, Claude Code, and Copilot. Mneme HQ flags violations before AI-generated code reaches review." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/coding-assistant-governance/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Data Platform Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ keeps AI assistants aligned with data platform architecture — enforcing warehouse standards, naming conventions, and pipeline constraints before code is written." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -22,6 +22,9 @@
   <meta name="twitter:title" content="Data Platform Governance | Mneme HQ" />
   <meta name="twitter:description" content="Keep AI assistants aligned with warehouse standards, naming conventions, and pipeline constraints. Mneme HQ enforces data platform architecture at prompt time." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/data-platform-governance/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -22,6 +22,9 @@
   <meta name="twitter:title" content="Design System Governance | Mneme HQ" />
   <meta name="twitter:description" content="Preserve design tokens, component hierarchy rules, and accessibility requirements for AI-assisted UI development. Mneme HQ flags non-approved usage before code reaches review." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/design-system-governance/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Design System Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ preserves design system and UX decisions for AI builders — preventing LLMs from violating design tokens, component hierarchy, and accessibility rules when generating UI code." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI Governance Use Cases for Coding Agents &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="AI governance use cases for coding agents and AI-assisted development. Mneme HQ enforces architectural decisions before generation across Cursor, Claude Code, Copilot, and SDK agents." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Architectural governance use cases for AI coding workflows. Enforce ADRs, security boundaries, and engineering standards across Cursor, Claude Code, Copilot, LangGraph, and CrewAI." />
   <meta name="twitter:image" content="https://mnemehq.com/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Legacy Codebase Memory — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ preserves tribal knowledge in legacy codebases, preventing AI coding assistants from breaking fragile systems by surfacing hidden constraints at query time." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Capture undocumented constraints and tribal knowledge in a structured decision store. Mneme HQ surfaces hidden rules before AI coding assistants can violate them." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/legacy-codebase-memory/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Multi-Agent Workflow Governance — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ governs multi-step AI development workflows — ensuring every agent in a planner-coder-reviewer pipeline respects architectural rules, anti-patterns, and prior decisions." />
   <meta name="robots" content="index, follow" />

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -22,6 +22,9 @@
   <meta name="twitter:title" content="Multi-Agent Workflow Governance | Mneme HQ" />
   <meta name="twitter:description" content="A shared decision layer every agent in your pipeline can query. Mneme HQ enforces architectural rules across planner, coder, and reviewer stages of automated AI workflows." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/multi-agent-workflow-governance/og.png" />
+  <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Enforce PII handling rules, auth requirements, and secrets policies before AI-generated code reaches review. Mneme HQ is a scalable guardrail for LLM-powered development." />
   <meta name="twitter:image" content="https://mnemehq.com/use-cases/security-compliance-guardrails/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Security &amp; Compliance Guardrails — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="How Mneme HQ prevents AI coding assistants from introducing security vulnerabilities and compliance violations by enforcing security decisions at prompt time." />
   <meta name="robots" content="index, follow" />

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Works With &mdash; Models, Agents, Frameworks, Environments &mdash; Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <meta name="description" content="Mneme HQ is the governance layer that operates across heterogeneous AI coding systems. Model-agnostic, designed to support frontier, open-weight, and self-hosted models, coding agents, and agent frameworks." />
   <meta name="robots" content="index, follow" />

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -23,6 +23,9 @@
   <meta name="twitter:description" content="Governance across AI coding models and agent frameworks. Mneme is model-agnostic and designed for heterogeneous agent environments." />
   <meta name="twitter:image" content="https://mnemehq.com/works-with/og.png" />
 
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->


### PR DESCRIPTION
## What

- **Consent mode defaults** added before GTM on all 97 pages: explicitly grants `analytics_storage`, denies ad signals. The live site was sending `_eu=AAAAAAQ` (ambiguous consent bits) on every collect hit — this resolves that.
- **`pilot_form_submitted`** event fires via `gtag('event', ...)` when the Formspree form on `/pilot/` succeeds.
- **`cta_clicked`** event fires via `gtag('event', ...)` on any click to `/pilot`, `/demo`, or `.btn-primary` links on the homepage, with `cta_text`, `cta_href`, and `cta_type` properties.
- Events use `gtag('event', ...)` format so they're processed directly by the GA4 library GTM already loads — **no GTM tag/trigger wiring needed**.

## Why events weren't tracking

Two root causes found by inspecting live network traffic:

1. **GA4 collect returning 503** — every hit to `google-analytics.com/g/collect` for `G-ZZ9YG12PPX` is rejected. The consent defaults in this PR may resolve it. If 503 persists after deploy, check GA4 Admin → Data Streams and recreate the web stream.
2. **No custom event tracking in code** — only `install_command_copied` existed. Pilot form and CTA clicks had zero tracking.

## After merging

Mark `pilot_form_submitted` as a Key Event in GA4 Admin → Key Events.