### PR TITLE
site: add video walkthrough sections to demo pages

### DIFF
--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -441,6 +441,18 @@ Result: WARN</code></pre>
 
         <p>The drift demo shows the failure mode. The multi-agent demo shows where governance has to scale to. The compiler is the artifact that makes both of them tractable &mdash; <strong>it is the step that turns existing architectural documentation into the executable substrate the other demos rely on.</strong> Without a compiler, governance stays advisory. With one, it becomes infrastructure. The product experience that demonstrates this end-to-end is the <a href="/demo/governed-python-agent/">Governed Python agent demo</a>.</p>
 
+      <h2>Video walkthrough</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? Watch the full ADR compiler walkthrough — ADRs compiled into executable constraints, end-to-end.</p>
+      <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/lMkq-RoKeD4"
+          title="ADRs Don't Govern AI Agents. Compilers Do."
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
+      </div>
+
     <aside class="related-panel" aria-labelledby="related-panel-label">
     <div class="related-panel-label" id="related-panel-label">Related governance concepts</div>
     <ul class="related-list">

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -547,6 +547,18 @@ python run.py</code></pre>
 
       <p>The drift demo is what happens when those three artifacts are missing. The convergent timeline is what happens when they are wired up.</p>
 
+      <h2>Video walkthrough</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? Watch drift compound across agents — and the governance layer that stops it.</p>
+      <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/xkXJqSnXBJ8"
+          title="AI Agents Break Architecture at Speed. Mneme Catches the Drift."
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
+      </div>
+
   <aside class="related-panel" aria-labelledby="related-panel-label">
     <div class="related-panel-label" id="related-panel-label">Related governance concepts</div>
     <ul class="related-list">

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -383,6 +383,18 @@
       </details>
     </div>
 
+      <h2>Video walkthrough</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? Watch dependency policy enforcement in action — project memory as enforcement policy.</p>
+      <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/pBJSpN8d9FU"
+          title="Project Memory Is Not Just Context. It Is Enforcement."
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
+      </div>
+
     <div class="scenario-cta">
       <a href="/demo/storage-decision/">&larr; Previous &middot; Storage decision (PASS)</a>
       <a href="/demo/repository-pattern/" class="next">Next &middot; Repository pattern (FAIL) &rarr;</a>

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -386,6 +386,7 @@
       <h2>Video walkthrough</h2>
       <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? Watch dependency policy enforcement in action — project memory as enforcement policy.</p>
       <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <!-- pBJSpN8d9FU assigned here by topic inference — recheck after watching the video; move to a different demo page if content doesn't match dependency-policy scenario -->
         <iframe
           src="https://www.youtube-nocookie.com/embed/pBJSpN8d9FU"
           title="Project Memory Is Not Just Context. It Is Enforcement."

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -324,6 +324,18 @@ Result: WARN</code></pre>
 
       <p>The walkthrough runs the ADR compiler, applies decisions to a fresh memory file, then enforces against a namespace violation so ADR-005 fires on the wrong import path.</p>
 
+      <h2>Video walkthrough</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? The animation above covers the mechanism; the walkthrough below narrates the full scenario end-to-end.</p>
+      <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/4Yg43V9amao"
+          title="An AI Agent Writes Python Code. Mneme Keeps It Governed."
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
+      </div>
+
   <aside class="related-panel" aria-labelledby="related-panel-label">
     <div class="related-panel-label" id="related-panel-label">Related governance concepts</div>
     <ul class="related-list">

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -517,8 +517,25 @@
       <p style="margin-top:1.25rem;margin-bottom:0;font-size:0.82rem;color:var(--muted);">Want help wiring it up? <a href="/pilot/" style="color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.3);">Request a pilot</a> &mdash; we'll compile your ADRs and walk the enforcement trace on your own repo.</p>
     </div>
 
-    <!-- â”€â”€â”€â”€â”€ FAQ â”€â”€â”€â”€â”€ -->
-    <section class="section" id="faq" style="margin-top: 5rem;">
+    <!-- ───── DEMO VIDEOS ───── -->
+    <section class=”section” id=”videos” style=”margin-top: 5rem;”>
+      <div class=”section-header”>
+        <span class=”section-num”>Videos</span>
+        <h2>Watch the walkthroughs</h2>
+      </div>
+      <p class=”section-lede”>Prefer video walkthroughs? Each demo page leads with an interactive animation — the videos below narrate the same scenarios end-to-end.</p>
+      <ul style=”list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.6rem;font-size:0.9rem;”>
+        <li><a href=”https://www.youtube.com/watch?v=4Yg43V9amao” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>Governed Python Agent</a> <span style=”color:var(--muted);”>&mdash; agent proposes violating code, Mneme catches it, agent retries compliant</span></li>
+        <li><a href=”https://www.youtube.com/watch?v=lMkq-RoKeD4” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>ADR Compiler</a> <span style=”color:var(--muted);”>&mdash; ADRs compiled into an executable governance corpus</span></li>
+        <li><a href=”https://www.youtube.com/watch?v=xkXJqSnXBJ8” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>Architectural Drift</a> <span style=”color:var(--muted);”>&mdash; drift at AI speed, caught before it compounds</span></li>
+        <li><a href=”https://www.youtube.com/watch?v=LaJqeJrKkgg” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>GitHub Actions Governance</a> <span style=”color:var(--muted);”>&mdash; ADR enforcement gate in CI</span></li>
+        <li><a href=”https://www.youtube.com/watch?v=pBJSpN8d9FU” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>Dependency Policy</a> <span style=”color:var(--muted);”>&mdash; project memory as enforcement policy</span></li>
+      </ul>
+      <p style=”margin-top:1.25rem;font-size:0.82rem;color:var(--muted);”>Full playlist on the <a href=”https://www.youtube.com/@MnemeHQ” target=”_blank” rel=”noopener” style=”color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(200,240,96,0.25);”>Mneme HQ YouTube channel</a>.</p>
+    </section>
+
+    <!-- ───── FAQ ───── -->
+    <section class=”section” id=”faq” style=”margin-top: 5rem;”>
       <div class="section-header">
         <span class="section-num">FAQ</span>
         <h2>Common questions about the demo structure</h2>

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -418,6 +418,18 @@ python run.py</code></pre>
         <li>&rarr; <a href="/benchmark/">Governance Benchmark v1.1</a> &mdash; the deterministic scenario suite this enforcement is measured against.</li>
       </ul>
 
+      <h2>Video walkthrough</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.5rem;">Prefer video? Watch governance hold across multiple actors and CI — from ADR to enforcement gate.</p>
+      <div style="max-width:720px;aspect-ratio:16/9;position:relative;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:2rem;">
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/LaJqeJrKkgg"
+          title="From ADR to CI: Enforcing Architecture in GitHub Actions"
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          style="position:absolute;inset:0;width:100%;height:100%;border:0;"></iframe>
+      </div>
+
   <aside class="related-panel" aria-labelledby="related-panel-label">
     <div class="related-panel-label" id="related-panel-label">Related governance concepts</div>
     <ul class="related-list">


### PR DESCRIPTION
## Summary

- Adds **Video walkthrough** section to 5 demo pages, below the animation and "Run it yourself" block, above the related-concepts panel
- Adds compact **Watch the walkthroughs** video list to `/demo/` index, before the FAQ section
- Animations remain primary; videos are secondary proof assets with narration

## Page → video mapping

| Page | YouTube video |
|------|--------------|
| `/demo/governed-python-agent/` | `4Yg43V9amao` — An AI Agent Writes Python Code. Mneme Keeps It Governed. |
| `/demo/adr-compiler/` | `lMkq-RoKeD4` — ADRs Don't Govern AI Agents. Compilers Do. |
| `/demo/architectural-drift/` | `xkXJqSnXBJ8` — AI Agents Break Architecture at Speed. Mneme Catches the Drift. |
| `/demo/multi-agent-governance/` | `LaJqeJrKkgg` — From ADR to CI: Enforcing Architecture in GitHub Actions |
| `/demo/dependency-policy/` | `pBJSpN8d9FU` — Project Memory Is Not Just Context. It Is Enforcement. |

Videos 6 and 7 from the playlist (conceptual/educational) are not mapped to demo pages.

## Test plan

- [ ] Each demo page: scroll past animation to verify video embed renders without layout break
- [ ] `/demo/` index: verify video list appears before FAQ, links open correct YouTube videos
- [ ] Mobile: check 16/9 aspect-ratio iframe doesn't overflow at narrow viewport
- [ ] Verify `loading="lazy"` — iframes should not block page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)