### PR TITLE
site(insights): fix breadcrumb hierarchy on 20 pages; add nav.breadcrumb check

### DIFF
--- a/scripts/seo_check.py
+++ b/scripts/seo_check.py
@@ -432,6 +432,44 @@ def rule_linking_pattern(html: str, ctx: PageContext) -> RuleResult:
     return PASS, ""
 
 
+def rule_breadcrumb_html(html: str, ctx: PageContext) -> RuleResult:
+    """The visible <ol class="breadcrumb"> parent links must match the page's URL hierarchy.
+
+    For a page at /section/slug/, the parent hrefs must be exactly ["/" , "/section/"].
+    Catches stray intermediate items (e.g. /concepts/ or /architecture/ inside an
+    /insights/ article breadcrumb).
+
+    Pages that don't use the ol.breadcrumb pattern are skipped — this rule only
+    fires when the markup is present.
+    """
+    rel = ctx.rel_path
+    parts = rel.split("/")
+
+    # Home page or single-segment paths: no breadcrumb constraint
+    if len(parts) <= 1:
+        return PASS, ""
+
+    # Build the expected parent hrefs list based on depth:
+    #   section hub  (e.g. insights/index.html)         → ["/"]
+    #   sub-page     (e.g. insights/foo/index.html)      → ["/", "/section/"]
+    if len(parts) == 2:
+        expected = ["/"]
+    else:
+        section = parts[0]
+        expected = ["/", f"/{section}/"]
+
+    m = re.search(r'<ol\s+class=["\']breadcrumb["\']>(.*?)</ol>', html, flags=re.S | re.I)
+    if not m:
+        return PASS, ""  # no ol.breadcrumb present; skip
+
+    block = re.sub(r'<li[^>]*\baria-current\b[^>]*>.*?</li>', '', m.group(1), flags=re.S | re.I)
+    actual = re.findall(r'<a\b[^>]*\bhref\s*=\s*["\']([^"\']*)["\']', block, flags=re.I)
+
+    if actual != expected:
+        return FAIL, f"breadcrumb parents {actual} != expected {expected}"
+    return PASS, ""
+
+
 def rule_jsonld_breadcrumb(html: str, ctx: PageContext) -> RuleResult:
     # Skip the home page — it doesn't need a breadcrumb.
     if ctx.rel_path == "index.html":
@@ -694,6 +732,7 @@ RULES: list[tuple[str, RuleFn]] = [
     ("structure.links",     rule_internal_links),
     ("links.targets",       rule_link_targets),
     ("links.pattern",       rule_linking_pattern),
+    ("nav.breadcrumb",      rule_breadcrumb_html),
     ("jsonld.breadcrumb",   rule_jsonld_breadcrumb),
     ("jsonld.main",         rule_jsonld_main),
     ("jsonld.author",       rule_jsonld_author),

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -264,9 +264,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Agents of Chaos and the Governance Gap</li>
   </ol>
 </nav>

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -269,9 +269,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">AI Code Review Does Not Scale Linearly</li>
   </ol>
 </nav>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -276,9 +276,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">AI Coding Governance Should Be Reviewable</li>
   </ol>
 </nav>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -322,9 +322,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Architectural Governance Across Heterogeneous AI Coding Agents</li>
   </ol>
 </nav>

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -266,9 +266,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Deployment Quality Will Define the AI Era</li>
   </ol>
 </nav>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -295,9 +295,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">The Generative AI software engineering stack</li>
   </ol>
 </nav>

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -230,9 +230,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Quantifying GitHub Copilot's Impact</li>
   </ol>
 </nav>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -331,9 +331,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Memory Is Not Governance</li>
   </ol>
 </nav>

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -295,9 +295,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Mneme vs Cursor Rules</li>
   </ol>
 </nav>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -283,9 +283,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">OpenAI-compatible APIs are commoditizing models</li>
   </ol>
 </nav>

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -262,9 +262,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">OpenClaw and the Limits of Autonomous Coding</li>
   </ol>
 </nav>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -301,9 +301,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Prompt Engineering Is Not Governance</li>
   </ol>
 </nav>

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -266,9 +266,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Review Is Not Governance</li>
   </ol>
 </nav>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -291,9 +291,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Rise of agentic engineering education</li>
   </ol>
 </nav>

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -208,9 +208,7 @@
   <nav class="breadcrumb-nav" aria-label="Breadcrumb">
     <ol class="breadcrumb">
       <li><a href="/">Home</a></li>
-      <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+      <li><a href="/insights/">Insights</a></li>
       <li aria-current="page">What Is the AI SDLC?</li>
     </ol>
   </nav>

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -315,9 +315,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Why AI Architectural Governance Needs Precedence Semantics</li>
   </ol>
 </nav>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -303,9 +303,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Why Code Review Cannot Scale With AI Output</li>
   </ol>
 </nav>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -271,7 +271,6 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
     <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Why Observability Is Not Governance</li>
   </ol>

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -266,9 +266,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Why Prompt Memory Fails at Scale</li>
   </ol>
 </nav>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -301,9 +301,7 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/concepts/">Concepts</a></li>
-        <li><a href="/architecture/">Architecture</a></li>
-        <li><a href="/insights/">Insights</a></li>
+    <li><a href="/insights/">Insights</a></li>
     <li aria-current="page">Why RAG Fails for Architectural Governance</li>
   </ol>
 </nav>


### PR DESCRIPTION
## Summary

- Removes bogus `Concepts / Architecture` intermediate items from 20 insight article breadcrumbs — correct hierarchy is `Home > Insights > Title`
- One page (`why-observability-is-not-governance`) had `Concepts` only, also fixed
- Adds `rule_breadcrumb_html` to `seo_check.py` as `nav.breadcrumb` — validates visible `<ol class="breadcrumb">` parent hrefs match the page's actual URL hierarchy; deploy pre-flight will FAIL on any future regression

## Test plan
- [ ] 107 unit tests pass
- [ ] `seo_check.py --only insights --json` shows 0 `nav.breadcrumb` failures
- [ ] Visual spot-check: breadcrumb reads `Home / Insights / [title]` on any insight article

🤖 Generated with [Claude Code](https://claude.com/claude-code)