### PR TITLE
site(concepts): multi-category metadata block (phase 2)

### DIFF
--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -167,6 +167,28 @@
     .diagram-caption strong { color: var(--accent); font-weight: 500; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -505,15 +527,41 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Context persistence cannot enforce architectural invariants. Recall is not constraint.</p></a></li>
-      <li><a href="/insights/why-prompt-memory-fails-at-scale/"><div class="rel-title">Why Prompt Memory Fails at Scale</div><p class="rel-desc">Context injection has a ceiling â€” no precedence, no enforcement, no persistence across sessions.</p></a></li>
+      <li><a href="/insights/why-prompt-memory-fails-at-scale/"><div class="rel-title">Why Prompt Memory Fails at Scale</div><p class="rel-desc">Context injection has a ceiling — no precedence, no enforcement, no persistence across sessions.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Prompt files document standards but cannot deterministically enforce them across sessions and agents.</p></a></li>
       <li><a href="/insights/agents-of-chaos-and-the-governance-gap/"><div class="rel-title">Agents of Chaos and the Governance Gap</div><p class="rel-desc">AI agents acting at high throughput surface the governance layer most teams quietly skipped.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/copilot/"><div class="rel-title">GitHub Copilot</div><p class="rel-desc">Governance layer applied to Copilot-assisted generation via shared constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/architectural-drift/"><div class="rel-title">Architectural Drift Demo</div><p class="rel-desc">Before/after trace of drift accumulation and governance interception.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/architectural-drift/"><div class="rel-title">Architectural Drift</div><p class="rel-desc">The codebase-side residue of ungoverned generation — invariants quietly eroded across sessions.</p></a></li>
+      <li><a href="/concepts/multi-agent-continuity/"><div class="rel-title">Multi-Agent Continuity</div><p class="rel-desc">Decisions persist across sessions, agents, and tools so the architectural worldview survives the next run.</p></a></li>
+      <li><a href="/concepts/governance-before-generation/"><div class="rel-title">Governance Before Generation</div><p class="rel-desc">Governance posture that intercepts agent output at the point of intent rather than at the point of review.</p></a></li>
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -232,6 +232,28 @@
     .diag-arrow-active { stroke: #c8f060; stroke-width: 1.5; fill: none; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -616,15 +638,38 @@ PostgreSQL only.</span>
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/why-rag-fails-for-architectural-governance/"><div class="rel-title">Why RAG Fails for Architectural Governance</div><p class="rel-desc">Semantic retrieval finds related text. Governance requires scoped, precedence-resolved constraint records.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Prompt files document standards but cannot deterministically enforce them across sessions and agents.</p></a></li>
-      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution â€” not best-effort guessing from a model.</p></a></li>
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution — not best-effort guessing from a model.</p></a></li>
       <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates nudge output. They cannot enforce architectural invariants across sessions and agents.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/adr-import/"><div class="rel-title">ADR Import</div><p class="rel-desc">Ingests existing ADR corpora and compiles them into enforcement-ready constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/adr-compiler/"><div class="rel-title">ADR Compiler</div><p class="rel-desc">Compiles a versioned ADR corpus into machine-evaluable constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/precedence-semantics/"><div class="rel-title">Precedence Semantics</div><p class="rel-desc">Explicit resolution rules for how overlapping or superseding decisions combine into a single verdict.</p></a></li>
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -224,6 +224,28 @@
     .diag-arrow-active { stroke: #c8f060; stroke-width: 1.5; fill: none; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -527,17 +549,52 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">Agent infrastructure is separating into layers. Architectural governance is the layer that constrains what agents are allowed to do.</p></a></li>
-      <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Harnesses help agents act. Governance ensures they act within architectural boundaries &mdash; the missing layer above orchestration.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/review-is-not-governance/"><div class="rel-title">Review Is Not Governance</div><p class="rel-desc">Human review systems do not scale linearly with AI output velocity. Review samples; governance shapes.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
       <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Context persistence cannot enforce architectural invariants. Recall is not constraint.</p></a></li>
       <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/"><div class="rel-title">Why Code Review Cannot Scale With AI Output</div><p class="rel-desc">Review is linear with team size. AI generation isn't. The bottleneck moves upstream of the review queue.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/copilot/"><div class="rel-title">GitHub Copilot</div><p class="rel-desc">Governance layer applied to Copilot-assisted generation via shared constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/demo/repository-pattern/"><div class="rel-title">Repository Pattern</div><p class="rel-desc">Pattern-level architectural constraint enforced at the point of agent generation.</p></a></li>
+      <li><a href="/demo/storage-decision/"><div class="rel-title">Storage Decision</div><p class="rel-desc">ADR-sourced storage constraint enforced deterministically across two competing agent proposals.</p></a></li>
+      <li><a href="/demo/dependency-policy/"><div class="rel-title">Dependency Policy</div><p class="rel-desc">Dependency policy decision compiled from ADR and enforced before a package is imported.</p></a></li>
+      <li><a href="/demo/governed-python-agent/"><div class="rel-title">Governed Python Agent</div><p class="rel-desc">Live enforcement of storage and dependency decisions by a Claude-powered agent.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/governance-before-generation/"><div class="rel-title">Governance Before Generation</div><p class="rel-desc">Governance posture that intercepts agent output at the point of intent rather than at the point of review.</p></a></li>
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      <li><a href="/concepts/architectural-drift/"><div class="rel-title">Architectural Drift</div><p class="rel-desc">The codebase-side residue of ungoverned generation — invariants quietly eroded across sessions.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -227,6 +227,28 @@
     .diag-arrow-active { stroke: #c8f060; stroke-width: 1.5; fill: none; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -563,15 +585,49 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
-      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution â€” not best-effort guessing from a model.</p></a></li>
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution — not best-effort guessing from a model.</p></a></li>
       <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates nudge output. They cannot enforce architectural invariants across sessions and agents.</p></a></li>
       <li><a href="/insights/why-rag-fails-for-architectural-governance/"><div class="rel-title">Why RAG Fails for Architectural Governance</div><p class="rel-desc">Semantic retrieval finds related text. Governance requires scoped, precedence-resolved constraint records.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/gitlab/"><div class="rel-title">GitLab</div><p class="rel-desc">Pipeline-stage governance enforcement on merge requests.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/repository-pattern/"><div class="rel-title">Repository Pattern</div><p class="rel-desc">Pattern-level architectural constraint enforced at the point of agent generation.</p></a></li>
+      <li><a href="/demo/storage-decision/"><div class="rel-title">Storage Decision</div><p class="rel-desc">ADR-sourced storage constraint enforced deterministically across two competing agent proposals.</p></a></li>
+      <li><a href="/demo/dependency-policy/"><div class="rel-title">Dependency Policy</div><p class="rel-desc">Dependency policy decision compiled from ADR and enforced before a package is imported.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/precedence-semantics/"><div class="rel-title">Precedence Semantics</div><p class="rel-desc">Explicit resolution rules for how overlapping or superseding decisions combine into a single verdict.</p></a></li>
+      <li><a href="/concepts/governance-before-generation/"><div class="rel-title">Governance Before Generation</div><p class="rel-desc">Governance posture that intercepts agent output at the point of intent rather than at the point of review.</p></a></li>
+      <li><a href="/concepts/enforcement-provenance/"><div class="rel-title">Enforcement Provenance</div><p class="rel-desc">Every governance verdict is traceable back through the precedence chain to the originating decision record.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -159,6 +159,28 @@
     .diagram-caption strong { color: var(--accent); font-weight: 500; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -438,15 +460,47 @@
 
   </div>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable â€” or engineer trust collapses.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable — or engineer trust collapses.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
-      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution â€” not best-effort guessing from a model.</p></a></li>
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution — not best-effort guessing from a model.</p></a></li>
       <li><a href="/insights/review-is-not-governance/"><div class="rel-title">Review Is Not Governance</div><p class="rel-desc">Human review systems do not scale linearly with AI output velocity. Review samples; governance shapes.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/gitlab/"><div class="rel-title">GitLab</div><p class="rel-desc">Pipeline-stage governance enforcement on merge requests.</p></a></li>
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/multi-agent-governance/"><div class="rel-title">Multi-Agent Governance</div><p class="rel-desc">Governance constraints propagate identically across Claude, Cursor, and CI in a single workflow.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/precedence-semantics/"><div class="rel-title">Precedence Semantics</div><p class="rel-desc">Explicit resolution rules for how overlapping or superseding decisions combine into a single verdict.</p></a></li>
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -227,6 +227,28 @@
     .diag-bad { fill: #e87c7c; font-family: 'DM Mono', monospace; font-size: 10px; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -571,16 +593,53 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Governance has to sit in front of the action it constrains. Pre-generation enforcement is what makes that possible across an agent loop.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/review-is-not-governance/"><div class="rel-title">Review Is Not Governance</div><p class="rel-desc">Human review systems do not scale linearly with AI output velocity. Review samples; governance shapes.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
       <li><a href="/insights/ai-code-review-does-not-scale-linearly/"><div class="rel-title">AI Code Review Does Not Scale Linearly</div><p class="rel-desc">Adding reviewers cannot keep pace with agent-paced generation rates. The math is structural.</p></a></li>
       <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates nudge output. They cannot enforce architectural invariants across sessions and agents.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/claude-agent-sdk/"><div class="rel-title">Claude Agent SDK</div><p class="rel-desc">Tool-call interception enforces decisions inside multi-agent SDK workflows.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/demo/governed-python-agent/"><div class="rel-title">Governed Python Agent</div><p class="rel-desc">Live enforcement of storage and dependency decisions by a Claude-powered agent.</p></a></li>
+      <li><a href="/demo/repository-pattern/"><div class="rel-title">Repository Pattern</div><p class="rel-desc">Pattern-level architectural constraint enforced at the point of agent generation.</p></a></li>
+      <li><a href="/demo/storage-decision/"><div class="rel-title">Storage Decision</div><p class="rel-desc">ADR-sourced storage constraint enforced deterministically across two competing agent proposals.</p></a></li>
+      <li><a href="/demo/dependency-policy/"><div class="rel-title">Dependency Policy</div><p class="rel-desc">Dependency policy decision compiled from ADR and enforced before a package is imported.</p></a></li>
+      <li><a href="/demo/agent-sdk-governance/"><div class="rel-title">Claude Agent SDK Governance</div><p class="rel-desc">Governance before generation wired into the Claude Agent SDK tool-call layer.</p></a></li>
+      <li><a href="/demo/architectural-drift/"><div class="rel-title">Architectural Drift Demo</div><p class="rel-desc">Before/after trace of drift accumulation and governance interception.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/architectural-governance/"><div class="rel-title">Architectural Governance</div><p class="rel-desc">The discipline of constraining what AI agents are allowed to do, not just observing what they did.</p></a></li>
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      <li><a href="/concepts/enforcement-provenance/"><div class="rel-title">Enforcement Provenance</div><p class="rel-desc">Every governance verdict is traceable back through the precedence chain to the originating decision record.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -235,6 +235,28 @@
     .diag-arrow-active { stroke: #c8f060; stroke-width: 1.5; fill: none; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -689,17 +711,54 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">The eight-layer category map &mdash; models, tools, orchestration, memory, observability, governance, provenance, verification &mdash; and where governance fits.</p></a></li>
-      <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Harnesses coordinate execution. Governance enforces architectural intent. They are different layers of the agent stack.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
       <li><a href="/insights/review-is-not-governance/"><div class="rel-title">Review Is Not Governance</div><p class="rel-desc">Human review systems do not scale linearly with AI output velocity. Review samples; governance shapes.</p></a></li>
       <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Context persistence cannot enforce architectural invariants. Recall is not constraint.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Prompt files document standards but cannot deterministically enforce them across sessions and agents.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/claude-agent-sdk/"><div class="rel-title">Claude Agent SDK</div><p class="rel-desc">Tool-call interception enforces decisions inside multi-agent SDK workflows.</p></a></li>
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/gitlab/"><div class="rel-title">GitLab</div><p class="rel-desc">Pipeline-stage governance enforcement on merge requests.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/copilot/"><div class="rel-title">GitHub Copilot</div><p class="rel-desc">Governance layer applied to Copilot-assisted generation via shared constraint records.</p></a></li>
+      <li><a href="/integrations/jetbrains/"><div class="rel-title">JetBrains AI Assistant</div><p class="rel-desc">IDE-level enforcement surface for JetBrains AI Assistant workflows.</p></a></li>
+      <li><a href="/integrations/vscode/"><div class="rel-title">VS Code</div><p class="rel-desc">Governance constraints surfaced inside VS Code via the Mneme extension.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/adr-compiler/"><div class="rel-title">ADR Compiler</div><p class="rel-desc">Compiles a versioned ADR corpus into machine-evaluable constraint records.</p></a></li>
+      <li><a href="/demo/multi-agent-governance/"><div class="rel-title">Multi-Agent Governance</div><p class="rel-desc">Governance constraints propagate identically across Claude, Cursor, and CI in a single workflow.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/architectural-governance/"><div class="rel-title">Architectural Governance</div><p class="rel-desc">The discipline of constraining what AI agents are allowed to do, not just observing what they did.</p></a></li>
+      <li><a href="/concepts/governance-propagation/"><div class="rel-title">Governance Propagation</div><p class="rel-desc">Identical compiled constraints fan out to every agent, IDE, hook, and CI surface — one decision, one verdict, everywhere.</p></a></li>
+      <li><a href="/concepts/enforcement-provenance/"><div class="rel-title">Enforcement Provenance</div><p class="rel-desc">Every governance verdict is traceable back through the precedence chain to the originating decision record.</p></a></li>
+      <li><a href="/concepts/multi-agent-continuity/"><div class="rel-title">Multi-Agent Continuity</div><p class="rel-desc">Decisions persist across sessions, agents, and tools so the architectural worldview survives the next run.</p></a></li>
+      <li><a href="/concepts/architectural-compiler/"><div class="rel-title">Architectural Compiler</div><p class="rel-desc">Compiles a versioned decision corpus into deterministic constraint records the enforcement layer can evaluate.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -162,6 +162,28 @@
     .diagram-caption strong { color: var(--accent); font-weight: 500; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -432,16 +454,45 @@
 
   </div>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Branch names, PR titles, CI config, deployment artifacts &mdash; governance must propagate across every surface the agent writes to, not just source code.</p></a></li>
-      <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">Claude, Cursor, Copilot â€” each has its own surface. Governance must be portable across all of them.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">Claude, Cursor, Copilot — each has its own surface. Governance must be portable across all of them.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Prompt files document standards but cannot deterministically enforce them across sessions and agents.</p></a></li>
       <li><a href="/insights/mneme-vs-cursor-rules/"><div class="rel-title">Mneme vs Cursor Rules</div><p class="rel-desc">Cursor rules are per-tool prompt files. A governance corpus is a multi-tool decision substrate.</p></a></li>
       <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Context persistence cannot enforce architectural invariants. Recall is not constraint.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/copilot/"><div class="rel-title">GitHub Copilot</div><p class="rel-desc">Governance layer applied to Copilot-assisted generation via shared constraint records.</p></a></li>
+      <li><a href="/integrations/jetbrains/"><div class="rel-title">JetBrains AI Assistant</div><p class="rel-desc">IDE-level enforcement surface for JetBrains AI Assistant workflows.</p></a></li>
+      <li><a href="/integrations/vscode/"><div class="rel-title">VS Code</div><p class="rel-desc">Governance constraints surfaced inside VS Code via the Mneme extension.</p></a></li>
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/gitlab/"><div class="rel-title">GitLab</div><p class="rel-desc">Pipeline-stage governance enforcement on merge requests.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/multi-agent-governance/"><div class="rel-title">Multi-Agent Governance</div><p class="rel-desc">Governance constraints propagate identically across Claude, Cursor, and CI in a single workflow.</p></a></li>
+      <li><a href="/demo/agent-sdk-governance/"><div class="rel-title">Claude Agent SDK Governance</div><p class="rel-desc">Governance before generation wired into the Claude Agent SDK tool-call layer.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      <li><a href="/concepts/multi-agent-continuity/"><div class="rel-title">Multi-Agent Continuity</div><p class="rel-desc">Decisions persist across sessions, agents, and tools so the architectural worldview survives the next run.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -159,6 +159,28 @@
     .diagram-caption strong { color: var(--accent); font-weight: 500; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -438,15 +460,43 @@
 
   </div>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">Claude, Cursor, Copilot â€” each has its own surface. Governance must be portable across all of them.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">Claude, Cursor, Copilot — each has its own surface. Governance must be portable across all of them.</p></a></li>
       <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Context persistence cannot enforce architectural invariants. Recall is not constraint.</p></a></li>
-      <li><a href="/insights/why-prompt-memory-fails-at-scale/"><div class="rel-title">Why Prompt Memory Fails at Scale</div><p class="rel-desc">Context injection has a ceiling â€” no precedence, no enforcement, no persistence across sessions.</p></a></li>
+      <li><a href="/insights/why-prompt-memory-fails-at-scale/"><div class="rel-title">Why Prompt Memory Fails at Scale</div><p class="rel-desc">Context injection has a ceiling — no precedence, no enforcement, no persistence across sessions.</p></a></li>
       <li><a href="/insights/long-running-agents-need-governance/"><div class="rel-title">Long-Running Agents Need Governance</div><p class="rel-desc">Persistent agents accumulate drift faster than they refresh context. Governance is the substrate they read from.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      <li><a href="/integrations/claude-agent-sdk/"><div class="rel-title">Claude Agent SDK</div><p class="rel-desc">Tool-call interception enforces decisions inside multi-agent SDK workflows.</p></a></li>
+      <li><a href="/integrations/cursor/"><div class="rel-title">Cursor</div><p class="rel-desc">CLAUDE.md-equivalent governance surface for Cursor-based development.</p></a></li>
+      <li><a href="/integrations/copilot/"><div class="rel-title">GitHub Copilot</div><p class="rel-desc">Governance layer applied to Copilot-assisted generation via shared constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/multi-agent-governance/"><div class="rel-title">Multi-Agent Governance</div><p class="rel-desc">Governance constraints propagate identically across Claude, Cursor, and CI in a single workflow.</p></a></li>
+      <li><a href="/demo/agent-sdk-governance/"><div class="rel-title">Claude Agent SDK Governance</div><p class="rel-desc">Governance before generation wired into the Claude Agent SDK tool-call layer.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/governance-propagation/"><div class="rel-title">Governance Propagation</div><p class="rel-desc">Identical compiled constraints fan out to every agent, IDE, hook, and CI surface — one decision, one verdict, everywhere.</p></a></li>
+      <li><a href="/concepts/decision-continuity/"><div class="rel-title">Decision Continuity</div><p class="rel-desc">Decisions and their constraints survive intact across sessions, agents, and code changes.</p></a></li>
+      <li><a href="/concepts/ai-agent-drift/"><div class="rel-title">AI Agent Drift</div><p class="rel-desc">Agents diverge from architectural intent as soon as a run begins; drift compounds session by session without an enforcement substrate.</p></a></li>
+      <li><a href="/concepts/governance-infrastructure/"><div class="rel-title">Governance Infrastructure</div><p class="rel-desc">The engineering platform layer that encodes, distributes, versions, and enforces architectural decisions across agents and CI.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -160,6 +160,28 @@
     .diagram-caption strong { color: var(--accent); font-weight: 500; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -418,15 +440,39 @@
 
   </div>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution â€” not best-effort guessing from a model.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution — not best-effort guessing from a model.</p></a></li>
       <li><a href="/insights/why-rag-fails-for-architectural-governance/"><div class="rel-title">Why RAG Fails for Architectural Governance</div><p class="rel-desc">Semantic retrieval finds related text. Governance requires scoped, precedence-resolved constraint records.</p></a></li>
-      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable â€” or engineer trust collapses.</p></a></li>
+      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable — or engineer trust collapses.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Prompt files document standards but cannot deterministically enforce them across sessions and agents.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/adr-import/"><div class="rel-title">ADR Import</div><p class="rel-desc">Ingests existing ADR corpora and compiles them into enforcement-ready constraint records.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/demo/adr-compiler/"><div class="rel-title">ADR Compiler</div><p class="rel-desc">Compiles a versioned ADR corpus into machine-evaluable constraint records.</p></a></li>
+      <li><a href="/demo/storage-decision/"><div class="rel-title">Storage Decision</div><p class="rel-desc">ADR-sourced storage constraint enforced deterministically across two competing agent proposals.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/concepts/architectural-compiler/"><div class="rel-title">Architectural Compiler</div><p class="rel-desc">Compiles a versioned decision corpus into deterministic constraint records the enforcement layer can evaluate.</p></a></li>
+      <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Pre-registered, machine-evaluable claims a generated artifact must satisfy before it is allowed to land.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -226,6 +226,28 @@
     .diag-arrow-active { stroke: #c8f060; stroke-width: 1.5; fill: none; }
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+  
+    /* Phase 2 — multi-category metadata block; mirrors .related-panel card styling onto .concept-metadata-list
+       so .rel-title / .rel-desc carry the same treatment when used here. */
+    .concept-metadata { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .concept-metadata-group { margin-bottom: 2rem; }
+    .concept-metadata-group:last-child { margin-bottom: 0; }
+    .concept-metadata-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .concept-metadata-label.tint-accent { color: var(--accent); }
+    .concept-metadata-label.tint-teal { color: var(--teal); }
+    .concept-metadata-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .concept-metadata-list.is-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; }
+    .concept-metadata-list li { margin: 0; }
+    .concept-metadata-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .concept-metadata-list a:hover { background: var(--surface2); }
+    .concept-metadata-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .concept-metadata-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .concept-metadata-list a:hover .rel-title { color: var(--accent); }
+    .concept-metadata-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .concept-metadata-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+    @media (max-width: 640px) {
+      .concept-metadata-list.is-grid { grid-template-columns: 1fr; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -559,16 +581,50 @@
     </details>
   </section>
 
-  <aside class="related-panel" aria-labelledby="related-panel-label">
-    <div class="related-panel-label" id="related-panel-label">Related operational essays</div>
-    <ul class="related-list">
-      <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Harnesses coordinate execution. Verification contracts are how governance becomes enforceable instead of advisory.</p></a></li>
-      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable â€” or engineer trust collapses.</p></a></li>
+  <aside class="concept-metadata" aria-label="Concept metadata">
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-accent">Operational implications</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">Governance verdicts must be inspectable, citable, and disagreeable — or engineer trust collapses.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
-      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution â€” not best-effort guessing from a model.</p></a></li>
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When ADRs overlap, the system needs deterministic resolution — not best-effort guessing from a model.</p></a></li>
       <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates nudge output. They cannot enforce architectural invariants across sessions and agents.</p></a></li>
-    </ul>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Enforcement surfaces</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/integrations/github-actions/"><div class="rel-title">GitHub Actions</div><p class="rel-desc">CI enforcement gate: every PR is checked against the compiled constraint set.</p></a></li>
+      <li><a href="/integrations/gitlab/"><div class="rel-title">GitLab</div><p class="rel-desc">Pipeline-stage governance enforcement on merge requests.</p></a></li>
+      <li><a href="/integrations/claude-code/"><div class="rel-title">Claude Code</div><p class="rel-desc">PreToolUse hook enforces governance constraints before every file write.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related demos</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/demo/repository-pattern/"><div class="rel-title">Repository Pattern</div><p class="rel-desc">Pattern-level architectural constraint enforced at the point of agent generation.</p></a></li>
+      <li><a href="/demo/storage-decision/"><div class="rel-title">Storage Decision</div><p class="rel-desc">ADR-sourced storage constraint enforced deterministically across two competing agent proposals.</p></a></li>
+      <li><a href="/demo/dependency-policy/"><div class="rel-title">Dependency Policy</div><p class="rel-desc">Dependency policy decision compiled from ADR and enforced before a package is imported.</p></a></li>
+      <li><a href="/demo/governed-python-agent/"><div class="rel-title">Governed Python Agent</div><p class="rel-desc">Live enforcement of storage and dependency decisions by a Claude-powered agent.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label tint-teal">Related benchmarks</div>
+      <ul class="concept-metadata-list">
+      <li><a href="/benchmark/"><div class="rel-title">Benchmark</div><p class="rel-desc">Empirical reproducibility measurements across governance scenarios — same input, same verdict.</p></a></li>
+      </ul>
+    </div>
+    <div class="concept-metadata-group">
+      <div class="concept-metadata-label">Related concepts</div>
+      <ul class="concept-metadata-list is-grid">
+      <li><a href="/concepts/enforcement-provenance/"><div class="rel-title">Enforcement Provenance</div><p class="rel-desc">Every governance verdict is traceable back through the precedence chain to the originating decision record.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic Enforcement</div><p class="rel-desc">Same input, same verdict — every time. Governance verdicts are reproducible, not probabilistic.</p></a></li>
+      <li><a href="/concepts/precedence-semantics/"><div class="rel-title">Precedence Semantics</div><p class="rel-desc">Explicit resolution rules for how overlapping or superseding decisions combine into a single verdict.</p></a></li>
+      <li><a href="/concepts/architectural-compiler/"><div class="rel-title">Architectural Compiler</div><p class="rel-desc">Compiles a versioned decision corpus into deterministic constraint records the enforcement layer can evaluate.</p></a></li>
+      </ul>
+    </div>
   </aside>
+
 
   <footer class="article-footer">
     <a href="/concepts/" class="back-link">â† Back to Concepts</a>


### PR DESCRIPTION
## Summary

Phase 2 of the Mneme HQ knowledge-graph roadmap. Replaces the single `.related-panel` block on 11 in-scope concept pages with a 5-category `.concept-metadata` block sourced from the canonical adjacency table (`concepts-graph.json`). Closes ~80% of the 155 missing graph edges Phase 1 identified.

- 5 categories per page: **Operational implications** (insights), **Enforcement surfaces** (integrations), **Related demos**, **Related benchmarks**, **Related concepts**.
- Empty-category rule: a category that has zero entries does not render — no empty headers.
- Card shape (`rel-title` + `rel-desc` + accent-arrow) inherits the existing `.related-panel` contract per ADR-011 §3.
- Visual treatment per ADR-011 §4: operational implications tinted `--accent` (lime); enforcement / demos / benchmarks tinted `--teal`; related concepts kept `--muted`.
- 2-col grid fires at ≥4 items per category; mobile collapses to single column at 640px.
- Descriptions for insights / concepts were harvested from existing `.related-panel` blocks (one canonical phrasing per slug) so vocabulary stays stable. Descriptions for demos, integrations, and benchmark are fresh per the Phase 2 plan and frame the *relationship* (ADR-012 §6), not the destination's definition.

## Authority-score delta

| Concept | Pre-Phase-2 | Post-Phase-2 | Δ |
|---|---:|---:|---:|
| governance-infrastructure | 27 | 46 | +19 |
| enforcement-provenance | 13 | 28 | +15 |
| verification-contracts | 22 | 37 | +15 |
| deterministic-enforcement | 21 | 35 | +14 |
| precedence-semantics | 10 | 22 | +12 |
| architectural-compiler | 6 | 16 | +10 |
| architectural-governance | 27 | 36 | +9 |
| multi-agent-continuity | 11 | 19 | +8 |
| governance-before-generation | 31 | 38 | +7 |
| governance-propagation | 9 | 16 | +7 |
| ai-agent-drift | 6 | 8 | +2 |
| **Total Δ (in-scope)** | | | **+118** |

Top-5 authority ranking after Phase 2:

1. governance-infrastructure — 46
2. governance-before-generation — 38
3. verification-contracts — 37
4. architectural-governance — 36
5. deterministic-enforcement — 35

(Same five concepts as the pre-Phase-2 ranking, in a slightly reshuffled order — flagship set remains stable.)

## Test plan

- [x] `python scripts/seo_check.py --only concepts` — 0 fails, 4 warnings (all pre-existing on `intent-debt` and `precedence-semantics`; byte-identical to baseline).
- [x] HTML balance check on all 20 `site/concepts/**/index.html` files: 0 unbalanced tags.
- [x] Idempotent generator — re-running the one-shot script on patched pages yields 11 SKIP, 0 OK, 0 ERROR.
- [x] Empty-category rule verified — pages with no related_benchmarks render 4 groups, not 5 (e.g. `architectural-compiler`, `ai-agent-drift`, `multi-agent-continuity`).
- [x] `python scripts/graph_metrics.py --format summary` — authority scores rise on all 11 in-scope concepts (+2 to +19 each, +118 total).
- [x] Visual review on 3 designated pages × desktop + 375px mobile (`governance-infrastructure` / `verification-contracts` / `multi-agent-continuity`):
   - Category labels DM Mono caps, 0.68rem, 0.1em letter-spacing
   - Tint colors: lime on operational-implications, teal on enforcement / demos / benchmarks, muted on related-concepts
   - 2-col grid fires at ≥4 items; ≤3 items render single-column
   - Mobile (375 × 812) collapses all grids to single column
   - Accent-arrow ::after pseudo renders ("→", `--accent`, opacity 0.4) on every card
   - Card text styled correctly (`.rel-title` 14.72px / weight 600 / `--text`; `.rel-desc` 13.12px / line-height 1.65 / `--muted`)
- [x] Block sits below FAQ section and above `<footer class="article-footer">` on every patched page.

## Out of scope (intentional)

- `intent-debt` and the 4 adjacent concepts (`ai-native-sdlc`, `architectural-drift`, `decision-continuity`, `agentic-development`) — Phase 6.
- Canonical visual primitives — Phase 3.
- Flagship-essay expansion — Phase 4.
- Resolving the two ADR-011 / two ADR-010 file collisions — separate PR.
- Touching `.mneme/project_memory.json` — requires explicit `[memory]` task.
- Reverse wiring on `/integrations/`, `/use-cases/`, `/works-with/` — Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)