### PR TITLE
site: complete sticky-nav mobile fix (59 files missed by a9d27a3)

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -62,7 +62,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav { position: relative; padding: 1rem 1.25rem; }
+  nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -457,7 +457,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -157,7 +157,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -158,7 +158,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -65,7 +65,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important; flex-direction: column; position: absolute;

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -148,7 +148,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/agent-verification/index.html
+++ b/site/concepts/agent-verification/index.html
@@ -115,7 +115,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -131,7 +131,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -164,7 +164,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/ai-operating-layer/index.html
+++ b/site/concepts/ai-operating-layer/index.html
@@ -153,7 +153,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -161,7 +161,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -162,7 +162,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -125,7 +125,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/executable-architectural-intent/index.html
+++ b/site/concepts/executable-architectural-intent/index.html
@@ -152,7 +152,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/execution-surfaces/index.html
+++ b/site/concepts/execution-surfaces/index.html
@@ -109,7 +109,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -156,7 +156,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -165,7 +165,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -127,7 +127,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/governance-provenance/index.html
+++ b/site/concepts/governance-provenance/index.html
@@ -116,7 +116,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -75,7 +75,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/intent-debt/index.html
+++ b/site/concepts/intent-debt/index.html
@@ -131,7 +131,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -163,7 +163,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -124,7 +124,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/objective-driven-development/index.html
+++ b/site/concepts/objective-driven-development/index.html
@@ -144,7 +144,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -125,7 +125,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/concepts/reliable-delegation/index.html
+++ b/site/concepts/reliable-delegation/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -155,7 +155,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -351,7 +351,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -190,7 +190,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -184,7 +184,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -192,7 +192,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -175,7 +175,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -253,7 +253,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -191,7 +191,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -125,7 +125,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+      nav.site-nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -103,7 +103,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav { position: relative; padding: 1rem 1.25rem; }
+  nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -134,7 +134,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -122,7 +122,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -134,7 +134,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -399,7 +399,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/index.html
+++ b/site/index.html
@@ -776,7 +776,6 @@
       html, body { overflow-x: clip; }
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -151,7 +151,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -134,7 +134,7 @@
 
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -164,7 +164,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -146,7 +146,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -234,7 +234,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -150,7 +150,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -343,7 +343,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: clip; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links {
         display: flex !important;

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -152,7 +152,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav { position: relative; padding: 1rem 1.25rem; }
+  nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -155,7 +155,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -123,7 +123,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav { position: relative; padding: 1rem 1.25rem; }
+  nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -122,7 +122,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+  nav.site-nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -123,7 +123,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+  nav.site-nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -122,7 +122,7 @@
 @media (max-width: 900px) {
   html, body { overflow-x: clip; }
   body.menu-open { overflow: hidden; }
-  nav.site-nav { position: relative; padding: 1rem 1.25rem; }
+  nav.site-nav { padding: 1rem 1.25rem; }
   .nav-hamburger { display: flex; }
   .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
   .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -225,7 +225,6 @@
     @media (max-width: 640px) {
       nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
-      nav { position: relative; }
       .nav-links {
         display: none;
         position: absolute;


### PR DESCRIPTION
## Summary
- Removes two CSS bug variants that prior fix [a9d27a3](https://github.com/TheoV823/mneme/commit/a9d27a3) missed, which still demote the main top nav from sticky on viewports under 900px.
- 49 files: `nav { position: relative; padding: 1rem 1.25rem; }` inside `@media (max-width: 900px)` (overrides the desktop `position: sticky`).
- 10 files: orphan `nav { position: relative; }` lines inside `@media (max-width: 640px)`.
- After this PR, both remaining patterns are at zero occurrences site-wide.

## Why this happened
This is the third attempt at the fix ([e5970e2](https://github.com/TheoV823/mneme/commit/e5970e2), [a9d27a3](https://github.com/TheoV823/mneme/commit/a9d27a3), now this one). The cycle suggests the page-generation template or script still emits the buggy CSS block when new pages are added, so each new wave of pages reintroduces the bug. **Follow-up worth filing:** locate the source template and patch it there to make the fix stick.

## Test plan
- [ ] Open any concept/insight/use-case page on a viewport &le; 900px and confirm the top site nav stays sticky as the page scrolls.
- [ ] `grep -rE 'nav \{ position: relative' site/` returns no matches.
- [ ] No visual regressions on desktop (the changes are mobile-only).

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)