### PR TITLE
fix: declare PyYAML runtime dependency

### DIFF
--- a/mneme-project-memory/pyproject.toml
+++ b/mneme-project-memory/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.25.0",
     "python-dotenv>=1.0.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Root cause

`mneme/adr_parser.py` does a top-level `import yaml`, but PyYAML was absent from the project's declared runtime dependencies. On a fresh CI runner `pip install -e mneme-project-memory` succeeded but PyYAML was never installed, so `python -m mneme.cli` crashed at import time with `ModuleNotFoundError: No module named 'yaml'` — producing UNKNOWN verdicts on every file in [PR #110](https://github.com/TheoV823/mneme/pull/110)'s mneme-check run (the run that #102 made visible).

Local dev environments masked the gap because PyYAML was installed as a transitive of unrelated tools.

## Change

One line in `mneme-project-memory/pyproject.toml`:

```toml
dependencies = [
    "anthropic>=0.25.0",
    "python-dotenv>=1.0.0",
+   "PyYAML>=6.0",
]
```

## Scope

- No code paths touched.
- No governance, benchmark, retrieval, or CLI semantics changed.
- No README/ADR/site/docs edits.
- No test infrastructure changes (intentionally out of scope per direction).

## Validation

Clean-venv reproduction:

```
$ python -m venv /tmp/v && /tmp/v/bin/python -c "import yaml"
ModuleNotFoundError: No module named 'yaml'

$ /tmp/v/bin/python -m pip install -e mneme-project-memory
$ /tmp/v/bin/python -c "import yaml; print(yaml.__version__)"
6.0.3

$ /tmp/v/bin/python -m mneme.cli --help
usage: mneme [-h] {list_decisions,add_decision,test_query,check,cursor,benchmark,adr} ...

$ /tmp/v/bin/python -m mneme.cli check --memory .mneme/project_memory.json \
    --input site/insights/<file>.html --query "..." --mode warn
... Result: FAIL    # real verdict, not UNKNOWN
```

## Note on this PR's own CI run

The mneme-check workflow's path filter scopes to `mneme-project-memory/mneme/`, `docs/adr/`, `.mneme/`, `site/`, `scripts/`. `mneme-project-memory/pyproject.toml` is outside that filter, so this PR's own mneme-check run will hit the no-files-in-scope branch and won't directly exercise the fix. The fix was validated in the clean-venv reproduction above; the in-the-wild confirmation will arrive on the next in-scope PR (UNKNOWN should drop to 0).