### PR TITLE
site(concepts): phase 3 canonical diagram primitives

### DIFF
--- a/docs/contributing/diagram-conventions.md
+++ b/docs/contributing/diagram-conventions.md
@@ -1,18 +1,17 @@
 # Mneme HQ — Diagram Conventions
 
-Internal reference for the canonical diagram primitives used across `/concepts/`,
+Contributor reference for the canonical diagram primitives used across `/concepts/`,
 `/insights/`, `/demo/`, and `/compare/`. New diagrams must follow these
 conventions; bespoke per-page SVGs are no longer how we add visual
 infrastructure.
 
-The four canonical primitives live in `site/assets/css/diagrams.css`:
+The four canonical primitives live in `site/assets/css/diagrams.css`, each
+embedded on its canonical concept-page home:
 
-- `.mneme-diagram--propagation` — fan-out from a compiled corpus to consumers
-- `.mneme-diagram--checkpoints` — lifecycle enforcement checkpoints
-- `.mneme-diagram--chain` — backward citation chain (verdict → ADR)
-- `.mneme-diagram--cascade` — compounding drift over sessions
-
-Canonical homes are documented in the Phase 3 design doc (private repo).
+- `.mneme-diagram--propagation` — fan-out from a compiled corpus to consumers — `/concepts/governance-propagation/`
+- `.mneme-diagram--checkpoints` — lifecycle enforcement checkpoints — `/concepts/governance-before-generation/`
+- `.mneme-diagram--chain` — backward citation chain (verdict → ADR) — `/concepts/enforcement-provenance/`
+- `.mneme-diagram--cascade` — compounding drift over sessions — `/concepts/architectural-drift/`
 
 ---
 

--- a/docs/contributing/diagram-conventions.md
+++ b/docs/contributing/diagram-conventions.md
@@ -1,0 +1,141 @@
+# Mneme HQ — Diagram Conventions
+
+Internal reference for the canonical diagram primitives used across `/concepts/`,
+`/insights/`, `/demo/`, and `/compare/`. New diagrams must follow these
+conventions; bespoke per-page SVGs are no longer how we add visual
+infrastructure.
+
+The four canonical primitives live in `site/assets/css/diagrams.css`:
+
+- `.mneme-diagram--propagation` — fan-out from a compiled corpus to consumers
+- `.mneme-diagram--checkpoints` — lifecycle enforcement checkpoints
+- `.mneme-diagram--chain` — backward citation chain (verdict → ADR)
+- `.mneme-diagram--cascade` — compounding drift over sessions
+
+Canonical homes are documented in the Phase 3 design doc (private repo).
+
+---
+
+## Markup contract
+
+Every primitive uses this wrapper:
+
+```html
+<figure class="diagram-figure" aria-labelledby="X-diag-title">
+  <div class="mneme-diagram mneme-diagram--<kind>" role="img"
+       aria-labelledby="X-diag-title X-diag-desc">
+    <h3 id="X-diag-title" class="mneme-diagram__title">Visible title</h3>
+    <p id="X-diag-desc" class="mneme-diagram__sr-desc">Long description for AT</p>
+    <!-- primitive-specific markup -->
+  </div>
+  <figcaption class="diagram-caption">One-line argument summary.</figcaption>
+</figure>
+```
+
+- The heading level matches the surrounding document outline. Class and ARIA
+  wiring stay constant; only the `h*` level varies per page.
+- `.mneme-diagram__sr-desc` is screen-reader-only.
+- `.diagram-figure` and `.diagram-caption` chrome is shared with the legacy
+  SVG diagrams and must not be modified.
+
+---
+
+## Color roles
+
+Every node belongs to exactly one role. Roles are documented choices on top
+of the existing theme tokens (`--accent`, `--teal`, etc.). No new `:root`
+variables are introduced.
+
+| Role | Stroke / border | Fill | Used for |
+|---|---|---|---|
+| **Source** | `--teal` | `rgba(139, 224, 200, 0.05)` | Origin of truth: ADR, decision, intent. |
+| **Active** | `--accent`, 1.5px | `rgba(200, 240, 96, 0.05)` | Compiled, on-path, governance-touched. |
+| **Gate** | `--accent` | solid `--accent`, dark text | Hard enforcement points only. Reserved. |
+| **Neutral** | `--border2` | `--surface` | Passive consumers / endpoints. |
+| **Muted** | `--border`, dashed | `--surface` | Drift, divergence, observation-only. |
+
+Solid accent fills are reserved for genuine hard enforcement gates (CI merge
+check, pre-tool-use hook). Do not use solid accent for general active-path
+nodes.
+
+---
+
+## Typography
+
+- **Eyebrow** (one per primitive): DM Mono, 0.68rem, uppercase, letter-spacing
+  0.08–0.1em, color `--muted`.
+- **Node title**: Inter, 0.85rem, weight 600, color `--text`.
+- **Node sub-label**: DM Mono, 0.66–0.7rem, color `--muted` (or the role
+  color when the sub-label is itself a verdict / output).
+- **Caption**: stays on the shared `.diagram-caption` class — do not restyle.
+
+If the 0.66rem sub-label fails contrast or feels visually weak, raise the
+size; do not introduce new colors.
+
+---
+
+## Connectors
+
+- 1–1.5px borders or pseudo-elements, color-matched to the role.
+- No diagonal lines. Fan-outs use a vertical bus + horizontal stubs.
+- Arrow glyphs use literal `→` `←` `↑` `↓` characters (not images), so they
+  are selectable, indexable, and accessible.
+
+---
+
+## Accessibility
+
+- `role="img"` on the wrapper.
+- `aria-labelledby` references both visible title and screen-reader-only
+  description IDs.
+- All visible text is real HTML, not images or SVG `<text>`.
+- DOM order matches visual reading order at all widths.
+- WCAG AA contrast at smallest type sizes.
+- No keyboard interaction, no focus order. Primitives are static.
+- No information by color alone: every role-tinted node has a textual label.
+
+---
+
+## Motion
+
+None. No transitions, no hovers, no animations.
+
+---
+
+## Responsive
+
+- Test widths: 360px, 640px, 768px, 1024px+.
+- Collapse breakpoint: `@media (max-width: 640px)`.
+- No horizontal scroll. No overflow on `.mneme-diagram`.
+- Truncation that loses meaning is a bug; raise the breakpoint or restructure.
+
+---
+
+## CSS scoping invariant
+
+Every selector in `diagrams.css` must either:
+
+1. Be scoped under `.mneme-diagram`, or
+2. Target a class that only appears inside `.mneme-diagram` markup.
+
+No bare element selectors, no global resets. The `.mneme-diagram` wrapper is
+the firewall against style bleed into the rest of the page.
+
+---
+
+## No invented capabilities
+
+Every node label must correspond to a real Mneme surface, integration page,
+or product feature. If a label cannot be sourced, reword it generically
+("Source decision," "Example ADR") or drop it. ADR identifiers must be real
+IDs from `docs/adr/` — no fake `ADR-NNNN` placeholders.
+
+---
+
+## Adding a new diagram
+
+1. Check if an existing primitive fits. If so, embed it (markup + stylesheet
+   link). Do not author new CSS.
+2. If a new shape is needed, prefer extending an existing primitive over
+   creating a new one. Discuss before adding a fifth primitive.
+3. New CSS must follow the scoping invariant and use existing theme tokens.

--- a/docs/contributing/diagram-conventions.md
+++ b/docs/contributing/diagram-conventions.md
@@ -21,10 +21,10 @@ Canonical homes are documented in the Phase 3 design doc (private repo).
 Every primitive uses this wrapper:
 
 ```html
-<figure class="diagram-figure" aria-labelledby="X-diag-title">
+<figure class="diagram-figure">
   <div class="mneme-diagram mneme-diagram--<kind>" role="img"
        aria-labelledby="X-diag-title X-diag-desc">
-    <h3 id="X-diag-title" class="mneme-diagram__title">Visible title</h3>
+    <p id="X-diag-title" class="mneme-diagram__title">Visible title</p>
     <p id="X-diag-desc" class="mneme-diagram__sr-desc">Long description for AT</p>
     <!-- primitive-specific markup -->
   </div>
@@ -32,8 +32,16 @@ Every primitive uses this wrapper:
 </figure>
 ```
 
-- The heading level matches the surrounding document outline. Class and ARIA
-  wiring stay constant; only the `h*` level varies per page.
+- The visible title can be any element (`<h2>`, `<h3>`, `<h4>`, or `<p>` / `<div>`).
+  Pick whatever fits the page's document outline. Use a heading element only when
+  the diagram occupies a heading slot in the page hierarchy; use `<p>` when it sits
+  inside a section as an illustration. The class and ARIA wiring stay constant
+  regardless.
+- **ARIA labelling:** the inner `<div role="img">` carries `aria-labelledby`
+  pointing at both the visible title id and the sr-only description id. The outer
+  `<figure>` does NOT use `aria-labelledby` — it derives its accessible name
+  natively from `<figcaption>`. This avoids duplicate announcements in screen
+  readers.
 - `.mneme-diagram__sr-desc` is screen-reader-only.
 - `.diagram-figure` and `.diagram-caption` chrome is shared with the legacy
   SVG diagrams and must not be modified.

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -346,7 +346,10 @@
 
 .mneme-diagram--chain .chain {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  /* minmax(0, 1fr) so long content (l-id strings like
+   * "predicate(decision, diff) -> block") wraps within its cell
+   * rather than forcing its column wider than its siblings. */
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 6px;
   list-style: none;
   margin: 0;
@@ -413,6 +416,10 @@
   color: var(--text);
   margin-bottom: 0.3rem;
   line-height: 1.35;
+  /* Some l-id values contain long un-breakable tokens such as
+   * "predicate(decision," that would otherwise force the cell wider
+   * than its siblings. anywhere lets the browser break mid-token. */
+  overflow-wrap: anywhere;
 }
 
 .mneme-diagram--chain .l-meta {

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -211,8 +211,125 @@
 
 /* ============================================================
  * Primitive 2: Enforcement checkpoints
- * (filled in Task 18)
+ * Five lifecycle checkpoints, bracketed into pre- and post-generation,
+ * with the strategic hard gate (CI check) visually marked.
  * ============================================================ */
+
+.mneme-diagram--checkpoints {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.mneme-diagram--checkpoints .brackets {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 12px;
+  margin-bottom: 0.5rem;
+}
+
+.mneme-diagram--checkpoints .bracket-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border2);
+}
+
+.mneme-diagram--checkpoints .bracket-label.pre {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.mneme-diagram--checkpoints .bracket-label.post {
+  color: var(--muted);
+}
+
+.mneme-diagram--checkpoints .row {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  align-items: stretch;
+  position: relative;
+}
+
+.mneme-diagram--checkpoints .step {
+  background: var(--surface2);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 0.7rem 0.55rem;
+  text-align: center;
+  position: relative;
+}
+
+.mneme-diagram--checkpoints .step--active {
+  background: rgba(200, 240, 96, 0.05);
+  border-color: var(--accent);
+  border-width: 1.5px;
+}
+
+.mneme-diagram--checkpoints .step--gate {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.mneme-diagram--checkpoints .step--gate .s-title,
+.mneme-diagram--checkpoints .step--gate .s-sub {
+  color: #0c0c0d;
+}
+
+.mneme-diagram--checkpoints .step--muted {
+  border-style: dashed;
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.mneme-diagram--checkpoints .s-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+
+.mneme-diagram--checkpoints .s-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.66rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.mneme-diagram--checkpoints .step + .step::before {
+  content: '\2192';
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-family: 'DM Mono', monospace;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .mneme-diagram--checkpoints .brackets {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+  .mneme-diagram--checkpoints .row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .mneme-diagram--checkpoints .step + .step::before {
+    content: '\2193';
+    left: 50%;
+    top: -10px;
+    transform: translateX(-50%);
+  }
+}
 
 /* ============================================================
  * Primitive 3: Provenance chain

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -1,0 +1,63 @@
+/*
+ * Mneme HQ — Canonical Diagram Primitives
+ *
+ * Four self-contained HTML+CSS diagram primitives, all scoped under
+ * .mneme-diagram. See docs/contributing/diagram-conventions.md for the visual
+ * language spec and the no-invented-capabilities rule.
+ *
+ * Theme tokens (--accent, --teal, --surface, etc.) are defined in each
+ * page's inline <style> block. This file relies on them but does not
+ * redefine them.
+ */
+
+/* ============================================================
+ * Base wrapper
+ * ============================================================ */
+
+.mneme-diagram {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+}
+
+.mneme-diagram__title {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 400;
+  margin: 0 0 1.1rem 0;
+}
+
+.mneme-diagram__sr-desc {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================================
+ * Primitive 1: Governance propagation
+ * (filled in Task 11)
+ * ============================================================ */
+
+/* ============================================================
+ * Primitive 2: Enforcement checkpoints
+ * (filled in Task 18)
+ * ============================================================ */
+
+/* ============================================================
+ * Primitive 3: Provenance chain
+ * (filled in Task 25)
+ * ============================================================ */
+
+/* ============================================================
+ * Primitive 4: Architectural drift cascade
+ * (filled in Task 32)
+ * ============================================================ */

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -333,8 +333,145 @@
 
 /* ============================================================
  * Primitive 3: Provenance chain
- * (filled in Task 25)
+ * Six numbered links from authoring ADR to enforcement event,
+ * plus a citable-chain summary trailer.
  * ============================================================ */
+
+.mneme-diagram--chain {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.mneme-diagram--chain .chain {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mneme-diagram--chain .link {
+  background: var(--surface2);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 0.7rem 0.55rem;
+  position: relative;
+}
+
+.mneme-diagram--chain .link--source {
+  background: rgba(139, 224, 200, 0.05);
+  border-color: var(--teal);
+}
+
+.mneme-diagram--chain .link--active {
+  background: rgba(200, 240, 96, 0.05);
+  border-color: var(--accent);
+  border-width: 1.5px;
+}
+
+.mneme-diagram--chain .link + .link::before {
+  content: '\2192';
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--accent);
+  font-family: 'DM Mono', monospace;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.mneme-diagram--chain .l-num {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 0.2rem;
+}
+
+.mneme-diagram--chain .l-type {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.3rem;
+  line-height: 1.3;
+}
+
+.mneme-diagram--chain .link--source .l-type {
+  color: var(--teal);
+}
+
+.mneme-diagram--chain .l-id {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.3rem;
+  line-height: 1.35;
+}
+
+.mneme-diagram--chain .l-meta {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.mneme-diagram--chain .citation {
+  margin-top: 1.1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(139, 224, 200, 0.05);
+  border: 1px solid var(--teal);
+  border-radius: 6px;
+}
+
+.mneme-diagram--chain .citation-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--teal);
+  margin-bottom: 0.5rem;
+}
+
+.mneme-diagram--chain .citation-line {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text);
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.mneme-diagram--chain .citation-summary {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  color: var(--muted);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  line-height: 1.55;
+}
+
+@media (max-width: 640px) {
+  .mneme-diagram--chain .chain {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .mneme-diagram--chain .link + .link::before {
+    content: '\2193';
+    left: 50%;
+    top: -10px;
+    transform: translateX(-50%);
+  }
+  .mneme-diagram--chain .citation-line {
+    font-size: 0.66rem;
+  }
+}
 
 /* ============================================================
  * Primitive 4: Architectural drift cascade

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -482,5 +482,88 @@
 
 /* ============================================================
  * Primitive 4: Architectural drift cascade
- * (filled in Task 32)
+ * Five schematic tier rows showing compounding drift across
+ * sessions. Bar widths are illustrative (20/40/60/80/100%); no
+ * specific violation counts or benchmark figures appear in the
+ * markup. See /benchmark/ for measured rates.
+ *
+ * Note on rgba values: the rgba(168, 168, 184, X) tier shades
+ * derive from #a8a8b8, the --muted token. CSS does not natively
+ * interpolate var() into rgba() without color-mix(), and we are
+ * not pinning evergreen-only browser support yet. These rgba
+ * literals are intentional theme-token derivatives, not stray hex.
  * ============================================================ */
+
+.mneme-diagram--cascade {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.mneme-diagram--cascade .tier {
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.mneme-diagram--cascade .tier:last-child {
+  margin-bottom: 0;
+}
+
+.mneme-diagram--cascade .t-session {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.mneme-diagram--cascade .t-body {
+  position: relative;
+  height: 44px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.mneme-diagram--cascade .t-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(168, 168, 184, 0.1);
+  border-right: 1px solid var(--border2);
+}
+
+/* Schematic widths increase across tiers; no measured units. */
+.mneme-diagram--cascade .t-bar--w1 { width: 20%; }
+.mneme-diagram--cascade .t-bar--w2 { width: 40%; background: rgba(168, 168, 184, 0.15); }
+.mneme-diagram--cascade .t-bar--w3 { width: 60%; background: rgba(168, 168, 184, 0.2); }
+.mneme-diagram--cascade .t-bar--w4 { width: 80%; background: rgba(168, 168, 184, 0.25); border-right-style: dashed; }
+.mneme-diagram--cascade .t-bar--w5 { width: 100%; background: rgba(168, 168, 184, 0.3); border-right-style: dashed; }
+
+.mneme-diagram--cascade .t-label {
+  position: absolute;
+  left: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text);
+  z-index: 1;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .mneme-diagram--cascade .tier {
+    grid-template-columns: 44px 1fr;
+    gap: 8px;
+  }
+  .mneme-diagram--cascade .t-label {
+    font-size: 0.74rem;
+  }
+}

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -185,14 +185,27 @@
 }
 
 @media (max-width: 640px) {
+  /* Pipeline collapses to a single vertical stack. */
   .mneme-diagram--propagation .pipeline {
     grid-template-columns: 1fr;
   }
+  /* Consumers also collapse to a single vertical stack. The 2-column
+   * layout with a span-2 gate cell left empty grid slots and orphaned
+   * connector stubs whose horizontal bar lived only above row 1. The
+   * fan-out argument is communicated by the figcaption and structural
+   * flow (3 pipeline cells -> bus -> 5 consumer cells stacked); the
+   * horizontal bar and per-cell stubs are decorative and hidden. */
   .mneme-diagram--propagation .consumers {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding-top: 0;
   }
-  .mneme-diagram--propagation .consumer--gate {
-    grid-column: span 2;
+  .mneme-diagram--propagation .consumers::before,
+  .mneme-diagram--propagation .consumer::before {
+    display: none;
+  }
+  .mneme-diagram--propagation .consumer {
+    padding-top: 0;
   }
 }
 

--- a/site/assets/css/diagrams.css
+++ b/site/assets/css/diagrams.css
@@ -18,6 +18,7 @@
   margin: 0;
   font-family: 'Inter', sans-serif;
   color: var(--text);
+  position: relative;
 }
 
 .mneme-diagram__title {
@@ -44,8 +45,156 @@
 
 /* ============================================================
  * Primitive 1: Governance propagation
- * (filled in Task 11)
+ * Three-row layout: pipeline → bus → consumers, with equivalence line
  * ============================================================ */
+
+.mneme-diagram--propagation {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.mneme-diagram--propagation .pipeline {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.mneme-diagram--propagation .node {
+  background: var(--surface2);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 0.7rem 0.55rem;
+  text-align: center;
+}
+
+.mneme-diagram--propagation .node--source {
+  background: rgba(139, 224, 200, 0.05);
+  border-color: var(--teal);
+}
+
+.mneme-diagram--propagation .node--active {
+  background: rgba(200, 240, 96, 0.05);
+  border-color: var(--accent);
+  border-width: 1.5px;
+}
+
+.mneme-diagram--propagation .node--gate {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.mneme-diagram--propagation .node--gate .n-title,
+.mneme-diagram--propagation .node--gate .n-sub {
+  color: #0c0c0d;
+}
+
+.mneme-diagram--propagation .n-eyebrow {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.25rem;
+}
+
+.mneme-diagram--propagation .node--source .n-eyebrow { color: var(--teal); }
+.mneme-diagram--propagation .node--active .n-eyebrow { color: var(--accent); }
+
+.mneme-diagram--propagation .n-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.2rem;
+}
+
+.mneme-diagram--propagation .n-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.66rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.mneme-diagram--propagation .bus {
+  position: relative;
+  height: 36px;
+}
+
+.mneme-diagram--propagation .bus::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1.5px;
+  background: var(--accent);
+  transform: translateX(-50%);
+}
+
+.mneme-diagram--propagation .consumers {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  position: relative;
+  padding-top: 10px;
+}
+
+.mneme-diagram--propagation .consumers::before {
+  content: '';
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  top: 0;
+  height: 1.5px;
+  background: var(--accent);
+}
+
+.mneme-diagram--propagation .consumer {
+  position: relative;
+  padding-top: 8px;
+}
+
+.mneme-diagram--propagation .consumer::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 1.5px;
+  height: 8px;
+  background: var(--accent);
+  transform: translateX(-50%);
+}
+
+.mneme-diagram--propagation .equiv {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--accent);
+  text-align: center;
+  margin-top: 1.1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--border);
+  line-height: 1.6;
+}
+
+.mneme-diagram--propagation .equiv small {
+  display: block;
+  font-size: 0.66rem;
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 640px) {
+  .mneme-diagram--propagation .pipeline {
+    grid-template-columns: 1fr;
+  }
+  .mneme-diagram--propagation .consumers {
+    grid-template-columns: 1fr 1fr;
+  }
+  .mneme-diagram--propagation .consumer--gate {
+    grid-column: span 2;
+  }
+}
 
 /* ============================================================
  * Primitive 2: Enforcement checkpoints

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -7,6 +7,7 @@
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
+  <link rel="stylesheet" href="/assets/css/diagrams.css">
   <meta name="description" content="Architectural drift is the compound degradation in codebase coherence caused by AI agents producing code inconsistent with established decisions, uncorrected across sessions and agents." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -337,6 +338,51 @@
     <div class="callout">
       <p><strong>Drift is the structural divergence between what the codebase is doing and what architectural decisions say it should do, growing over time.</strong> The accumulation of violations is the symptom. The underlying problem is that each uncorrected violation expands the space from which the next violation can emerge â€” compounding the distance between the actual codebase and the intended architecture.</p>
     </div>
+
+    <figure class="diagram-figure">
+      <div class="mneme-diagram mneme-diagram--cascade" role="img"
+           aria-labelledby="dc-diag-title dc-diag-desc">
+        <p id="dc-diag-title" class="mneme-diagram__title">Schematic &middot; drift compounds across sessions</p>
+        <p id="dc-diag-desc" class="mneme-diagram__sr-desc">Five schematic tiers of accumulating architectural drift across sessions. S1 new drift; S2 compounded; S3 deeply compounded; S4 architecturally divergent (dashed boundary signals ungoverned territory); S5 governance reset required. Bar widths are illustrative of compounding shape, not measured rates.</p>
+
+        <div class="tier">
+          <div class="t-session">S1</div>
+          <div class="t-body">
+            <div class="t-bar t-bar--w1"></div>
+            <div class="t-label">new drift</div>
+          </div>
+        </div>
+        <div class="tier">
+          <div class="t-session">S2</div>
+          <div class="t-body">
+            <div class="t-bar t-bar--w2"></div>
+            <div class="t-label">compounded</div>
+          </div>
+        </div>
+        <div class="tier">
+          <div class="t-session">S3</div>
+          <div class="t-body">
+            <div class="t-bar t-bar--w3"></div>
+            <div class="t-label">deeply compounded</div>
+          </div>
+        </div>
+        <div class="tier">
+          <div class="t-session">S4</div>
+          <div class="t-body">
+            <div class="t-bar t-bar--w4"></div>
+            <div class="t-label">architecturally divergent</div>
+          </div>
+        </div>
+        <div class="tier">
+          <div class="t-session">S5</div>
+          <div class="t-body">
+            <div class="t-bar t-bar--w5"></div>
+            <div class="t-label">governance reset required</div>
+          </div>
+        </div>
+      </div>
+      <figcaption class="diagram-caption"><strong>Drift is compound, not additive.</strong> Each session inherits the previous session's drift as precedent and adds to it. Schematic; see <a href="/benchmark/">/benchmark/</a> for measured drift rate.</figcaption>
+    </figure>
 
     <p>A codebase that has drifted is not just a codebase with many violations. It is a codebase where the violations have become embedded in patterns, where those patterns have been treated as precedent, and where correcting the drift requires not just fixing individual violations but restoring the structural coherence that the violations eroded. That is categorically more expensive than catching the first violation.</p>
 

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -6,6 +6,7 @@
   <title>Enforcement Provenance â€” Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
+  <link rel="stylesheet" href="/assets/css/diagrams.css">
   <meta name="description" content="Enforcement provenance: every governance verdict traces back to a specific decision record, the precedence rule that selected it, and the source ADR â€” a citable chain." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -269,71 +270,59 @@
 
     <p>A governance system that blocks a merge but cannot explain why is indistinguishable from a flaky test. The block becomes noise to be worked around â€” disabled in CI, ignored in review, treated as a hostile gate rather than an architectural signal. Provenance is the property that converts an enforcement event from "the system said no" into "this specific team decision, written on this date, by this person, applies because of this precedence rule, and the rationale is at this URL."</p>
 
-    <figure class="diagram-figure" aria-labelledby="ep-diag-title">
-      <svg viewBox="0 0 800 380" role="img" aria-labelledby="ep-diag-title ep-diag-desc" xmlns="http://www.w3.org/2000/svg">
-        <title id="ep-diag-title">The provenance chain of an enforcement verdict</title>
-        <desc id="ep-diag-desc">A six-link chain from authoring ADR through compilation, retrieval, precedence resolution, evaluation, and enforcement output â€” each link annotated with its citable identifier.</desc>
-        <g>
-          <text x="40" y="28" fill="#c8f060" font-family="DM Mono, monospace" font-size="10" letter-spacing="0.06em">PROVENANCE CHAIN Â· enforcement verdict â†’ authoring intent</text>
+    <figure class="diagram-figure">
+      <div class="mneme-diagram mneme-diagram--chain" role="img"
+           aria-labelledby="ep-diag-title ep-diag-desc">
+        <p id="ep-diag-title" class="mneme-diagram__title">Provenance chain &middot; enforcement verdict cites authoring intent</p>
+        <p id="ep-diag-desc" class="mneme-diagram__sr-desc">Six-link chain from authoring ADR through compilation, retrieval, precedence resolution, evaluation, and enforcement event. Link 1 (authoring) is the source decision; link 6 (enforcement event) is the verdict. Each link cites the previous, making the chain the audit record. A citable-chain summary block follows the six links.</p>
 
-          <!-- Link 1: ADR -->
-          <rect x="40" y="56" width="170" height="70" rx="8" fill="rgba(139,224,200,0.05)" stroke="#8be0c8" stroke-width="1.2"/>
-          <text x="55" y="78" fill="#8be0c8" font-family="DM Mono, monospace" font-size="10">01 Â· AUTHORING</text>
-          <text x="55" y="98" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">ADR-0017.md</text>
-          <text x="55" y="116" fill="#88889a" font-family="DM Mono, monospace" font-size="10">git sha Â· author Â· date</text>
+        <ol class="chain">
+          <li class="link link--source">
+            <div class="l-num">01</div>
+            <div class="l-type">Authoring</div>
+            <div class="l-id">Source decision</div>
+            <div class="l-meta">git sha &middot; author &middot; date</div>
+          </li>
+          <li class="link">
+            <div class="l-num">02</div>
+            <div class="l-type">Compiled record</div>
+            <div class="l-id">decision_id</div>
+            <div class="l-meta">corpus version &middot; schema</div>
+          </li>
+          <li class="link">
+            <div class="l-num">03</div>
+            <div class="l-type">Retrieval</div>
+            <div class="l-id">scope match &middot; top-K</div>
+            <div class="l-meta">query &middot; rank &middot; candidates</div>
+          </li>
+          <li class="link">
+            <div class="l-num">04</div>
+            <div class="l-type">Precedence</div>
+            <div class="l-id">rule &middot; winner</div>
+            <div class="l-meta">supersession &middot; scope</div>
+          </li>
+          <li class="link">
+            <div class="l-num">05</div>
+            <div class="l-type">Evaluation</div>
+            <div class="l-id">predicate(decision, diff) &rarr; block</div>
+            <div class="l-meta">tool &middot; agent &middot; timestamp</div>
+          </li>
+          <li class="link link--active">
+            <div class="l-num">06</div>
+            <div class="l-type">Enforcement event</div>
+            <div class="l-id">verdict &middot; severity</div>
+            <div class="l-meta">queryable from CI, dashboard, IDE</div>
+          </li>
+        </ol>
 
-          <!-- Link 2: Compile -->
-          <rect x="240" y="56" width="170" height="70" rx="8" fill="#141416" stroke="#2e2e34"/>
-          <text x="255" y="78" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">02 Â· COMPILED RECORD</text>
-          <text x="255" y="98" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">decision_id = d-17</text>
-          <text x="255" y="116" fill="#88889a" font-family="DM Mono, monospace" font-size="10">corpus version Â· schema</text>
-
-          <!-- Link 3: Retrieve -->
-          <rect x="440" y="56" width="170" height="70" rx="8" fill="#141416" stroke="#2e2e34"/>
-          <text x="455" y="78" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">03 Â· RETRIEVAL</text>
-          <text x="455" y="98" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">scope match Â· top-K</text>
-          <text x="455" y="116" fill="#88889a" font-family="DM Mono, monospace" font-size="10">query Â· rank Â· candidates</text>
-
-          <!-- Link 4: Precedence -->
-          <rect x="640" y="56" width="120" height="70" rx="8" fill="#141416" stroke="#2e2e34"/>
-          <text x="650" y="78" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">04 Â· PRECEDENCE</text>
-          <text x="650" y="98" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">rule Â· winner</text>
-          <text x="650" y="116" fill="#88889a" font-family="DM Mono, monospace" font-size="10">supersession Â· scope</text>
-
-          <!-- Arrows top row -->
-          <line x1="210" y1="91" x2="240" y2="91" stroke="#c8f060" stroke-width="1.5"/>
-          <line x1="410" y1="91" x2="440" y2="91" stroke="#c8f060" stroke-width="1.5"/>
-          <line x1="610" y1="91" x2="640" y2="91" stroke="#c8f060" stroke-width="1.5"/>
-
-          <!-- Down arrow -->
-          <line x1="700" y1="126" x2="700" y2="146" stroke="#c8f060" stroke-width="1.5"/>
-          <polygon points="695,142 705,142 700,150" fill="#c8f060"/>
-
-          <!-- Link 5: Evaluate -->
-          <rect x="440" y="156" width="320" height="70" rx="8" fill="#141416" stroke="#2e2e34"/>
-          <text x="455" y="178" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">05 Â· EVALUATION</text>
-          <text x="455" y="198" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">predicate(d-17, diff) â†’ block</text>
-          <text x="455" y="216" fill="#88889a" font-family="DM Mono, monospace" font-size="10">tool Â· agent Â· timestamp Â· pre-tool-use hook</text>
-
-          <line x1="440" y1="191" x2="410" y2="191" stroke="#c8f060" stroke-width="1.5"/>
-          <polygon points="414,186 414,196 406,191" fill="#c8f060"/>
-
-          <!-- Link 6: Verdict -->
-          <rect x="40" y="156" width="370" height="70" rx="8" fill="rgba(200,240,96,0.05)" stroke="#c8f060" stroke-width="1.5"/>
-          <text x="55" y="178" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">06 Â· ENFORCEMENT EVENT Â· stored, queryable</text>
-          <text x="55" y="198" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">verdict = BLOCK Â· severity = high</text>
-          <text x="55" y="216" fill="#88889a" font-family="DM Mono, monospace" font-size="10">links: 01 Â· 02 Â· 03 Â· 04 Â· 05 Â· queryable from CI, dashboard, IDE</text>
-
-          <!-- Chain summary -->
-          <rect x="40" y="252" width="720" height="100" rx="10" fill="rgba(139,224,200,0.05)" stroke="#8be0c8" stroke-width="1.2"/>
-          <text x="55" y="276" fill="#8be0c8" font-family="DM Mono, monospace" font-size="10">CITABLE CHAIN</text>
-
-          <text x="55" y="298" fill="#e8e8ec" font-family="DM Mono, monospace" font-size="11">verdict#9341 â† evaluator(d-17 @ corpus v.42) â† precedence(supersession) â† retrieval(query qâ‚)</text>
-          <text x="55" y="316" fill="#e8e8ec" font-family="DM Mono, monospace" font-size="11">          â† d-17 â† compile(ADR-0017.md @ sha 9f3a) â† author: Theo Â· 2026-01-14</text>
-          <text x="55" y="340" fill="#88889a" font-family="DM Mono, monospace" font-size="10">Every step is a link Â· every link is queryable Â· the chain is the audit record</text>
-        </g>
-      </svg>
-      <figcaption class="diagram-caption"><strong>The chain is the audit record.</strong> Verdict â†’ evaluator â†’ precedence rule â†’ retrieval â†’ compiled record â†’ authoring ADR. Each link cites the next. "Why did this fail?" resolves to a single chain, not a guess.</figcaption>
+        <div class="citation">
+          <div class="citation-label">Citable chain</div>
+          <div class="citation-line">verdict#NNNN &larr; evaluator(decision @ corpus v.N) &larr; precedence(supersession) &larr; retrieval(query q)</div>
+          <div class="citation-line">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &larr; decision &larr; compile(source @ sha) &larr; author</div>
+          <div class="citation-summary">Every step is a link &middot; every link is queryable &middot; the chain is the audit record.</div>
+        </div>
+      </div>
+      <figcaption class="diagram-caption"><strong>The chain is the audit record.</strong> Verdict &rarr; evaluator &rarr; precedence rule &rarr; retrieval &rarr; compiled record &rarr; authoring ADR. Each link cites the next. "Why did this fail?" resolves to a single chain, not a guess.</figcaption>
     </figure>
 
     <h2>What enforcement provenance actually means</h2>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -7,6 +7,7 @@
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
+  <link rel="stylesheet" href="/assets/css/diagrams.css">
   <meta name="description" content="Governance before generation means enforcing architectural constraints before the AI writes code, not after it reaches review. The enforcement point is the strategic variable." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -467,6 +468,45 @@
     <div class="callout">
       <p><strong>The enforcement point is the strategic variable.</strong> Everything else â€” the quality of your decision records, the precision of your retrieval, the coverage of your constraints â€” is multiplied or divided by where enforcement fires. Pre-generation enforcement multiplies; post-generation enforcement divides attention.</p>
     </div>
+
+    <p>The five concrete checkpoints across the AI development lifecycle make this choice visible. Each is a place where governance can fire &mdash; but only the first two fire before generation. The rest react to output that already exists.</p>
+
+    <figure class="diagram-figure">
+      <div class="mneme-diagram mneme-diagram--checkpoints" role="img"
+           aria-labelledby="ec-diag-title ec-diag-desc">
+        <p id="ec-diag-title" class="mneme-diagram__title">Five enforcement checkpoints &middot; two fire before generation</p>
+        <p id="ec-diag-desc" class="mneme-diagram__sr-desc">Five lifecycle checkpoints. Pre-generation governance: IDE corpus as context, and pre-tool-use hook that blocks before the agent writes. Post-generation checks: CI check (the hard gate that blocks before merge), Merge gated on the verdict, and post-hoc Audit review.</p>
+
+        <div class="brackets">
+          <div class="bracket-label pre">Pre-generation governance</div>
+          <div class="bracket-label post">Post-generation checks</div>
+        </div>
+
+        <div class="row">
+          <div class="step step--active">
+            <div class="s-title">IDE</div>
+            <div class="s-sub">corpus as context</div>
+          </div>
+          <div class="step step--active">
+            <div class="s-title">Pre-tool-use hook</div>
+            <div class="s-sub">block before generation</div>
+          </div>
+          <div class="step step--gate">
+            <div class="s-title">CI check</div>
+            <div class="s-sub">block before merge</div>
+          </div>
+          <div class="step">
+            <div class="s-title">Merge</div>
+            <div class="s-sub">gated on verdict</div>
+          </div>
+          <div class="step step--muted">
+            <div class="s-title">Audit</div>
+            <div class="s-sub">post-hoc review</div>
+          </div>
+        </div>
+      </div>
+      <figcaption class="diagram-caption"><strong>Five checkpoints, one strategic split.</strong> Pre-generation governance shapes a single proposal before the agent writes. Post-generation checks react to output that already exists; the CI gate is the only one that can still block.</figcaption>
+    </figure>
 
     <h2>Why this problem exists in AI-native development</h2>
 

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -373,7 +373,7 @@
 
     <p>That distinction â€” shaping versus reacting â€” is the structural argument this page develops. The enforcement point is not a scheduling detail. It is the variable that determines whether governance is architectural infrastructure or expensive remediation.</p>
 
-    <figure class="diagram-figure" aria-labelledby="gbg-diag-title">
+    <figure class="diagram-figure">
       <svg viewBox="0 0 800 340" role="img" aria-labelledby="gbg-diag-title gbg-diag-desc" xmlns="http://www.w3.org/2000/svg">
         <title id="gbg-diag-title">Two enforcement points on the same pipeline</title>
         <desc id="gbg-diag-desc">Two parallel pipelines: the upper one places enforcement before generation and produces shaped output. The lower one places enforcement after generation as review and accumulates rework.</desc>
@@ -488,7 +488,7 @@
             <div class="s-sub">corpus as context</div>
           </div>
           <div class="step step--active">
-            <div class="s-title">Pre-tool-use hook</div>
+            <div class="s-title">Pre-tool hook</div>
             <div class="s-sub">block before generation</div>
           </div>
           <div class="step step--gate">

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -6,6 +6,7 @@
   <title>Governance Propagation â€” Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
+  <link rel="stylesheet" href="/assets/css/diagrams.css">
   <meta name="description" content="Governance propagation: a single compiled decision reaches every agent, every developer, every CI run with identical semantics, scope, and enforcement verdict." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -272,69 +273,59 @@
 
     <p>Most discussion of AI coding governance focuses on a single surface â€” usually a single agent in a single editor. The unspoken assumption is that if the constraint works in that one place, governance is solved. It is not. The hard problem in real teams is not enforcing a constraint in one session; it is making sure the same constraint, with the same meaning, is enforced in every session, by every agent, on every developer's machine, and in CI. That property has a name: <strong>governance propagation</strong>.</p>
 
-    <figure class="diagram-figure" aria-labelledby="gp-diag-title">
-      <svg viewBox="0 0 800 360" role="img" aria-labelledby="gp-diag-title gp-diag-desc" xmlns="http://www.w3.org/2000/svg">
-        <title id="gp-diag-title">A single compiled decision propagating to every consumer</title>
-        <desc id="gp-diag-desc">Central node 'ADR-0017' compiles into a decision corpus that fans out to multiple consumers â€” Claude Code, Cursor, Copilot, CI, JetBrains, code review bots â€” each receiving the identical constraint.</desc>
-        <g>
-          <text x="40" y="28" fill="#c8f060" font-family="DM Mono, monospace" font-size="10" letter-spacing="0.06em">ONE DECISION Â· IDENTICAL SEMANTICS Â· EVERY CONSUMER</text>
+    <figure class="diagram-figure">
+      <div class="mneme-diagram mneme-diagram--propagation" role="img"
+           aria-labelledby="gp-diag-title gp-diag-desc">
+        <p id="gp-diag-title" class="mneme-diagram__title">One decision · identical semantics · every consumer</p>
+        <p id="gp-diag-desc" class="mneme-diagram__sr-desc">A single compiled decision propagates from a source decision through a compiler into a corpus, then fans out to five consumers (Claude Code, Cursor, Copilot, CI merge gate, JetBrains) which each produce the same verdict.</p>
 
-          <!-- Source -->
-          <rect x="40" y="68" width="160" height="60" rx="8" fill="rgba(139,224,200,0.05)" stroke="#8be0c8" stroke-width="1.2"/>
-          <text x="120" y="92" text-anchor="middle" fill="#8be0c8" font-family="DM Mono, monospace" font-size="10">ADR-0017</text>
-          <text x="120" y="112" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">use repository pattern</text>
+        <div class="pipeline">
+          <div class="node node--source">
+            <div class="n-eyebrow">ADR</div>
+            <div class="n-title">Source decision</div>
+            <div class="n-sub">authored once</div>
+          </div>
+          <div class="node node--active">
+            <div class="n-eyebrow">COMPILER</div>
+            <div class="n-title">parse · validate · emit</div>
+          </div>
+          <div class="node node--active">
+            <div class="n-eyebrow">CORPUS</div>
+            <div class="n-title">project_memory.json</div>
+            <div class="n-sub">single source of truth</div>
+          </div>
+        </div>
 
-          <!-- Compiler -->
-          <rect x="240" y="68" width="140" height="60" rx="8" fill="rgba(200,240,96,0.05)" stroke="#c8f060" stroke-width="1.5"/>
-          <text x="310" y="92" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">COMPILER</text>
-          <text x="310" y="112" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">parse Â· validate Â· emit</text>
+        <div class="bus" aria-hidden="true"></div>
 
-          <line x1="200" y1="98" x2="240" y2="98" stroke="#c8f060" stroke-width="1.5"/>
+        <div class="consumers">
+          <div class="consumer node">
+            <div class="n-title">Claude Code</div>
+            <div class="n-sub">pre-tool-use hook</div>
+          </div>
+          <div class="consumer node">
+            <div class="n-title">Cursor</div>
+            <div class="n-sub">rules emission</div>
+          </div>
+          <div class="consumer node">
+            <div class="n-title">Copilot</div>
+            <div class="n-sub">instructions file</div>
+          </div>
+          <div class="consumer consumer--gate node node--gate">
+            <div class="n-title">CI gate</div>
+            <div class="n-sub">merge enforcement</div>
+          </div>
+          <div class="consumer node">
+            <div class="n-title">JetBrains</div>
+            <div class="n-sub">corpus context</div>
+          </div>
+        </div>
 
-          <!-- Corpus -->
-          <rect x="420" y="68" width="200" height="60" rx="8" fill="rgba(200,240,96,0.05)" stroke="#c8f060" stroke-width="1.5"/>
-          <text x="520" y="92" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="10">project_memory.json</text>
-          <text x="520" y="112" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">single source of truth</text>
-
-          <line x1="380" y1="98" x2="420" y2="98" stroke="#c8f060" stroke-width="1.5"/>
-
-          <!-- Fanout point -->
-          <circle cx="520" cy="170" r="4" fill="#c8f060"/>
-          <line x1="520" y1="128" x2="520" y2="170" stroke="#c8f060" stroke-width="1.5"/>
-
-          <!-- Fanout lines -->
-          <line x1="520" y1="170" x2="100" y2="240" stroke="#c8f060" stroke-width="1.2"/>
-          <line x1="520" y1="170" x2="240" y2="240" stroke="#c8f060" stroke-width="1.2"/>
-          <line x1="520" y1="170" x2="380" y2="240" stroke="#c8f060" stroke-width="1.2"/>
-          <line x1="520" y1="170" x2="520" y2="240" stroke="#c8f060" stroke-width="1.2"/>
-          <line x1="520" y1="170" x2="660" y2="240" stroke="#c8f060" stroke-width="1.2"/>
-
-          <!-- Consumers -->
-          <rect x="40" y="240" width="120" height="56" rx="6" fill="#141416" stroke="#2e2e34"/>
-          <text x="100" y="262" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">Claude Code</text>
-          <text x="100" y="280" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">pre-tool-use hook</text>
-
-          <rect x="180" y="240" width="120" height="56" rx="6" fill="#141416" stroke="#2e2e34"/>
-          <text x="240" y="262" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">Cursor</text>
-          <text x="240" y="280" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">rules emission</text>
-
-          <rect x="320" y="240" width="120" height="56" rx="6" fill="#141416" stroke="#2e2e34"/>
-          <text x="380" y="262" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">Copilot</text>
-          <text x="380" y="280" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">instructions file</text>
-
-          <rect x="460" y="240" width="120" height="56" rx="6" fill="rgba(200,240,96,0.05)" stroke="#c8f060" stroke-width="1.5"/>
-          <text x="520" y="262" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">CI gate</text>
-          <text x="520" y="280" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="9">merge enforcement</text>
-
-          <rect x="600" y="240" width="120" height="56" rx="6" fill="#141416" stroke="#2e2e34"/>
-          <text x="660" y="262" text-anchor="middle" fill="#e8e8ec" font-family="Inter, sans-serif" font-size="12" font-weight="500">JetBrains</text>
-          <text x="660" y="280" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="9">plugin Â· inline</text>
-
-          <!-- Equivalence note -->
-          <text x="400" y="328" text-anchor="middle" fill="#c8f060" font-family="DM Mono, monospace" font-size="11">verdict(claude) â‰¡ verdict(cursor) â‰¡ verdict(copilot) â‰¡ verdict(ci)</text>
-          <text x="400" y="346" text-anchor="middle" fill="#88889a" font-family="DM Mono, monospace" font-size="10">same query Â· same corpus Â· same scope Â· same precedence Â· same answer</text>
-        </g>
-      </svg>
+        <div class="equiv">
+          verdict(claude) ≡ verdict(cursor) ≡ verdict(copilot) ≡ verdict(ci)
+          <small>same query · same corpus · same scope · same precedence · same answer</small>
+        </div>
+      </div>
       <figcaption class="diagram-caption"><strong>Propagation is a one-to-many invariant.</strong> A decision is compiled once. Every consumer reads the same corpus, applies the same scope and precedence rules, and produces the same verdict. There is no second copy of the truth to drift against.</figcaption>
     </figure>
 


### PR DESCRIPTION
## Summary

Phase 3 of the Mneme HQ knowledge-graph roadmap. Ships four reusable HTML+CSS diagram primitives on their canonical concept pages, plus a contributor-facing visual-language spec. Establishes a recognizable Mneme visual language so future diagrams reuse a shared vocabulary instead of growing the inline-SVG count further.

- New `site/assets/css/diagrams.css` — four self-contained primitives (`--propagation`, `--checkpoints`, `--chain`, `--cascade`), all scoped under `.mneme-diagram`.
- New `docs/contributing/diagram-conventions.md` — durable visual-language rules: markup contract, color roles, typography, scoping invariant, no-invented-capabilities rule.
- Four canonical concept pages updated to embed their primitive: `/concepts/governance-propagation/`, `/concepts/governance-before-generation/`, `/concepts/enforcement-provenance/`, `/concepts/architectural-drift/`.

The internal-planning design lives in the private `mneme-growth-ops` repo (commits `44c3442` design + `e285832` implementation plan + `4527a76` path-rename). Public scope is exactly the six files in this PR. No insight, demo, or compare-page embeds in this PR; those are queued for a follow-up.

## Replace / keep / add decisions

Applied the design's replacement rule strictly:

> Replace an existing SVG only when the CSS primitive is clearly smaller or theme-token cleaner, more accessible, and at least semantically equivalent. If it is only prettier or more consistent, do not replace it in this PR.

| Page | Existing | Action | Per-criterion reasoning |
|---|---|---|---|
| `/concepts/governance-propagation/` | Inline SVG (65 lines): ADR → Compiler → Corpus → 5 consumers. Hardcoded hex, `<text>` labels. JetBrains sub-label said "plugin · inline" — contradicted `/integrations/jetbrains/` ("No native JetBrains plugin yet"). | **REPLACE** | (a) theme-cleaner — `var(--token)` throughout, zero stray hex except `#0c0c0d` for gate dark text. (b) more accessible — real HTML > SVG `<text>`; clean ARIA. (c) semantically equivalent — same source / compiler / corpus / 5 consumers / equivalence statement; one capability-claim correction (JetBrains "plugin · inline" → "corpus context", matching the integration page). |
| `/concepts/governance-before-generation/` | Inline SVG: two-pipeline strategic argument. Figcaption: *"The enforcement point is the strategic variable."* | **KEEP BOTH** | The existing SVG argues **why** enforcement-point choice matters (strategic comparison of shape vs react). The new primitive argues **what** the concrete checkpoints are (operational map with the CI gate marked, two-vs-three split between pre- and post-generation). They answer different questions on the same page. A one-sentence connecting paragraph bridges them. Replacement rule does not apply: the two diagrams are not making the same argument. |
| `/concepts/enforcement-provenance/` | Inline SVG: six-link chain (01 Authoring → 06 Enforcement event) plus a "Citable chain" summary trailer. Hardcoded hex; fake identifiers (`ADR-0017.md`, `d-17`, `verdict#9341`, `sha 9f3a`, real personal name + date). | **REPLACE** | (a) theme-cleaner. (b) more accessible — real HTML; clean ARIA. (c) semantically equivalent — all 6 links preserved with type/id/meta; citable-chain trailer preserved as its own block within the wrapper; figcaption preserved verbatim. Fake identifiers genericized per the no-invented-capabilities rule, but the chain structure and argument are unchanged. |
| `/concepts/architectural-drift/` | No existing diagram. | **ADD** | Pure addition; replacement rule does not apply. Five schematic tier rows (S1–S5) with growing bar widths and qualitative labels. Schematic by design: no violation counts, benchmark rates, percentages in markup, or session numbers beyond S1–S5. S5 labeled "governance reset required," not "unrecoverable." Figcaption explicitly marks the diagram as schematic and links to `/benchmark/` for measured drift rate. |

The strategic SVG on `/concepts/governance-before-generation/` also had its outer `<figure aria-labelledby="…">` removed in `d286d9d` so both diagrams on that page announce consistently to assistive tech (the figure now derives its accessible name from `<figcaption>` natively; the SVG keeps its internal `<title>`/`<desc>` for the inner `role="img"`).

## Per-page diff sizes

```
 docs/contributing/diagram-conventions.md           | 149 ++++++ (new)
 site/assets/css/diagrams.css                       | 569 +++++++++++++++++++++ (new)
 site/concepts/architectural-drift/index.html       |  46 ++
 site/concepts/enforcement-provenance/index.html    | 119 ++---
 site/concepts/governance-before-generation/index.html |  42 +-
 site/concepts/governance-propagation/index.html    | 117 ++---
 6 files changed, 913 insertions(+), 129 deletions(-)
```

## Commit log on this branch (8 commits)

```
31c18c2 site(concepts): drift-cascade primitive (HTML+CSS)
f4167cd fix(diagrams): chain primitive equal-width columns at desktop
20ebe83 site(concepts): provenance-chain primitive (HTML+CSS)
d286d9d site(concepts): governance-before-generation phase 3 cleanup
55d9047 site(concepts): enforcement-checkpoints primitive (HTML+CSS)
a1b355a fix(diagrams): propagation primitive mobile layout
db556bf site(concepts): governance-propagation primitive (HTML+CSS)
c6e504d site(diagrams): scaffold diagrams.css and conventions doc
```

## Why `diagrams.css` is 569 LOC (over the 500 soft target)

The design doc set a 500 LOC soft budget for `diagrams.css`. Final size is 569. Per the design's own escape clause ("report the final size and why the added lines are necessary rather than compressing readability"), the breakdown:

- ~45 lines: header comment + base wrapper + sr-only helper
- ~165 lines: Primitive 1 (governance propagation) — three-row layout, fan-out bus, equivalence note, mobile collapse
- ~85 lines: Primitive 2 (enforcement checkpoints) — bracketed row, 5 step variants (active / gate / muted), mobile collapse
- ~150 lines: Primitive 3 (provenance chain) — 6-link grid, source/active variants, citation trailer (label + lines + summary), mobile collapse
- ~85 lines: Primitive 4 (architectural drift cascade) — tier grid, 5 schematic bar-width variants, mobile collapse + documentation comment on the rgba derivation
- ~39 lines: media-query bodies and inter-block comments

No compression would improve clarity. The four primitives together are now the canonical visual language; the 500 was a soft ceiling, not a hard limit. Future primitives, if any, are expected to extend rather than replace these — atomization (extracting shared `__node` / `__arrow` / `__caption` rules) is deferred to a follow-up cleanup PR per the design.

## Verification

### Theme + scoping discipline

- Scoping invariant: every selector in `diagrams.css` is scoped under `.mneme-diagram` (or a class that only appears inside `.mneme-diagram` markup). Verified by `grep -E '^[^/{}* @].*{' diagrams.css | grep -v '^\.mneme-diagram'` returning no matches.
- Hex literals in declarations: only `#0c0c0d` at lines 91 and 281 (both documented gate-text uses; `#a8a8b8` appears only inside an explanatory CSS comment about the rgba derivation from `--muted`). All other colors use `var(--token)` or documented `rgba()` tints of token hex values.
- No new `:root` variables introduced.

### `mneme check --mode warn`

Baseline comparison on `origin/main` vs HEAD for the four pre-existing concept pages, plus the two new files:

| File | Origin/main | HEAD | Note |
|---|---|---|---|
| `site/concepts/governance-propagation/index.html` | FAIL | FAIL | Identical noise; not introduced by this PR |
| `site/concepts/governance-before-generation/index.html` | FAIL | FAIL | Identical noise; not introduced by this PR |
| `site/concepts/enforcement-provenance/index.html` | FAIL | FAIL | Identical noise; not introduced by this PR |
| `site/concepts/architectural-drift/index.html` | FAIL | FAIL | Identical noise; not introduced by this PR |
| `site/assets/css/diagrams.css` | (new) | FAIL | Keyword-trigger noise: CSS comments contain words like "governance" and "enforcement" |
| `docs/contributing/diagram-conventions.md` | (new) | PASS | Clean |

These FAILs are pre-existing keyword-trigger noise on governance vocabulary, not real governance violations. `mneme check` runs in `warn` mode and never blocks merge (see `.mneme/README.md` rollout plan). The new files inherit the same shape of keyword noise; no actual governance regression has been introduced.

### `scripts/seo_check.py`

| Page | Pass | Warn | Fail |
|---|---|---|---|
| `/concepts/governance-propagation/` | 20 | 1 | 0 |
| `/concepts/governance-before-generation/` | 20 | 1 | 0 |
| `/concepts/enforcement-provenance/` | 20 | 1 | 0 |
| `/concepts/architectural-drift/` | 20 | 1 | 0 |

The single warn per page is `style.classes: undefined CSS classes` — the SEO scanner parses only inline `<style>` blocks and does not follow the external `diagrams.css` link. The classes are defined; the scanner is blind to the external sheet. No fails introduced.

### Visual smoke (headless preview, three widths)

All four primitives verified at 1024 / 640 / 360 viewports via the local preview MCP. Shared chrome on every primitive:
- Background `rgb(20, 20, 22)` (= `--surface`)
- Border `rgb(34, 34, 38) 1px` (= `--border`)
- Border-radius 10px
- Padding 24px
- Font-family Inter, color `rgb(232, 232, 236)` (= `--text`)

Mobile collapse (≤640px) verified for each: pipeline / row / chain all reduce to single-column grids; horizontal connectors hide where they no longer apply; no horizontal scroll; no overflow. Cascade primitive's tier grid (already vertical) reduces session-column width and label size for narrow viewports.

### No collateral damage

- Exactly 6 files touched (2 added, 4 modified).
- `schema.org` / `application/ld+json` blocks: untouched on every page.
- Breadcrumb / nav markup: untouched.
- `<head>` meta tags: untouched (only the new `<link rel="stylesheet" href="/assets/css/diagrams.css">` was added).
- Phase 2 `.concept-metadata` blocks: untouched.
- SVGs outside the four canonical pages: untouched. The strategic SVG on `/concepts/governance-before-generation/` is the only legacy SVG kept on a touched page (keep-both decision); its internal `<title>` / `<desc>` / `<g>` are unmodified, only its outer-figure `aria-labelledby` was dropped to bring it in line with the new ARIA strategy.

### Accessibility

Per-primitive ARIA convention applied uniformly:
- Outer `<figure>` derives accessible name natively from `<figcaption>` (no redundant `aria-labelledby` on the figure).
- Inner `<div role="img">` carries `aria-labelledby` to both the visible title `<p>` id and a screen-reader-only description `<p>` id.
- All visible text is real, selectable, indexable HTML.
- DOM order matches visual reading order at all widths.
- No motion, no keyboard interaction, no information conveyed by color alone.

## What is NOT in this PR

- Insight, demo, or compare-page embeds of the four primitives. Follow-up PR after the visual language is validated; the design lists the ~14 candidate embedding sites.
- Atomization of primitives into shared `__node` / `__arrow` / `__caption` rules. Deferred until real reuse patterns emerge across embed sites.
- Site-wide SVG cleanup. The ~30 SVGs on pages outside the four canonical homes stay as-is.
- Full shared-stylesheet refactor (`base.css` + `shared.css`). Stays deferred per the existing memory note.
- Schema.org / breadcrumb / head-meta changes.
- The Phase 2 `.concept-metadata` block.

## Test plan

- [ ] Open each of the four canonical concept pages in a real browser and confirm the primitive renders at desktop, tablet, and mobile widths.
- [ ] Verify the keep-both treatment on `/concepts/governance-before-generation/` reads coherently (strategic SVG above the connecting paragraph; operational primitive below).
- [ ] Confirm the cascade figcaption's `/benchmark/` link resolves.
- [ ] Inspect the page via DevTools Accessibility tab: outer `<figure>` accessible name from `<figcaption>`; inner `role="img"` aria-labelledby resolves to both title and sr-desc IDs.
- [ ] Spot-check that PageSpeed Insights / Core Web Vitals are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)