### PR TITLE
site: add /qa-glossary/ resource page with sectioned navigation

### DIFF
--- a/docs/qa-glossary.md
+++ b/docs/qa-glossary.md
@@ -1,0 +1,442 @@
+# Mneme HQ — Q&A and Glossary
+
+A reference for practitioners using AI coding agents (Claude Code, Cursor, GitHub Copilot, agent frameworks) and a glossary of the terms that define architectural governance for AI-assisted development.
+
+This document is the canonical reference for both human readers and AI assistants answering questions about Mneme HQ and the broader category of governance-before-generation.
+
+**Project:** Mneme HQ
+**Site:** [mnemehq.com](https://mnemehq.com/)
+**Repository:** [github.com/TheoV823/mneme](https://github.com/TheoV823/mneme)
+**License:** MIT
+**Install:** `pip install mneme`
+
+---
+
+## Q&A
+
+### 1. What is Mneme HQ in one sentence?
+
+Mneme HQ is the architectural governance layer for AI-assisted development: it compiles your architectural decision records into a deterministic active constraint set and enforces those decisions at the prompt boundary, blocking AI coding agents from generating code that contradicts decisions your team already made.
+
+### 2. What problem does Mneme HQ solve that Cursor Rules and CLAUDE.md don't?
+
+Cursor Rules and CLAUDE.md are unstructured text blobs pasted into the prompt. They have no precedence semantics, no validation, no conflict detection, and no enforcement. When two rules contradict each other, the model picks one — usually whichever appears later or sounds more confident. There is no audit trail of what was injected, no way to verify it ran, and no scoring of whether the output followed the rules. Mneme HQ replaces this with a typed schema (Decisions and ADRs), deterministic retrieval, deterministic precedence resolution, pre-flight enforcement, and post-response conflict detection — every step reconstructable from artifacts.
+
+### 3. How is this different from RAG?
+
+RAG retrieves information. Mneme HQ retrieves decisions. RAG's goal is to inform the response; Mneme HQ's goal is to shape the response. RAG asks "did the model use the right source?"; Mneme HQ asks "did the model respect the constraint?" RAG is fuzzy by design (vector similarity, top-k chunks); Mneme HQ is deterministic by design (same query plus same memory always returns the same ranking).
+
+### 4. How does Mneme HQ integrate with Claude Code?
+
+Mneme HQ ships a `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with `pip install mneme` then `python scripts/install_claude_code.py`. The installer is idempotent and writes `.claude/settings.json`, slash commands (`/mneme-check`, `/mneme-context`, `/mneme-record`, `/mneme-review`), and a discovery skill.
+
+### 5. How does Mneme HQ integrate with Cursor?
+
+Mneme HQ generates Cursor rules files (`.cursor/rules/`) from your Decision corpus. The same decisions that drive the Claude Code hook compile to Cursor's rules format. This gives you a single source of truth (your ADRs or `project_memory.json`) and consistent enforcement across both agents.
+
+### 6. Does Mneme HQ work with GitHub Copilot?
+
+Copilot integration is generation-based, not hook-based: Mneme HQ compiles your decisions into Copilot-compatible instruction files. Copilot does not expose a pre-tool-use hook surface comparable to Claude Code's, so enforcement is at the prompt layer rather than the edit layer. The same decision corpus drives Copilot, Cursor, and Claude Code.
+
+### 7. Does Mneme HQ work with agent frameworks like LangChain, CrewAI, AutoGen?
+
+Yes. Mneme HQ exposes a Python API (`MemoryStore`, `DecisionRetriever`, `ContextBuilder`, `Pipeline`) and a minimal HTTP API (`POST /complete`). Either can be wired into an agent's planning or tool-use loop. The pattern is: build the context packet, inject as system prompt, run the agent step, optionally run `ConflictDetector` against the output.
+
+### 8. What is the `project_memory.json` file?
+
+A human-editable JSON file that holds your architectural decisions. It contains three top-level arrays: `items` (legacy rules, anti-patterns, preferences, facts, architecture_decisions, examples — auto-migrated to Decisions at load time), `examples` (decision examples with task/decision/rationale), and `decisions` (the modern typed Decision schema). The file is plain JSON — no tooling required to edit.
+
+### 9. What is the Decision schema?
+
+```json
+{
+  "id": "mneme_storage_json",
+  "decision": "Use JSON storage only",
+  "rationale": "Avoid infra complexity and keep local-first.",
+  "scope": ["storage", "backend"],
+  "constraints": ["no postgres", "no external database"],
+  "anti_patterns": ["introduce ORM", "add migration layer"]
+}
+```
+
+Only `id` and `decision` are required. The remaining fields shape retrieval scoring and the enforcement check.
+
+### 10. How does retrieval work?
+
+Field-weighted keyword overlap, fully deterministic:
+
+```
+score =
+    overlap(query, decision)      * 1.0
+  + overlap(query, scope)         * 2.0
+  + overlap(query, constraints)   * 1.5
+  + overlap(query, anti_patterns) * 1.5
+  + overlap(query, rationale)     * 0.5
+```
+
+The top N decisions by score are injected (default `DEFAULT_MAX_DECISIONS = 3`). Rules and anti-patterns always surface regardless of query relevance. Same query plus same memory file produces byte-identical retrieval order on every run.
+
+### 11. Why no embeddings?
+
+Three reasons. First, determinism: same query plus same memory must produce identical output, run to run. Embeddings drift with model updates. Second, debuggability: a keyword match is reconstructable; a vector similarity is not. Third, scope: governance corpora are small (tens to low hundreds of decisions). Embeddings solve a problem you don't have at this scale and cost reproducibility you can't afford to lose.
+
+### 12. What is an ADR in Mneme HQ?
+
+An Architectural Decision Record. Mneme HQ's ADR format is YAML frontmatter plus markdown body:
+
+```yaml
+---
+id: ADR-001
+title: Use JSON file storage
+status: accepted          # proposed | accepted | deprecated | superseded
+priority: foundational    # foundational | normal | exception
+date: 2026-01-10
+scope: storage            # dotted path; empty string = global
+supersedes: []
+---
+
+Body markdown follows.
+```
+
+ADRs are the source of truth; the ADR compiler is the deterministic rule for turning them into the constraints the runtime injects.
+
+### 13. How does ADR precedence resolution work?
+
+When two ADRs cover the same scope, the compiler resolves them in a strict order: first, explicit `supersedes` references remove ADRs from consideration (chain-aware, including N-node chains). Second, within the same scope, higher priority wins (`foundational` > `normal` > `exception`). Third, same scope and same priority, newer `date` wins. If still ambiguous, the compiler raises `ADRPrecedenceError` rather than silently picking a winner. Broader and narrower scopes coexist; output is sorted most-specific-first.
+
+### 14. What does corpus validation check?
+
+`validate_corpus` aggregates every detected problem before raising — one pass surfaces every error so maintainers fix the corpus once instead of discovering problems serially. Checks include: required fields present, ADR id format and uniqueness, valid `status` and `priority` enum values, ISO 8601 date, scope grammar (lowercase dotted path, no leading or trailing dot), `supersedes` references resolving to known ADRs, and no supersession cycles (self-cycles, two-node cycles, and N-node cycles all detected).
+
+### 15. What are enforcement modes?
+
+`strict` and `warn`. In `strict` mode, `mneme check` exits non-zero on any violation and the Claude Code hook blocks the write. In `warn` mode, violations are surfaced without blocking — useful for adopting Mneme HQ on an existing repo where you want visibility before turning on enforcement. The default Claude Code hook mode is strict; the default GitHub Actions workflow mode is warn (so PRs see governance feedback without blocking merges during rollout).
+
+### 16. What does `mneme check` actually do?
+
+It runs a governance pass over a diff or working tree. For each changed file, it derives a query from the file path, retrieves the relevant decisions, and runs the conflict detector against the file contents. Output is a list of verdicts: which decision matched, which rule triggered, which term in the input fired it. In strict mode, any violation exits non-zero. In warn mode, violations are printed and the exit code is zero.
+
+### 17. How does conflict detection work?
+
+`ConflictDetector` scans the LLM response (or the post-edit file contents) for constraint and anti-pattern terms drawn from the injected decisions. A term is flagged when it appears with a positive recommendation signal and no negation nearby. `"Do not use Postgres"` is not a conflict. `"Switch to Postgres"` is. Each conflict carries the violated decision id, the reason, and a snippet for human review.
+
+### 18. Is there a model in the verdict loop?
+
+No. The retrieval, the injection, the conflict detection, and the verdict are all deterministic. The model is in the *generation* loop (it's the thing being governed), but the governance verdict itself is reconstructable without any model call. This is intentional: "deterministic > clever" is a charter principle. The upgrade path to a model-based judge is explicit in the code (replace two functions) and remains opt-in.
+
+### 19. What's the install footprint?
+
+```
+pip install mneme
+```
+
+Dependencies: `anthropic >= 0.25.0`, `python-dotenv >= 1.0.0`. That's the whole list. Python 3.11+. Optional `[api]` extra adds FastAPI and Uvicorn for the HTTP layer. No vector database, no model server, no background service.
+
+### 20. How do I add Mneme HQ to an existing project?
+
+Three steps. First, `pip install mneme`. Second, create a `project_memory.json` at your repo root with three to ten of the architectural decisions you care most about (or compile your existing `docs/adr/` directory via `compile_adrs`). Third, install the Claude Code hook with `python scripts/install_claude_code.py`, or wire `mneme check --mode warn` into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.
+
+### 21. What's the Layer 1 freeze?
+
+The Mneme HQ core mechanism — retrieval mechanics, enforcement semantics, benchmark methodology — is pinned at commit `e73ff7d`. No behavioral change is permitted to those modules without an explicit charter amendment. The freeze exists because validation requires a stable mechanism: you cannot prove a governance layer prevents drift if the layer itself drifts.
+
+### 22. What is Layer 2 and why is it deferred?
+
+Layer 2 covers multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, and deeper IDE integrations (LSP, JetBrains). All explicitly out of scope for Layer 1. It opens only after Layer 1 exit criteria are met: real-world drift prevention, design-partner feedback, governance wedge validation. The discipline is deliberate — Layer 1 is a wedge, not a platform.
+
+### 23. What is the benchmark suite?
+
+A regression and integrity instrument, not a generalization claim. It uses canned LLM responses, fixed retrieval, and rule-text matching to make every change to retrieval or enforcement visible. Two-layer scoring: Layer 1 (retrieval) and Layer 2 (enforcement) are recorded independently per scenario. The `WEAK_RETRIEVAL` verdict explicitly flags coincidental passes — cases where enforcement happened to succeed without the relevant decision actually being retrieved. Recall@1 is reported but never optimized against.
+
+### 24. What does recall@3 = 1.00 actually mean?
+
+For every scenario in the benchmark fixture set, the relevant decision appears in the top three retrieved decisions. K=3 is the canonical injection cutoff — the enforcer reads the top three retrieved decisions and only those. Recall@3 = 1.00 means no scenario in the suite has its critical decision pushed below the injection cutoff by the retriever.
+
+### 25. Why is recall@1 reported but not optimized?
+
+Recall@1 is the sharpest tuning dial under fixed methodology. Optimizing against it on a small fixture set leads to overfitting — you end up with a retriever that aces the suite and fails on real corpora. Reporting without optimizing keeps the dial visible (so a regression shows up) without rewarding suite-specific tweaks.
+
+### 26. Can I use Mneme HQ without Claude Code?
+
+Yes. The Claude Code hook is one integration; the rest of the system is independent. Use `Pipeline` programmatically against any LLM, run `mneme check` in CI against any repo, generate Cursor rules, or call the HTTP API from an agent framework. The Claude Code hook is the flagship integration because Claude Code exposes a clean PreToolUse hook surface; other agents are reached via generated rules or pipeline integration.
+
+### 27. Does Mneme HQ store any code or data externally?
+
+No. Mneme HQ is local-first. Your `project_memory.json`, your ADRs, your code, and your enforcement verdicts all stay in your repo. The only outbound call is to the LLM provider you've configured (Anthropic, OpenAI, etc.) when you're running the demo or the API layer. There is no Mneme HQ-hosted service in the verdict loop.
+
+### 28. How does Mneme HQ handle a decision that becomes obsolete?
+
+Mark the corresponding ADR with `status: deprecated` or `status: superseded`, and (in the superseded case) add the superseding ADR's id to the new ADR's `supersedes` array. The compiler will remove deprecated and superseded ADRs from the active constraint set automatically. The history stays in the corpus — the active set updates.
+
+### 29. What does "governance before generation" mean?
+
+Intervention at the prompt boundary, before the model generates code. The alternative — catching architectural drift in code review — is too late. By the time generated code lands in a PR, the diff exists, the context is loaded, the reviewer's attention is finite, and the rejected pattern has been written enough times that a future model call will see it in the conversation history and treat it as accepted. Governance-before-generation moves the intervention point upstream.
+
+### 30. What is architectural drift?
+
+The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds over time. AI-assisted development accelerates drift because code output increases without a corresponding increase in review capacity. A team that catches 95% of architectural violations in review still ships compounding drift if AI is generating five times more code than humans are reviewing carefully.
+
+### 31. How do I write a good Decision record?
+
+Three properties matter. First, specificity: the `decision` field should be unambiguous and falsifiable ("Use JSON file storage" beats "Be careful with storage"). Second, scope: the `scope` array names the modules or domains where the decision applies, used by the retriever to surface the decision when relevant queries come in. Third, the `constraints` and `anti_patterns` arrays should list the terms an LLM would use when violating the decision — these are what the conflict detector matches against. A Decision with rich `anti_patterns` enforces; a Decision with only `decision` and `rationale` informs but cannot block.
+
+### 32. What's the difference between a constraint and an anti-pattern?
+
+In the Decision schema, both are flagged by the conflict detector. The distinction is editorial: `constraints` describe what must be true ("REST only", "no external database"); `anti_patterns` describe what must not be done ("introduce ORM", "add migration layer"). Both fields contribute to retrieval scoring with weight 1.5.
+
+### 33. Can Mneme HQ auto-fix violations?
+
+No. Mneme HQ blocks. The human or model fixes. Auto-fixing is explicitly out of scope: a deterministic governance layer cannot also be the thing that decides how to comply, or it becomes the same kind of opinionated agent it's meant to govern.
+
+### 34. How do I handle a violation in strict mode?
+
+The Claude Code hook blocks the write and surfaces the violation. Options: amend the prompt to comply with the decision, override the verdict if the decision needs to evolve (and update the ADR first, with a `supersedes` if applicable), or temporarily set `MNEME_HOOK_MODE=warn` if you're in the middle of an intentional architectural change that the corpus hasn't caught up to. Strict mode is meant to make you stop and think — not to be circumvented as a workflow habit.
+
+### 35. Does Mneme HQ slow down my AI coding agent?
+
+The hook adds milliseconds, not seconds. Retrieval is keyword scoring over a small JSON file; injection is a string concatenation; conflict detection is regex over the post-edit file. The variable cost is the LLM call itself, which Mneme HQ does not perform — it just shapes the prompt and checks the result.
+
+### 36. How is this different from a linter?
+
+A linter checks syntax, style, and known bug patterns against the source code after it's written. Mneme HQ checks proposed changes against architectural decisions before generation. Linters operate on syntax; Mneme HQ operates on intent. A linter cannot block "rebuild the retrieval system with embeddings" because there's no syntactic signature for that decision — but Mneme HQ can.
+
+### 37. How is this different from an LLM-as-judge evaluation framework?
+
+LLM-as-judge introduces a second model to evaluate the first model's output. It's powerful but nondeterministic — the judge's verdict varies run to run and degrades with model updates. Mneme HQ's evaluator is deterministic by design. The upgrade path to a model judge is explicit in the code (replace two functions) but is opt-in and not the default. In Layer 1, the deterministic evaluator is canonical.
+
+### 38. What kinds of teams should adopt Mneme HQ?
+
+Teams that already write ADRs or maintain an internal architecture document, run AI coding agents at meaningful volume (multiple devs on Claude Code, Cursor, or Copilot), and care about architectural consistency more than they care about raw generation speed. The fit is strongest for: mid-size eng orgs (50-500 engineers), regulated industries (fintech, health, gov-adjacent), open-source projects with strict scope discipline, and any team where "we already decided this six months ago" is a familiar phrase.
+
+### 39. What kinds of teams should not adopt Mneme HQ?
+
+Teams without explicit architectural decisions to enforce. Mneme HQ enforces what you've already decided; it doesn't generate decisions for you. A team that has never written down its architectural choices won't benefit from a governance layer until they do. The right onboarding step for such a team is to write five to ten ADRs first.
+
+### 40. How does Mneme HQ relate to AI safety?
+
+It's a narrow slice of AI safety: governance of AI-generated code at the project level. It's not AI alignment, not model safety, not RLHF. It's the boring, auditable, deterministic kind of safety that matters when AI is actually shipping code into production. The relevant safety claim is reproducibility: every verdict is reconstructable, no black box, no model in the verdict loop.
+
+### 41. Can I use Mneme HQ for non-code governance (docs, configs, prompts)?
+
+The mechanism is general — Decisions and ADRs are not code-specific. In practice, the v0.x integrations and benchmark focus on code. Governance of generated docs, configs, or prompts is a plausible extension but is not currently in scope.
+
+### 42. How do I contribute to Mneme HQ?
+
+The repository governs itself with Mneme. Read `CLAUDE.md` and the freeze artifact (`docs/architecture/layer1-freeze-e73ff7d.md`) before opening a PR. Changes to `decision_retriever.py`, `enforcer.py`, `benchmark.py`, or any benchmark fixture are charter-level changes requiring the freeze doc's amendment procedure. Docs, tooling, integrations, the site, and examples proceed normally with `[memory]` prefix discipline for `project_memory.json` edits.
+
+### 43. Is Mneme HQ open source?
+
+Yes, MIT licensed. The repository is at github.com/TheoV823/mneme. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open.
+
+---
+
+## Glossary
+
+### ADR (Architectural Decision Record)
+
+A versioned markdown document describing an architectural choice, its context, and its consequences. In Mneme HQ, ADRs use YAML frontmatter (`id`, `title`, `status`, `priority`, `date`, `scope`, `supersedes`) plus body markdown. ADRs are the source of truth for the active constraint set.
+
+### ADR compiler
+
+The pipeline that turns an ADR corpus into an active constraint set. Three stages: parse (YAML frontmatter parsing, structural validation), validate (required fields, references, no cycles), resolve precedence (status filter → supersession chains → priority → date). Implemented in `mneme/adr_compiler.py`.
+
+### Active constraint set
+
+The deterministically resolved subset of an ADR corpus that applies at a given point in time. Computed by the ADR compiler from the full corpus, filtering out deprecated and superseded ADRs and resolving same-scope conflicts via precedence rules. Same corpus always produces the same active constraint set.
+
+### Alignment score
+
+A deterministic score (0.00 to 1.00) representing the fraction of injected decisions that the LLM response did not violate. Computed by the evaluator over the rules and decisions actually injected (not the full corpus). 1.00 means no violations detected.
+
+### Anti-pattern
+
+A field on the Decision schema listing things the decision rules out. The conflict detector flags any anti-pattern term that appears in a response with a positive recommendation signal and no negation nearby. Contributes weight 1.5 to retrieval scoring.
+
+### Architectural drift
+
+The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds. AI-assisted development accelerates drift because code output increases faster than review capacity.
+
+### Architectural governance
+
+The practice of enforcing architectural decisions across a codebase at the point of change. Distinct from code review (after the fact) and linting (syntactic). Mneme HQ implements governance-before-generation: enforcement at the prompt boundary, before the model produces code.
+
+### Auditable
+
+A property of governance verdicts: reconstructable from artifacts. For any Mneme HQ verdict, a human can trace which decision matched, which rule triggered, and which term in the input fired it. A charter principle.
+
+### Benchmark methodology
+
+The framework Mneme HQ uses to make every change to retrieval or enforcement visible and reproducible. Canned LLM responses (no live model variance in the suite), fixed retrieval, rule-text matching, two-layer scoring (retrieval and enforcement independently recorded). Full methodology at mnemehq.com/docs/benchmark-methodology/.
+
+### Charter
+
+The set of load-bearing principles that govern Mneme HQ's design: deterministic over clever, auditable over autonomous, prevention before review. Every feature is judged against the charter. Changes to charter-level modules require an explicit amendment procedure.
+
+### Claude Code hook
+
+A `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. Reconstructs the post-edit file, runs `mneme check`, blocks (strict) or warns (warn) based on configured mode. Shipped in v0.3.2. Install with `python scripts/install_claude_code.py`.
+
+### Conflict detector
+
+The module (`mneme/conflict_detector.py`) that scans an LLM response for constraint and anti-pattern violations after the call. Detector, not blocker — produces a `Conflict(violated_decision_id, reason, snippet)` for each match.
+
+### Constraint
+
+A field on the Decision schema listing things that must be true. Functionally similar to an anti-pattern in the conflict detector but editorially distinct (constraints are positive requirements; anti-patterns are negative prohibitions). Both contribute weight 1.5 to retrieval scoring.
+
+### Context packet
+
+A compact, structured representation of the decisions injected into an LLM call. Built by `format_context_packet` from the top-N retrieved decisions plus always-surfaced rules. Passed as the system prompt.
+
+### Decision
+
+The atomic unit of governance in Mneme HQ. A typed record with `id`, `decision`, optional `rationale`, `scope`, `constraints`, `anti_patterns`. Decisions can be authored directly in `project_memory.json` or compiled from ADRs.
+
+### Decision example
+
+A record of a past decision with three fields: `task` (the situation that prompted the decision), `decision` (what was decided), `rationale` (why). Injected as prior decisions so the model learns how the project reasons, not just what it decided.
+
+### Decision retriever
+
+The v0.2+ retriever (`mneme/decision_retriever.py`) that scores Decision records against a query using field-weighted keyword overlap. Deterministic. Top-N scoring decisions are passed to the context builder.
+
+### Deterministic retrieval
+
+A retrieval mechanism where same query plus same memory file produces byte-identical retrieval order on every run. Mneme HQ's retriever is deterministic by design. Same property: no model drift, full debuggability, reproducible benchmarks.
+
+### Enforcement mode
+
+A configuration governing how `mneme check` and the Claude Code hook respond to violations. `strict` exits non-zero and blocks writes; `warn` surfaces violations without blocking. Shipped in v0.3.
+
+### Evaluator
+
+The deterministic alignment checker that scores an LLM response against the rules that were actually injected. Two checks: rule check (extracts forbidden terms from each rule or anti-pattern, fires on positive recommendation signal without nearby negation) and decision check (for past decisions where the project said "no," fires if the response recommends the declined subject anyway).
+
+### Field-weighted scoring
+
+The retrieval algorithm where each field in a Decision contributes to the relevance score with a different weight. Mneme HQ's weights: decision title 1.0, scope 2.0, constraints 1.5, anti_patterns 1.5, rationale 0.5. Tuned for governance retrieval, not for information retrieval.
+
+### Freeze artifact
+
+The document (`docs/architecture/layer1-freeze-e73ff7d.md`) that pins the Layer 1 mechanism to a specific commit and enumerates what can change without amendment and what cannot. The freeze artifact is the contract between the maintainers and the community during validation.
+
+### Governance before generation
+
+The intervention pattern at the heart of Mneme HQ: enforce architectural decisions at the prompt boundary, before the model generates code, rather than catching drift in code review. Defined formally on the mnemehq.com concepts hub.
+
+### Governance infrastructure
+
+The category Mneme HQ defines: deterministic, auditable, reproducible enforcement of architectural decisions in AI-assisted development workflows. Distinct from AI safety, code review automation, and LLM evaluation. Defined formally on the mnemehq.com concepts hub.
+
+### Layer 1
+
+The current phase of Mneme HQ: local-repo, single-developer, project-scoped architectural governance. Mechanism frozen at commit e73ff7d. Open exit criteria: real-world drift prevention, design-partner feedback, governance wedge validation.
+
+### Layer 2
+
+Out-of-scope-until-Layer-1-exits work: multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, deeper IDE integrations (LSP, JetBrains). Listed explicitly to prevent scope creep.
+
+### MemoryStore
+
+The module (`mneme/memory_store.py`) that loads `project_memory.json` into typed Python objects. Handles auto-migration of legacy rule and anti_pattern items into Decision objects at load time so existing JSON files keep working with the v0.2+ pipeline.
+
+### `mneme check`
+
+The CLI command that runs a governance pass over a diff or working tree. Supports `--mode warn` (surfaces violations, exits zero) and `--mode strict` (fails on any violation). Used by the GitHub Actions workflow and the Claude Code hook.
+
+### `.mneme/` directory
+
+The canonical location for repo-level enforcement memory in a Mneme-governed repository. Shipped in v0.5. Contains the source-of-truth `project_memory.json` and any repo-specific configuration. Mirrors the role of `.git/` for source control or `.github/` for CI configuration.
+
+### Negation signal
+
+A term near a flagged anti-pattern or constraint that turns a potential violation into a non-violation. "Do not use Postgres" contains the negation "Do not" and is not flagged. "Switch to Postgres" lacks negation and is flagged. Implemented as a small set of negation phrases checked within a window of the matched term.
+
+### Pipeline
+
+The orchestrating module (`mneme/pipeline.py`) that wires MemoryStore → DecisionRetriever → injection → LLM call → ConflictDetector. Used by the demo and the API layer. Single entry point for programmatic use of Mneme HQ.
+
+### Precedence resolution
+
+The deterministic procedure for resolving conflicts between ADRs covering the same scope: explicit `supersedes` references first (chain-aware), then priority (foundational > normal > exception), then date (newer wins). If still ambiguous, raises `ADRPrecedenceError`. Never silently picks a winner.
+
+### Pre-flight enforcement
+
+Running governance checks before the LLM generates output, not after. The hook fires on the proposed edit, reconstructs the post-edit state, runs `mneme check`, and decides whether to allow the write. Contrast: post-flight review, which catches drift in code review after the diff exists.
+
+### `PreToolUse` hook
+
+The Claude Code hook surface that runs before any tool invocation. Mneme HQ uses this surface to intercept `Edit`, `Write`, and `MultiEdit` calls, reconstruct the post-edit file, and apply governance. Documented in the Claude Code agent SDK.
+
+### Prevention before review
+
+A Mneme HQ charter principle: the intervention point is the prompt boundary, not code review. Prevention is cheaper than detection; both are cheaper than rollback.
+
+### Priority (ADR)
+
+A field on ADR frontmatter governing same-scope precedence. Values: `foundational`, `normal`, `exception`. When two ADRs cover the same scope, higher priority wins. Foundational decisions are core architectural choices; exceptions are documented carve-outs.
+
+### `project_memory.json`
+
+The human-editable JSON file holding a project's architectural decisions. Three top-level arrays: `items` (legacy types, auto-migrated), `examples` (decision examples), `decisions` (modern Decision schema). Plain JSON, no tooling required.
+
+### Recall@k
+
+A retrieval metric: the fraction of scenarios where the relevant decision appears in the top-k retrieved decisions. Mneme HQ's benchmark reports recall@3 (the canonical injection cutoff) at 1.00 over the fixture suite. Recall@1 is reported but not optimized.
+
+### Retrieval cutoff (K)
+
+The number of top-scoring decisions passed from the retriever to the context builder. Default `DEFAULT_MAX_DECISIONS = 3`. K is a property of the system, not a benchmark parameter — it stays fixed across runs.
+
+### Rule (legacy)
+
+A pre-v0.2 type in `project_memory.json` describing a hard constraint. Auto-migrated to a Decision with appropriate constraints and anti_patterns at load time. Maintained for backward compatibility; new corpora should use Decisions directly.
+
+### Scope
+
+A dotted-path string (or array, on Decision records) naming the modules or domains where a decision applies. Used by the retriever to surface decisions when relevant queries come in. Empty string scope means global; nested scopes like `storage.backend` apply to that subtree.
+
+### Slash commands (Claude Code)
+
+Four commands shipped by the Mneme HQ Claude Code installer: `/mneme-check` (run a governance pass), `/mneme-context` (inspect what would be injected for a query), `/mneme-record` (record a new decision from the current conversation), `/mneme-review` (review the active constraint set).
+
+### Status (ADR)
+
+A field on ADR frontmatter: `proposed`, `accepted`, `deprecated`, `superseded`. Only accepted ADRs enter the active constraint set; deprecated and superseded ADRs are filtered out at compile time.
+
+### Supersession
+
+The mechanism by which a new ADR replaces an older one. The new ADR's `supersedes` array lists the older ADR ids. The compiler removes superseded ADRs from the active constraint set, including chain-aware supersession (ADR-003 supersedes ADR-002 which superseded ADR-001 → only ADR-003 is active). Supersession cycles are detected at validation time.
+
+### Verification contract
+
+A category-level concept defined on the mnemehq.com concepts hub: the explicit, reproducible commitment that a governance layer makes about what it will and will not check, and under what conditions. Mneme HQ's verification contract is the freeze artifact plus the benchmark methodology.
+
+### Warn mode
+
+An enforcement mode where violations are surfaced (logged, printed, posted to the PR) but do not fail the check. Used during adoption to give teams visibility before turning on strict mode. The default mode for the GitHub Actions workflow.
+
+### Wedge
+
+The narrow, intentional initial scope of Mneme HQ: explicit recorded decisions, deterministically retrieved, enforced before generation. The wedge is defined by what it excludes (autonomous agents, vector stores, long context, model-based judges in Layer 1) as much as by what it includes.
+
+---
+
+## Related concepts (on mnemehq.com/concepts/)
+
+For deeper treatment of the category-defining concepts, see the Mneme HQ concepts hub:
+
+- Governance before generation
+- Verification contracts
+- Architectural drift
+- Governance infrastructure
+
+These concept pages are the canonical references for the category Mneme HQ defines. This Q&A and glossary document is the practitioner-facing reference for the project specifically.
+
+---
+
+## How to cite
+
+Mneme HQ. *Q&A and Glossary*. mnemehq.com. 2026. Available at: https://mnemehq.com/qa-glossary/ and https://github.com/TheoV823/mneme.
+
+MIT License. Reproduction and citation encouraged.

--- a/site/index.html
+++ b/site/index.html
@@ -1012,6 +1012,7 @@
     <a href="/#how-it-works">How it works</a>
     <a href="/use-cases/">Use cases</a>
     <a href="/insights/">Insights</a>
+    <a href="/qa-glossary/">Q&amp;A</a>
     <a href="/roadmap/">Roadmap</a>
     <a href="/demo/">Demo</a>
     <a href="/benchmark/">Benchmark</a>

--- a/site/qa-glossary/index.html
+++ b/site/qa-glossary/index.html
@@ -1,0 +1,850 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mneme HQ — Q&amp;A and Glossary</title>
+  <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="/assets/css/fonts.css">
+  <meta name="description" content="Practitioner reference for Mneme HQ: 43 Q&A entries and 47 glossary terms covering governance-before-generation, ADR enforcement, the Claude Code hook, and how Mneme HQ compares to RAG, linters, LLM-as-judge, and Cursor Rules." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0c0c0d" />
+  <link rel="canonical" href="https://mnemehq.com/qa-glossary/" />
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Mneme HQ" />
+  <meta property="og:title" content="Mneme HQ — Q&amp;A and Glossary" />
+  <meta property="og:description" content="43 questions and 47 glossary terms covering Mneme HQ's architectural governance layer for AI-assisted development." />
+  <meta property="og:url" content="https://mnemehq.com/qa-glossary/" />
+  <meta property="og:image" content="https://mnemehq.com/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Mneme HQ — Q&amp;A and Glossary" />
+  <meta name="twitter:description" content="43 questions and 47 glossary terms covering Mneme HQ's architectural governance layer for AI-assisted development." />
+  <meta name="twitter:image" content="https://mnemehq.com/og.png" />
+  <meta name="author" content="Theo Valmis" />
+  <meta property="article:published_time" content="2026-05-22T00:00:00Z" />
+  <meta property="article:author" content="https://mnemehq.com/founder/" />
+  <meta property="article:section" content="Reference" />
+
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0c0c0d; --surface: #141416; --surface2: #1a1a1d;
+      --border: #222226; --border2: #2e2e34;
+      --text: #e8e8ec; --muted: #a8a8b8;
+      --accent: #c8f060; --accent-dim: #a8d040; --teal: #8be0c8;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; min-height: 100vh; }
+    nav.site { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 2.5rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(12,12,13,0.95); backdrop-filter: blur(12px); z-index: 100; }
+    .logo { display: flex; align-items: center; text-decoration: none; }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.82rem; transition: color 0.15s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .btn-nav-cta { background: var(--accent); color: #0c0c0d; padding: 0.45rem 1.1rem; border-radius: 6px; font-size: 0.82rem; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+    .btn-nav-cta:hover { background: var(--accent-dim); color: #0c0c0d; }
+
+    .article-wrap { max-width: 820px; margin: 0 auto; padding: 4rem 2rem 7rem; }
+    .article-header { margin-bottom: 3rem; }
+    .article-eyebrow { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.25rem; }
+    .eyebrow-tag { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); font-family: 'DM Mono', monospace; }
+    .eyebrow-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--border2); }
+    .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
+    .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.25rem; }
+    .article-lede { font-size: 1.05rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+
+    .article-body { font-size: 0.94rem; line-height: 1.85; color: var(--text); }
+    .article-body p { margin-bottom: 1.1rem; color: var(--muted); }
+    .article-body p strong { color: var(--text); font-weight: 500; }
+    .article-body ul, .article-body ol { margin: 0 0 1.1rem 1.5rem; color: var(--muted); }
+    .article-body li { margin-bottom: 0.4rem; }
+    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.25); }
+    .article-body a:hover { border-bottom-color: var(--accent); }
+    .article-body code { font-family: 'DM Mono', monospace; font-size: 0.82em; background: var(--surface); border: 1px solid var(--border); padding: 0.05rem 0.35rem; border-radius: 4px; color: var(--text); }
+
+    .section-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; padding-top: 0.5rem; }
+    .section-title { font-family: 'Instrument Serif', serif; font-size: 1.9rem; font-weight: 400; letter-spacing: -0.015em; color: var(--text); margin: 0 0 1.5rem; }
+    .section-block { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+
+    .toc { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.5rem 1.75rem; margin: 2rem 0 3rem; }
+    .toc-label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); margin-bottom: 1rem; }
+    .toc ul { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.5rem 1.5rem; }
+    .toc li { margin: 0; }
+    .toc a { color: var(--muted); text-decoration: none; font-size: 0.85rem; border: none; }
+    .toc a:hover { color: var(--accent); }
+    .toc .toc-count { color: var(--border2); font-family: 'DM Mono', monospace; font-size: 0.72rem; margin-left: 0.35rem; }
+
+    .qa-list { list-style: none; margin: 0; padding: 0; counter-reset: qa; }
+    .qa-item { margin: 0 0 2rem; padding-bottom: 1.75rem; border-bottom: 1px solid var(--border); counter-increment: qa; }
+    .qa-item:last-child { border-bottom: none; }
+    .qa-question { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; color: var(--text); letter-spacing: -0.005em; margin-bottom: 0.85rem; line-height: 1.45; scroll-margin-top: 6rem; }
+    .qa-question::before { content: counter(qa) ". "; color: var(--accent); font-family: 'DM Mono', monospace; font-weight: 500; font-size: 0.85em; margin-right: 0.3rem; }
+    .qa-answer p { margin-bottom: 0.85rem; color: var(--muted); }
+    .qa-answer p:last-child { margin-bottom: 0; }
+    .qa-answer pre { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; margin: 1rem 0; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--muted); line-height: 1.7; overflow-x: auto; }
+    .qa-answer pre code { background: none; border: none; padding: 0; font-size: inherit; color: inherit; }
+
+    dl.glossary { margin: 0; }
+    dl.glossary dt { font-family: 'Inter', sans-serif; font-weight: 600; color: var(--text); font-size: 0.98rem; margin-top: 1.75rem; scroll-margin-top: 6rem; }
+    dl.glossary dt:first-of-type { margin-top: 0; }
+    dl.glossary dt::before { content: ''; }
+    dl.glossary dt code { font-family: 'DM Mono', monospace; font-size: 0.85em; background: var(--surface); border: 1px solid var(--border); padding: 0.05rem 0.35rem; border-radius: 4px; color: var(--text); }
+    dl.glossary dd { margin: 0.45rem 0 0; color: var(--muted); font-size: 0.92rem; line-height: 1.75; }
+    dl.glossary dd a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.25); }
+
+    .cite-block { margin-top: 3.5rem; padding: 1.5rem 1.75rem; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--teal); border-radius: 0 8px 8px 0; }
+    .cite-block .cite-label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--teal); margin-bottom: 0.75rem; }
+    .cite-block p { font-size: 0.86rem; color: var(--muted); margin-bottom: 0.5rem; line-height: 1.75; }
+    .cite-block p:last-child { margin-bottom: 0; }
+
+    .breadcrumb-nav { max-width: 820px; margin: 0 auto; padding: 1.75rem 2rem 0.85rem; }
+    .breadcrumb { display: flex; align-items: center; gap: 0.5rem; list-style: none; font-size: 0.82rem; flex-wrap: wrap; }
+    .breadcrumb li + li::before { content: '/'; color: var(--border2); margin-right: 0.5rem; }
+    .breadcrumb a { color: var(--muted); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--text); }
+    .breadcrumb [aria-current="page"] { color: var(--text); }
+
+    .answer-capsule { max-width: 920px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
+    .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
+    .nav-hamburger:hover { border-color: var(--accent); }
+    .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .nav-hamburger span { display: block; width: 18px; height: 2px; background: currentColor; border-radius: 1px; transition: transform 0.25s ease, opacity 0.18s ease; transform-origin: center; }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+    @media (max-width: 900px) {
+      html, body { overflow-x: clip; }
+      body.menu-open { overflow: hidden; }
+      nav.site { padding: 1rem 1.25rem; }
+      .nav-hamburger { display: flex; }
+      .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
+      .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }
+      .nav-links a:not(.btn-nav-cta) { display: block; color: var(--text); font-size: 0.92rem; padding: 0.85rem 0; border-bottom: 1px solid var(--border); }
+      .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
+      .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
+      .article-wrap { padding: 3rem 1.25rem 5rem; }
+    }
+    @media (max-width: 768px) { nav.site { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+
+    /* In-page sticky anchor nav (sub-nav under main site nav) */
+    .section-nav { position: sticky; top: 69px; z-index: 90; background: rgba(12,12,13,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+    .section-nav::-webkit-scrollbar { display: none; }
+    .section-nav-inner { max-width: 920px; margin: 0 auto; display: flex; gap: 0; padding: 0 2rem; white-space: nowrap; }
+    .section-nav a { display: inline-block; padding: 0.85rem 0.95rem; font-size: 0.74rem; color: var(--muted); text-decoration: none; border-bottom: 2px solid transparent; transition: color 0.15s, border-color 0.15s; font-family: 'DM Mono', monospace; letter-spacing: 0.06em; text-transform: uppercase; }
+    .section-nav a:hover { color: var(--text); }
+    .section-nav a.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .section-nav a .sn-count { color: var(--border2); margin-left: 0.35rem; font-size: 0.92em; }
+    .section-nav a.active .sn-count { color: var(--accent-dim); }
+
+    /* Per-section header inside Q&A */
+    .qa-section { margin: 0 0 3rem; scroll-margin-top: 8rem; }
+    .qa-section:last-of-type { margin-bottom: 0; }
+    .qa-section-label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.5rem; padding-top: 0.5rem; }
+    .qa-section-title { font-family: 'Instrument Serif', serif; font-size: 1.5rem; font-weight: 400; letter-spacing: -0.01em; color: var(--text); margin: 0 0 1.5rem; }
+    .qa-section .qa-list { counter-reset: qa; }
+
+    .section-block { scroll-margin-top: 8rem; }
+    #glossary, #related-concepts, #how-to-cite { scroll-margin-top: 8rem; }
+
+    @media (max-width: 768px) {
+      .section-nav { top: 61px; }
+      .section-nav-inner { padding: 0 1.25rem; }
+      .section-nav a { padding: 0.75rem 0.75rem; font-size: 0.7rem; }
+      .qa-section { scroll-margin-top: 7rem; }
+      .section-block, #glossary, #related-concepts, #how-to-cite { scroll-margin-top: 7rem; }
+    }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Q&A and Glossary", "item": "https://mnemehq.com/qa-glossary/"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "Mneme HQ — Q&A and Glossary",
+        "description": "Practitioner reference for Mneme HQ: 43 Q&A entries and 47 glossary terms covering governance-before-generation, ADR enforcement, the Claude Code hook, and how Mneme HQ compares to RAG, linters, LLM-as-judge, and Cursor Rules.",
+        "url": "https://mnemehq.com/qa-glossary/",
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
+        "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
+        "image": "https://mnemehq.com/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/qa-glossary/",
+        "articleSection": "Reference"
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {"@type": "Question", "name": "What is Mneme HQ in one sentence?", "acceptedAnswer": {"@type": "Answer", "text": "Mneme HQ is the architectural governance layer for AI-assisted development: it compiles your architectural decision records into a deterministic active constraint set and enforces those decisions at the prompt boundary, blocking AI coding agents from generating code that contradicts decisions your team already made."}},
+          {"@type": "Question", "name": "What problem does Mneme HQ solve that Cursor Rules and CLAUDE.md don't?", "acceptedAnswer": {"@type": "Answer", "text": "Cursor Rules and CLAUDE.md are unstructured text blobs pasted into the prompt. They have no precedence semantics, no validation, no conflict detection, and no enforcement. When two rules contradict each other, the model picks one — usually whichever appears later or sounds more confident. There is no audit trail of what was injected, no way to verify it ran, and no scoring of whether the output followed the rules. Mneme HQ replaces this with a typed schema (Decisions and ADRs), deterministic retrieval, deterministic precedence resolution, pre-flight enforcement, and post-response conflict detection — every step reconstructable from artifacts."}},
+          {"@type": "Question", "name": "How is this different from RAG?", "acceptedAnswer": {"@type": "Answer", "text": "RAG retrieves information. Mneme HQ retrieves decisions. RAG's goal is to inform the response; Mneme HQ's goal is to shape the response. RAG asks 'did the model use the right source?'; Mneme HQ asks 'did the model respect the constraint?' RAG is fuzzy by design (vector similarity, top-k chunks); Mneme HQ is deterministic by design (same query plus same memory always returns the same ranking)."}},
+          {"@type": "Question", "name": "How does Mneme HQ integrate with Claude Code?", "acceptedAnswer": {"@type": "Answer", "text": "Mneme HQ ships a PreToolUse hook for Claude Code that intercepts every Edit, Write, and MultiEdit operation. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with `pip install mneme` then `python scripts/install_claude_code.py`. The installer is idempotent and writes .claude/settings.json, slash commands (/mneme-check, /mneme-context, /mneme-record, /mneme-review), and a discovery skill."}},
+          {"@type": "Question", "name": "How does Mneme HQ integrate with Cursor?", "acceptedAnswer": {"@type": "Answer", "text": "Mneme HQ generates Cursor rules files (.cursor/rules/) from your Decision corpus. The same decisions that drive the Claude Code hook compile to Cursor's rules format. This gives you a single source of truth (your ADRs or project_memory.json) and consistent enforcement across both agents."}},
+          {"@type": "Question", "name": "Does Mneme HQ work with GitHub Copilot?", "acceptedAnswer": {"@type": "Answer", "text": "Copilot integration is generation-based, not hook-based: Mneme HQ compiles your decisions into Copilot-compatible instruction files. Copilot does not expose a pre-tool-use hook surface comparable to Claude Code's, so enforcement is at the prompt layer rather than the edit layer. The same decision corpus drives Copilot, Cursor, and Claude Code."}},
+          {"@type": "Question", "name": "Does Mneme HQ work with agent frameworks like LangChain, CrewAI, AutoGen?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Mneme HQ exposes a Python API (MemoryStore, DecisionRetriever, ContextBuilder, Pipeline) and a minimal HTTP API (POST /complete). Either can be wired into an agent's planning or tool-use loop. The pattern is: build the context packet, inject as system prompt, run the agent step, optionally run ConflictDetector against the output."}},
+          {"@type": "Question", "name": "What is the project_memory.json file?", "acceptedAnswer": {"@type": "Answer", "text": "A human-editable JSON file that holds your architectural decisions. It contains three top-level arrays: items (legacy rules, anti-patterns, preferences, facts, architecture_decisions, examples — auto-migrated to Decisions at load time), examples (decision examples with task/decision/rationale), and decisions (the modern typed Decision schema). The file is plain JSON — no tooling required to edit."}},
+          {"@type": "Question", "name": "What is the Decision schema?", "acceptedAnswer": {"@type": "Answer", "text": "A typed record with id, decision, optional rationale, scope, constraints, anti_patterns. Only id and decision are required; the remaining fields shape retrieval scoring and the enforcement check. Example: id='mneme_storage_json', decision='Use JSON storage only', rationale='Avoid infra complexity and keep local-first', scope=['storage','backend'], constraints=['no postgres','no external database'], anti_patterns=['introduce ORM','add migration layer']."}},
+          {"@type": "Question", "name": "How does retrieval work?", "acceptedAnswer": {"@type": "Answer", "text": "Field-weighted keyword overlap, fully deterministic. Score = overlap(query, decision) * 1.0 + overlap(query, scope) * 2.0 + overlap(query, constraints) * 1.5 + overlap(query, anti_patterns) * 1.5 + overlap(query, rationale) * 0.5. The top N decisions by score are injected (default DEFAULT_MAX_DECISIONS = 3). Rules and anti-patterns always surface regardless of query relevance. Same query plus same memory file produces byte-identical retrieval order on every run."}},
+          {"@type": "Question", "name": "Why no embeddings?", "acceptedAnswer": {"@type": "Answer", "text": "Three reasons. First, determinism: same query plus same memory must produce identical output, run to run. Embeddings drift with model updates. Second, debuggability: a keyword match is reconstructable; a vector similarity is not. Third, scope: governance corpora are small (tens to low hundreds of decisions). Embeddings solve a problem you don't have at this scale and cost reproducibility you can't afford to lose."}},
+          {"@type": "Question", "name": "What is an ADR in Mneme HQ?", "acceptedAnswer": {"@type": "Answer", "text": "An Architectural Decision Record. Mneme HQ's ADR format is YAML frontmatter (id, title, status [proposed|accepted|deprecated|superseded], priority [foundational|normal|exception], date, scope [dotted path; empty = global], supersedes) plus markdown body. ADRs are the source of truth; the ADR compiler is the deterministic rule for turning them into the constraints the runtime injects."}},
+          {"@type": "Question", "name": "How does ADR precedence resolution work?", "acceptedAnswer": {"@type": "Answer", "text": "When two ADRs cover the same scope, the compiler resolves them in a strict order: first, explicit supersedes references remove ADRs from consideration (chain-aware, including N-node chains). Second, within the same scope, higher priority wins (foundational > normal > exception). Third, same scope and same priority, newer date wins. If still ambiguous, the compiler raises ADRPrecedenceError rather than silently picking a winner. Broader and narrower scopes coexist; output is sorted most-specific-first."}},
+          {"@type": "Question", "name": "What does corpus validation check?", "acceptedAnswer": {"@type": "Answer", "text": "validate_corpus aggregates every detected problem before raising — one pass surfaces every error so maintainers fix the corpus once instead of discovering problems serially. Checks include: required fields present, ADR id format and uniqueness, valid status and priority enum values, ISO 8601 date, scope grammar (lowercase dotted path, no leading or trailing dot), supersedes references resolving to known ADRs, and no supersession cycles (self-cycles, two-node cycles, and N-node cycles all detected)."}},
+          {"@type": "Question", "name": "What are enforcement modes?", "acceptedAnswer": {"@type": "Answer", "text": "strict and warn. In strict mode, mneme check exits non-zero on any violation and the Claude Code hook blocks the write. In warn mode, violations are surfaced without blocking — useful for adopting Mneme HQ on an existing repo where you want visibility before turning on enforcement. The default Claude Code hook mode is strict; the default GitHub Actions workflow mode is warn (so PRs see governance feedback without blocking merges during rollout)."}},
+          {"@type": "Question", "name": "What does mneme check actually do?", "acceptedAnswer": {"@type": "Answer", "text": "It runs a governance pass over a diff or working tree. For each changed file, it derives a query from the file path, retrieves the relevant decisions, and runs the conflict detector against the file contents. Output is a list of verdicts: which decision matched, which rule triggered, which term in the input fired it. In strict mode, any violation exits non-zero. In warn mode, violations are printed and the exit code is zero."}},
+          {"@type": "Question", "name": "How does conflict detection work?", "acceptedAnswer": {"@type": "Answer", "text": "ConflictDetector scans the LLM response (or the post-edit file contents) for constraint and anti-pattern terms drawn from the injected decisions. A term is flagged when it appears with a positive recommendation signal and no negation nearby. 'Do not use Postgres' is not a conflict. 'Switch to Postgres' is. Each conflict carries the violated decision id, the reason, and a snippet for human review."}},
+          {"@type": "Question", "name": "Is there a model in the verdict loop?", "acceptedAnswer": {"@type": "Answer", "text": "No. The retrieval, the injection, the conflict detection, and the verdict are all deterministic. The model is in the generation loop (it's the thing being governed), but the governance verdict itself is reconstructable without any model call. This is intentional: 'deterministic > clever' is a charter principle. The upgrade path to a model-based judge is explicit in the code (replace two functions) and remains opt-in."}},
+          {"@type": "Question", "name": "What's the install footprint?", "acceptedAnswer": {"@type": "Answer", "text": "pip install mneme. Dependencies: anthropic >= 0.25.0, python-dotenv >= 1.0.0. That's the whole list. Python 3.11+. Optional [api] extra adds FastAPI and Uvicorn for the HTTP layer. No vector database, no model server, no background service."}},
+          {"@type": "Question", "name": "How do I add Mneme HQ to an existing project?", "acceptedAnswer": {"@type": "Answer", "text": "Three steps. First, pip install mneme. Second, create a project_memory.json at your repo root with three to ten of the architectural decisions you care most about (or compile your existing docs/adr/ directory via compile_adrs). Third, install the Claude Code hook with python scripts/install_claude_code.py, or wire mneme check --mode warn into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes."}},
+          {"@type": "Question", "name": "What's the Layer 1 freeze?", "acceptedAnswer": {"@type": "Answer", "text": "The Mneme HQ core mechanism — retrieval mechanics, enforcement semantics, benchmark methodology — is pinned at commit e73ff7d. No behavioral change is permitted to those modules without an explicit charter amendment. The freeze exists because validation requires a stable mechanism: you cannot prove a governance layer prevents drift if the layer itself drifts."}},
+          {"@type": "Question", "name": "What is Layer 2 and why is it deferred?", "acceptedAnswer": {"@type": "Answer", "text": "Layer 2 covers multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, and deeper IDE integrations (LSP, JetBrains). All explicitly out of scope for Layer 1. It opens only after Layer 1 exit criteria are met: real-world drift prevention, design-partner feedback, governance wedge validation. The discipline is deliberate — Layer 1 is a wedge, not a platform."}},
+          {"@type": "Question", "name": "What is the benchmark suite?", "acceptedAnswer": {"@type": "Answer", "text": "A regression and integrity instrument, not a generalization claim. It uses canned LLM responses, fixed retrieval, and rule-text matching to make every change to retrieval or enforcement visible. Two-layer scoring: Layer 1 (retrieval) and Layer 2 (enforcement) are recorded independently per scenario. The WEAK_RETRIEVAL verdict explicitly flags coincidental passes — cases where enforcement happened to succeed without the relevant decision actually being retrieved. Recall@1 is reported but never optimized against."}},
+          {"@type": "Question", "name": "What does recall@3 = 1.00 actually mean?", "acceptedAnswer": {"@type": "Answer", "text": "For every scenario in the benchmark fixture set, the relevant decision appears in the top three retrieved decisions. K=3 is the canonical injection cutoff — the enforcer reads the top three retrieved decisions and only those. Recall@3 = 1.00 means no scenario in the suite has its critical decision pushed below the injection cutoff by the retriever."}},
+          {"@type": "Question", "name": "Why is recall@1 reported but not optimized?", "acceptedAnswer": {"@type": "Answer", "text": "Recall@1 is the sharpest tuning dial under fixed methodology. Optimizing against it on a small fixture set leads to overfitting — you end up with a retriever that aces the suite and fails on real corpora. Reporting without optimizing keeps the dial visible (so a regression shows up) without rewarding suite-specific tweaks."}},
+          {"@type": "Question", "name": "Can I use Mneme HQ without Claude Code?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. The Claude Code hook is one integration; the rest of the system is independent. Use Pipeline programmatically against any LLM, run mneme check in CI against any repo, generate Cursor rules, or call the HTTP API from an agent framework. The Claude Code hook is the flagship integration because Claude Code exposes a clean PreToolUse hook surface; other agents are reached via generated rules or pipeline integration."}},
+          {"@type": "Question", "name": "Does Mneme HQ store any code or data externally?", "acceptedAnswer": {"@type": "Answer", "text": "No. Mneme HQ is local-first. Your project_memory.json, your ADRs, your code, and your enforcement verdicts all stay in your repo. The only outbound call is to the LLM provider you've configured (Anthropic, OpenAI, etc.) when you're running the demo or the API layer. There is no Mneme HQ-hosted service in the verdict loop."}},
+          {"@type": "Question", "name": "How does Mneme HQ handle a decision that becomes obsolete?", "acceptedAnswer": {"@type": "Answer", "text": "Mark the corresponding ADR with status: deprecated or status: superseded, and (in the superseded case) add the superseding ADR's id to the new ADR's supersedes array. The compiler will remove deprecated and superseded ADRs from the active constraint set automatically. The history stays in the corpus — the active set updates."}},
+          {"@type": "Question", "name": "What does 'governance before generation' mean?", "acceptedAnswer": {"@type": "Answer", "text": "Intervention at the prompt boundary, before the model generates code. The alternative — catching architectural drift in code review — is too late. By the time generated code lands in a PR, the diff exists, the context is loaded, the reviewer's attention is finite, and the rejected pattern has been written enough times that a future model call will see it in the conversation history and treat it as accepted. Governance-before-generation moves the intervention point upstream."}},
+          {"@type": "Question", "name": "What is architectural drift?", "acceptedAnswer": {"@type": "Answer", "text": "The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds over time. AI-assisted development accelerates drift because code output increases without a corresponding increase in review capacity. A team that catches 95% of architectural violations in review still ships compounding drift if AI is generating five times more code than humans are reviewing carefully."}},
+          {"@type": "Question", "name": "How do I write a good Decision record?", "acceptedAnswer": {"@type": "Answer", "text": "Three properties matter. First, specificity: the decision field should be unambiguous and falsifiable ('Use JSON file storage' beats 'Be careful with storage'). Second, scope: the scope array names the modules or domains where the decision applies, used by the retriever to surface the decision when relevant queries come in. Third, the constraints and anti_patterns arrays should list the terms an LLM would use when violating the decision — these are what the conflict detector matches against. A Decision with rich anti_patterns enforces; a Decision with only decision and rationale informs but cannot block."}},
+          {"@type": "Question", "name": "What's the difference between a constraint and an anti-pattern?", "acceptedAnswer": {"@type": "Answer", "text": "In the Decision schema, both are flagged by the conflict detector. The distinction is editorial: constraints describe what must be true ('REST only', 'no external database'); anti_patterns describe what must not be done ('introduce ORM', 'add migration layer'). Both fields contribute to retrieval scoring with weight 1.5."}},
+          {"@type": "Question", "name": "Can Mneme HQ auto-fix violations?", "acceptedAnswer": {"@type": "Answer", "text": "No. Mneme HQ blocks. The human or model fixes. Auto-fixing is explicitly out of scope: a deterministic governance layer cannot also be the thing that decides how to comply, or it becomes the same kind of opinionated agent it's meant to govern."}},
+          {"@type": "Question", "name": "How do I handle a violation in strict mode?", "acceptedAnswer": {"@type": "Answer", "text": "The Claude Code hook blocks the write and surfaces the violation. Options: amend the prompt to comply with the decision, override the verdict if the decision needs to evolve (and update the ADR first, with a supersedes if applicable), or temporarily set MNEME_HOOK_MODE=warn if you're in the middle of an intentional architectural change that the corpus hasn't caught up to. Strict mode is meant to make you stop and think — not to be circumvented as a workflow habit."}},
+          {"@type": "Question", "name": "Does Mneme HQ slow down my AI coding agent?", "acceptedAnswer": {"@type": "Answer", "text": "The hook adds milliseconds, not seconds. Retrieval is keyword scoring over a small JSON file; injection is a string concatenation; conflict detection is regex over the post-edit file. The variable cost is the LLM call itself, which Mneme HQ does not perform — it just shapes the prompt and checks the result."}},
+          {"@type": "Question", "name": "How is this different from a linter?", "acceptedAnswer": {"@type": "Answer", "text": "A linter checks syntax, style, and known bug patterns against the source code after it's written. Mneme HQ checks proposed changes against architectural decisions before generation. Linters operate on syntax; Mneme HQ operates on intent. A linter cannot block 'rebuild the retrieval system with embeddings' because there's no syntactic signature for that decision — but Mneme HQ can."}},
+          {"@type": "Question", "name": "How is this different from an LLM-as-judge evaluation framework?", "acceptedAnswer": {"@type": "Answer", "text": "LLM-as-judge introduces a second model to evaluate the first model's output. It's powerful but nondeterministic — the judge's verdict varies run to run and degrades with model updates. Mneme HQ's evaluator is deterministic by design. The upgrade path to a model judge is explicit in the code (replace two functions) but is opt-in and not the default. In Layer 1, the deterministic evaluator is canonical."}},
+          {"@type": "Question", "name": "What kinds of teams should adopt Mneme HQ?", "acceptedAnswer": {"@type": "Answer", "text": "Teams that already write ADRs or maintain an internal architecture document, run AI coding agents at meaningful volume (multiple devs on Claude Code, Cursor, or Copilot), and care about architectural consistency more than they care about raw generation speed. The fit is strongest for: mid-size eng orgs (50-500 engineers), regulated industries (fintech, health, gov-adjacent), open-source projects with strict scope discipline, and any team where 'we already decided this six months ago' is a familiar phrase."}},
+          {"@type": "Question", "name": "What kinds of teams should not adopt Mneme HQ?", "acceptedAnswer": {"@type": "Answer", "text": "Teams without explicit architectural decisions to enforce. Mneme HQ enforces what you've already decided; it doesn't generate decisions for you. A team that has never written down its architectural choices won't benefit from a governance layer until they do. The right onboarding step for such a team is to write five to ten ADRs first."}},
+          {"@type": "Question", "name": "How does Mneme HQ relate to AI safety?", "acceptedAnswer": {"@type": "Answer", "text": "It's a narrow slice of AI safety: governance of AI-generated code at the project level. It's not AI alignment, not model safety, not RLHF. It's the boring, auditable, deterministic kind of safety that matters when AI is actually shipping code into production. The relevant safety claim is reproducibility: every verdict is reconstructable, no black box, no model in the verdict loop."}},
+          {"@type": "Question", "name": "Can I use Mneme HQ for non-code governance (docs, configs, prompts)?", "acceptedAnswer": {"@type": "Answer", "text": "The mechanism is general — Decisions and ADRs are not code-specific. In practice, the v0.x integrations and benchmark focus on code. Governance of generated docs, configs, or prompts is a plausible extension but is not currently in scope."}},
+          {"@type": "Question", "name": "How do I contribute to Mneme HQ?", "acceptedAnswer": {"@type": "Answer", "text": "The repository governs itself with Mneme. Read CLAUDE.md and the freeze artifact (docs/architecture/layer1-freeze-e73ff7d.md) before opening a PR. Changes to decision_retriever.py, enforcer.py, benchmark.py, or any benchmark fixture are charter-level changes requiring the freeze doc's amendment procedure. Docs, tooling, integrations, the site, and examples proceed normally with [memory] prefix discipline for project_memory.json edits."}},
+          {"@type": "Question", "name": "Is Mneme HQ open source?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, MIT licensed. The repository is at github.com/TheoV823/mneme. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open."}}
+        ]
+      },
+      {
+        "@type": "DefinedTermSet",
+        "name": "Mneme HQ Glossary",
+        "url": "https://mnemehq.com/qa-glossary/",
+        "hasDefinedTerm": [
+          {"@type": "DefinedTerm", "name": "ADR (Architectural Decision Record)", "description": "A versioned markdown document describing an architectural choice, its context, and its consequences. In Mneme HQ, ADRs use YAML frontmatter (id, title, status, priority, date, scope, supersedes) plus body markdown. ADRs are the source of truth for the active constraint set.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "ADR compiler", "description": "The pipeline that turns an ADR corpus into an active constraint set. Three stages: parse (YAML frontmatter parsing, structural validation), validate (required fields, references, no cycles), resolve precedence (status filter, supersession chains, priority, date). Implemented in mneme/adr_compiler.py.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Active constraint set", "description": "The deterministically resolved subset of an ADR corpus that applies at a given point in time. Computed by the ADR compiler from the full corpus, filtering out deprecated and superseded ADRs and resolving same-scope conflicts via precedence rules. Same corpus always produces the same active constraint set.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Alignment score", "description": "A deterministic score (0.00 to 1.00) representing the fraction of injected decisions that the LLM response did not violate. Computed by the evaluator over the rules and decisions actually injected (not the full corpus). 1.00 means no violations detected.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Anti-pattern", "description": "A field on the Decision schema listing things the decision rules out. The conflict detector flags any anti-pattern term that appears in a response with a positive recommendation signal and no negation nearby. Contributes weight 1.5 to retrieval scoring.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Architectural drift", "description": "The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds. AI-assisted development accelerates drift because code output increases faster than review capacity.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Architectural governance", "description": "The practice of enforcing architectural decisions across a codebase at the point of change. Distinct from code review (after the fact) and linting (syntactic). Mneme HQ implements governance-before-generation: enforcement at the prompt boundary, before the model produces code.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Auditable", "description": "A property of governance verdicts: reconstructable from artifacts. For any Mneme HQ verdict, a human can trace which decision matched, which rule triggered, and which term in the input fired it. A charter principle.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Benchmark methodology", "description": "The framework Mneme HQ uses to make every change to retrieval or enforcement visible and reproducible. Canned LLM responses (no live model variance in the suite), fixed retrieval, rule-text matching, two-layer scoring (retrieval and enforcement independently recorded). Full methodology at mnemehq.com/docs/benchmark-methodology/.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Charter", "description": "The set of load-bearing principles that govern Mneme HQ's design: deterministic over clever, auditable over autonomous, prevention before review. Every feature is judged against the charter. Changes to charter-level modules require an explicit amendment procedure.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Claude Code hook", "description": "A PreToolUse hook for Claude Code that intercepts every Edit, Write, and MultiEdit operation. Reconstructs the post-edit file, runs mneme check, blocks (strict) or warns (warn) based on configured mode. Shipped in v0.3.2. Install with python scripts/install_claude_code.py.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Conflict detector", "description": "The module (mneme/conflict_detector.py) that scans an LLM response for constraint and anti-pattern violations after the call. Detector, not blocker — produces a Conflict(violated_decision_id, reason, snippet) for each match.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Constraint", "description": "A field on the Decision schema listing things that must be true. Functionally similar to an anti-pattern in the conflict detector but editorially distinct (constraints are positive requirements; anti-patterns are negative prohibitions). Both contribute weight 1.5 to retrieval scoring.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Context packet", "description": "A compact, structured representation of the decisions injected into an LLM call. Built by format_context_packet from the top-N retrieved decisions plus always-surfaced rules. Passed as the system prompt.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Decision", "description": "The atomic unit of governance in Mneme HQ. A typed record with id, decision, optional rationale, scope, constraints, anti_patterns. Decisions can be authored directly in project_memory.json or compiled from ADRs.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Decision example", "description": "A record of a past decision with three fields: task (the situation that prompted the decision), decision (what was decided), rationale (why). Injected as prior decisions so the model learns how the project reasons, not just what it decided.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Decision retriever", "description": "The v0.2+ retriever (mneme/decision_retriever.py) that scores Decision records against a query using field-weighted keyword overlap. Deterministic. Top-N scoring decisions are passed to the context builder.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Deterministic retrieval", "description": "A retrieval mechanism where same query plus same memory file produces byte-identical retrieval order on every run. Mneme HQ's retriever is deterministic by design. Same property: no model drift, full debuggability, reproducible benchmarks.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Enforcement mode", "description": "A configuration governing how mneme check and the Claude Code hook respond to violations. strict exits non-zero and blocks writes; warn surfaces violations without blocking. Shipped in v0.3.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Evaluator", "description": "The deterministic alignment checker that scores an LLM response against the rules that were actually injected. Two checks: rule check (extracts forbidden terms from each rule or anti-pattern, fires on positive recommendation signal without nearby negation) and decision check (for past decisions where the project said 'no', fires if the response recommends the declined subject anyway).", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Field-weighted scoring", "description": "The retrieval algorithm where each field in a Decision contributes to the relevance score with a different weight. Mneme HQ's weights: decision title 1.0, scope 2.0, constraints 1.5, anti_patterns 1.5, rationale 0.5. Tuned for governance retrieval, not for information retrieval.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Freeze artifact", "description": "The document (docs/architecture/layer1-freeze-e73ff7d.md) that pins the Layer 1 mechanism to a specific commit and enumerates what can change without amendment and what cannot. The freeze artifact is the contract between the maintainers and the community during validation.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Governance before generation", "description": "The intervention pattern at the heart of Mneme HQ: enforce architectural decisions at the prompt boundary, before the model generates code, rather than catching drift in code review.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Governance infrastructure", "description": "The category Mneme HQ defines: deterministic, auditable, reproducible enforcement of architectural decisions in AI-assisted development workflows. Distinct from AI safety, code review automation, and LLM evaluation.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Layer 1", "description": "The current phase of Mneme HQ: local-repo, single-developer, project-scoped architectural governance. Mechanism frozen at commit e73ff7d. Open exit criteria: real-world drift prevention, design-partner feedback, governance wedge validation.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Layer 2", "description": "Out-of-scope-until-Layer-1-exits work: multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, deeper IDE integrations (LSP, JetBrains). Listed explicitly to prevent scope creep.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "MemoryStore", "description": "The module (mneme/memory_store.py) that loads project_memory.json into typed Python objects. Handles auto-migration of legacy rule and anti_pattern items into Decision objects at load time so existing JSON files keep working with the v0.2+ pipeline.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "mneme check", "description": "The CLI command that runs a governance pass over a diff or working tree. Supports --mode warn (surfaces violations, exits zero) and --mode strict (fails on any violation). Used by the GitHub Actions workflow and the Claude Code hook.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": ".mneme/ directory", "description": "The canonical location for repo-level enforcement memory in a Mneme-governed repository. Shipped in v0.5. Contains the source-of-truth project_memory.json and any repo-specific configuration. Mirrors the role of .git/ for source control or .github/ for CI configuration.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Negation signal", "description": "A term near a flagged anti-pattern or constraint that turns a potential violation into a non-violation. 'Do not use Postgres' contains the negation 'Do not' and is not flagged. 'Switch to Postgres' lacks negation and is flagged. Implemented as a small set of negation phrases checked within a window of the matched term.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Pipeline", "description": "The orchestrating module (mneme/pipeline.py) that wires MemoryStore, DecisionRetriever, injection, LLM call, and ConflictDetector. Used by the demo and the API layer. Single entry point for programmatic use of Mneme HQ.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Precedence resolution", "description": "The deterministic procedure for resolving conflicts between ADRs covering the same scope: explicit supersedes references first (chain-aware), then priority (foundational > normal > exception), then date (newer wins). If still ambiguous, raises ADRPrecedenceError. Never silently picks a winner.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Pre-flight enforcement", "description": "Running governance checks before the LLM generates output, not after. The hook fires on the proposed edit, reconstructs the post-edit state, runs mneme check, and decides whether to allow the write. Contrast: post-flight review, which catches drift in code review after the diff exists.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "PreToolUse hook", "description": "The Claude Code hook surface that runs before any tool invocation. Mneme HQ uses this surface to intercept Edit, Write, and MultiEdit calls, reconstruct the post-edit file, and apply governance. Documented in the Claude Code agent SDK.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Prevention before review", "description": "A Mneme HQ charter principle: the intervention point is the prompt boundary, not code review. Prevention is cheaper than detection; both are cheaper than rollback.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Priority (ADR)", "description": "A field on ADR frontmatter governing same-scope precedence. Values: foundational, normal, exception. When two ADRs cover the same scope, higher priority wins. Foundational decisions are core architectural choices; exceptions are documented carve-outs.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "project_memory.json", "description": "The human-editable JSON file holding a project's architectural decisions. Three top-level arrays: items (legacy types, auto-migrated), examples (decision examples), decisions (modern Decision schema). Plain JSON, no tooling required.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Recall@k", "description": "A retrieval metric: the fraction of scenarios where the relevant decision appears in the top-k retrieved decisions. Mneme HQ's benchmark reports recall@3 (the canonical injection cutoff) at 1.00 over the fixture suite. Recall@1 is reported but not optimized.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Retrieval cutoff (K)", "description": "The number of top-scoring decisions passed from the retriever to the context builder. Default DEFAULT_MAX_DECISIONS = 3. K is a property of the system, not a benchmark parameter — it stays fixed across runs.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Rule (legacy)", "description": "A pre-v0.2 type in project_memory.json describing a hard constraint. Auto-migrated to a Decision with appropriate constraints and anti_patterns at load time. Maintained for backward compatibility; new corpora should use Decisions directly.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Scope", "description": "A dotted-path string (or array, on Decision records) naming the modules or domains where a decision applies. Used by the retriever to surface decisions when relevant queries come in. Empty string scope means global; nested scopes like storage.backend apply to that subtree.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Slash commands (Claude Code)", "description": "Four commands shipped by the Mneme HQ Claude Code installer: /mneme-check (run a governance pass), /mneme-context (inspect what would be injected for a query), /mneme-record (record a new decision from the current conversation), /mneme-review (review the active constraint set).", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Status (ADR)", "description": "A field on ADR frontmatter: proposed, accepted, deprecated, superseded. Only accepted ADRs enter the active constraint set; deprecated and superseded ADRs are filtered out at compile time.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Supersession", "description": "The mechanism by which a new ADR replaces an older one. The new ADR's supersedes array lists the older ADR ids. The compiler removes superseded ADRs from the active constraint set, including chain-aware supersession (ADR-003 supersedes ADR-002 which superseded ADR-001 means only ADR-003 is active). Supersession cycles are detected at validation time.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Verification contract", "description": "A category-level concept: the explicit, reproducible commitment that a governance layer makes about what it will and will not check, and under what conditions. Mneme HQ's verification contract is the freeze artifact plus the benchmark methodology.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Warn mode", "description": "An enforcement mode where violations are surfaced (logged, printed, posted to the PR) but do not fail the check. Used during adoption to give teams visibility before turning on strict mode. The default mode for the GitHub Actions workflow.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"},
+          {"@type": "DefinedTerm", "name": "Wedge", "description": "The narrow, intentional initial scope of Mneme HQ: explicit recorded decisions, deterministically retrieved, enforced before generation. The wedge is defined by what it excludes (autonomous agents, vector stores, long context, model-based judges in Layer 1) as much as by what it includes.", "inDefinedTermSet": "https://mnemehq.com/qa-glossary/"}
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+<nav class="site">
+  <a href="/" class="logo"><img src="/logo-v2.png" alt="Mneme HQ" height="36" style="display:block;"></a>
+  <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
+  <div class="nav-links">
+    <a href="/#how-it-works">How it works</a>
+    <a href="/use-cases/">Use cases</a>
+    <a href="/insights/">Insights</a>
+    <a href="/qa-glossary/">Q&amp;A</a>
+    <a href="/roadmap/">Roadmap</a>
+    <a href="/demo/">Demo</a>
+    <a href="/benchmark/">Benchmark</a>
+    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/TheoV823/mneme" class="btn-nav-cta">Get started</a>
+  </div>
+</nav>
+
+<nav class="section-nav" aria-label="Section navigation">
+  <div class="section-nav-inner">
+    <a href="#s-what-is-mneme" data-target="s-what-is-mneme">What is Mneme<span class="sn-count">12</span></a>
+    <a href="#s-integrations" data-target="s-integrations">Integrations<span class="sn-count">5</span></a>
+    <a href="#s-adrs-and-decisions" data-target="s-adrs-and-decisions">ADRs &amp; decisions<span class="sn-count">10</span></a>
+    <a href="#s-enforcement" data-target="s-enforcement">Enforcement<span class="sn-count">7</span></a>
+    <a href="#s-benchmarks" data-target="s-benchmarks">Benchmarks<span class="sn-count">5</span></a>
+    <a href="#s-comparisons" data-target="s-comparisons">Comparisons<span class="sn-count">4</span></a>
+    <a href="#glossary" data-target="glossary">Glossary<span class="sn-count">47</span></a>
+  </div>
+</nav>
+
+<main>
+<div class="answer-capsule">
+  <strong>Q&amp;A and Glossary.</strong> The practitioner-facing reference for Mneme HQ — 43 questions and 47 glossary terms covering governance-before-generation, ADR enforcement, the Claude Code hook, and how Mneme HQ compares to RAG, linters, LLM-as-judge, and Cursor Rules.
+</div>
+
+<nav aria-label="Breadcrumb" class="breadcrumb-nav">
+  <ol class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li aria-current="page">Q&amp;A and Glossary</li>
+  </ol>
+</nav>
+
+<article class="article-wrap">
+  <header class="article-header">
+    <div class="article-eyebrow">
+      <span class="eyebrow-tag">Reference</span>
+      <span class="eyebrow-dot"></span>
+      <span class="eyebrow-meta">43 Q&amp;A &middot; 47 terms &middot; May 2026</span>
+    </div>
+    <h1>Mneme HQ — Q&amp;A and Glossary</h1>
+    <p class="article-lede">A reference for practitioners using AI coding agents (Claude Code, Cursor, GitHub Copilot, agent frameworks) and a glossary of the terms that define architectural governance for AI-assisted development. This document is the canonical reference for both human readers and AI assistants answering questions about Mneme HQ.</p>
+    <p class="byline">
+      By <a href="/founder/">Theo Valmis</a>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-22">Published May 2026</time>
+      <span class="sep">&middot;</span>
+      <a href="https://github.com/TheoV823/mneme">github.com/TheoV823/mneme</a>
+      <span class="sep">&middot;</span>
+      MIT License
+    </p>
+  </header>
+
+  <div class="article-body">
+    <p><strong>Project:</strong> Mneme HQ &middot; <strong>Site:</strong> <a href="https://mnemehq.com/">mnemehq.com</a> &middot; <strong>Install:</strong> <code>pip install mneme</code></p>
+
+    <nav class="toc" aria-label="On this page">
+      <div class="toc-label">On this page</div>
+      <ul>
+        <li><a href="#s-what-is-mneme">What is Mneme? <span class="toc-count">12</span></a></li>
+        <li><a href="#s-integrations">Integrations <span class="toc-count">5</span></a></li>
+        <li><a href="#s-adrs-and-decisions">ADRs and decisions <span class="toc-count">10</span></a></li>
+        <li><a href="#s-enforcement">Enforcement <span class="toc-count">7</span></a></li>
+        <li><a href="#s-benchmarks">Benchmarks <span class="toc-count">5</span></a></li>
+        <li><a href="#s-comparisons">Comparisons <span class="toc-count">4</span></a></li>
+        <li><a href="#glossary">Glossary <span class="toc-count">47</span></a></li>
+        <li><a href="#related-concepts">Related concepts</a></li>
+        <li><a href="#how-to-cite">How to cite</a></li>
+      </ul>
+    </nav>
+
+    <section class="section-block" id="qa">
+      <div class="section-label">Reference &middot; 43 questions across 6 topics</div>
+      <h2 class="section-title">Q&amp;A</h2>
+
+      <section class="qa-section" id="s-what-is-mneme" data-section>
+        <div class="qa-section-label">What is Mneme? &middot; 12 questions</div>
+        <h3 class="qa-section-title">What is Mneme?</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-what-is-mneme-hq">What is Mneme HQ in one sentence?</h3><div class="qa-answer"><p>Mneme HQ is the architectural governance layer for AI-assisted development: it compiles your architectural decision records into a deterministic active constraint set and enforces those decisions at the prompt boundary, blocking AI coding agents from generating code that contradicts decisions your team already made.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-install-footprint">What's the install footprint?</h3><div class="qa-answer">
+<pre><code>pip install mneme</code></pre>
+<p>Dependencies: <code>anthropic &gt;= 0.25.0</code>, <code>python-dotenv &gt;= 1.0.0</code>. That's the whole list. Python 3.11+. Optional <code>[api]</code> extra adds FastAPI and Uvicorn for the HTTP layer. No vector database, no model server, no background service.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-adopt-existing-project">How do I add Mneme HQ to an existing project?</h3><div class="qa-answer"><p>Three steps. First, <code>pip install mneme</code>. Second, create a <code>project_memory.json</code> at your repo root with three to ten of the architectural decisions you care most about (or compile your existing <code>docs/adr/</code> directory via <code>compile_adrs</code>). Third, install the Claude Code hook with <code>python scripts/install_claude_code.py</code>, or wire <code>mneme check --mode warn</code> into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-data-external">Does Mneme HQ store any code or data externally?</h3><div class="qa-answer"><p>No. Mneme HQ is local-first. Your <code>project_memory.json</code>, your ADRs, your code, and your enforcement verdicts all stay in your repo. The only outbound call is to the LLM provider you've configured (Anthropic, OpenAI, etc.) when you're running the demo or the API layer. There is no Mneme HQ-hosted service in the verdict loop.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-gbg-meaning">What does "governance before generation" mean?</h3><div class="qa-answer"><p>Intervention at the prompt boundary, before the model generates code. The alternative — catching architectural drift in code review — is too late. By the time generated code lands in a PR, the diff exists, the context is loaded, the reviewer's attention is finite, and the rejected pattern has been written enough times that a future model call will see it in the conversation history and treat it as accepted. Governance-before-generation moves the intervention point upstream.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-architectural-drift">What is architectural drift?</h3><div class="qa-answer"><p>The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds over time. AI-assisted development accelerates drift because code output increases without a corresponding increase in review capacity. A team that catches 95% of architectural violations in review still ships compounding drift if AI is generating five times more code than humans are reviewing carefully.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-who-should-adopt">What kinds of teams should adopt Mneme HQ?</h3><div class="qa-answer"><p>Teams that already write ADRs or maintain an internal architecture document, run AI coding agents at meaningful volume (multiple devs on Claude Code, Cursor, or Copilot), and care about architectural consistency more than they care about raw generation speed. The fit is strongest for: mid-size eng orgs (50-500 engineers), regulated industries (fintech, health, gov-adjacent), open-source projects with strict scope discipline, and any team where "we already decided this six months ago" is a familiar phrase.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-who-should-not-adopt">What kinds of teams should not adopt Mneme HQ?</h3><div class="qa-answer"><p>Teams without explicit architectural decisions to enforce. Mneme HQ enforces what you've already decided; it doesn't generate decisions for you. A team that has never written down its architectural choices won't benefit from a governance layer until they do. The right onboarding step for such a team is to write five to ten ADRs first.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-ai-safety">How does Mneme HQ relate to AI safety?</h3><div class="qa-answer"><p>It's a narrow slice of AI safety: governance of AI-generated code at the project level. It's not AI alignment, not model safety, not RLHF. It's the boring, auditable, deterministic kind of safety that matters when AI is actually shipping code into production. The relevant safety claim is reproducibility: every verdict is reconstructable, no black box, no model in the verdict loop.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-non-code">Can I use Mneme HQ for non-code governance (docs, configs, prompts)?</h3><div class="qa-answer"><p>The mechanism is general — Decisions and ADRs are not code-specific. In practice, the v0.x integrations and benchmark focus on code. Governance of generated docs, configs, or prompts is a plausible extension but is not currently in scope.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-contribute">How do I contribute to Mneme HQ?</h3><div class="qa-answer"><p>The repository governs itself with Mneme. Read <code>CLAUDE.md</code> and the freeze artifact (<code>docs/architecture/layer1-freeze-e73ff7d.md</code>) before opening a PR. Changes to <code>decision_retriever.py</code>, <code>enforcer.py</code>, <code>benchmark.py</code>, or any benchmark fixture are charter-level changes requiring the freeze doc's amendment procedure. Docs, tooling, integrations, the site, and examples proceed normally with <code>[memory]</code> prefix discipline for <code>project_memory.json</code> edits.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-open-source">Is Mneme HQ open source?</h3><div class="qa-answer"><p>Yes, MIT licensed. The repository is at <a href="https://github.com/TheoV823/mneme">github.com/TheoV823/mneme</a>. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open.</p></div></li>
+
+        </ol>
+      </section>
+
+      <section class="qa-section" id="s-integrations" data-section>
+        <div class="qa-section-label">Integrations &middot; 5 questions</div>
+        <h3 class="qa-section-title">Integrations</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-claude-code-integration">How does Mneme HQ integrate with Claude Code?</h3><div class="qa-answer"><p>Mneme HQ ships a <code>PreToolUse</code> hook for Claude Code that intercepts every <code>Edit</code>, <code>Write</code>, and <code>MultiEdit</code> operation. The hook reconstructs the full post-edit file, runs <code>mneme check</code> against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with <code>pip install mneme</code> then <code>python scripts/install_claude_code.py</code>. The installer is idempotent and writes <code>.claude/settings.json</code>, slash commands (<code>/mneme-check</code>, <code>/mneme-context</code>, <code>/mneme-record</code>, <code>/mneme-review</code>), and a discovery skill.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-cursor-integration">How does Mneme HQ integrate with Cursor?</h3><div class="qa-answer"><p>Mneme HQ generates Cursor rules files (<code>.cursor/rules/</code>) from your Decision corpus. The same decisions that drive the Claude Code hook compile to Cursor's rules format. This gives you a single source of truth (your ADRs or <code>project_memory.json</code>) and consistent enforcement across both agents.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-copilot">Does Mneme HQ work with GitHub Copilot?</h3><div class="qa-answer"><p>Copilot integration is generation-based, not hook-based: Mneme HQ compiles your decisions into Copilot-compatible instruction files. Copilot does not expose a pre-tool-use hook surface comparable to Claude Code's, so enforcement is at the prompt layer rather than the edit layer. The same decision corpus drives Copilot, Cursor, and Claude Code.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-agent-frameworks">Does Mneme HQ work with agent frameworks like LangChain, CrewAI, AutoGen?</h3><div class="qa-answer"><p>Yes. Mneme HQ exposes a Python API (<code>MemoryStore</code>, <code>DecisionRetriever</code>, <code>ContextBuilder</code>, <code>Pipeline</code>) and a minimal HTTP API (<code>POST /complete</code>). Either can be wired into an agent's planning or tool-use loop. The pattern is: build the context packet, inject as system prompt, run the agent step, optionally run <code>ConflictDetector</code> against the output.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-without-claude-code">Can I use Mneme HQ without Claude Code?</h3><div class="qa-answer"><p>Yes. The Claude Code hook is one integration; the rest of the system is independent. Use <code>Pipeline</code> programmatically against any LLM, run <code>mneme check</code> in CI against any repo, generate Cursor rules, or call the HTTP API from an agent framework. The Claude Code hook is the flagship integration because Claude Code exposes a clean PreToolUse hook surface; other agents are reached via generated rules or pipeline integration.</p></div></li>
+
+        </ol>
+      </section>
+
+      <section class="qa-section" id="s-adrs-and-decisions" data-section>
+        <div class="qa-section-label">ADRs and decisions &middot; 10 questions</div>
+        <h3 class="qa-section-title">ADRs and decisions</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-project-memory-json">What is the <code>project_memory.json</code> file?</h3><div class="qa-answer"><p>A human-editable JSON file that holds your architectural decisions. It contains three top-level arrays: <code>items</code> (legacy rules, anti-patterns, preferences, facts, architecture_decisions, examples — auto-migrated to Decisions at load time), <code>examples</code> (decision examples with task/decision/rationale), and <code>decisions</code> (the modern typed Decision schema). The file is plain JSON — no tooling required to edit.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-decision-schema">What is the Decision schema?</h3><div class="qa-answer">
+<pre><code>{
+  "id": "mneme_storage_json",
+  "decision": "Use JSON storage only",
+  "rationale": "Avoid infra complexity and keep local-first.",
+  "scope": ["storage", "backend"],
+  "constraints": ["no postgres", "no external database"],
+  "anti_patterns": ["introduce ORM", "add migration layer"]
+}</code></pre>
+<p>Only <code>id</code> and <code>decision</code> are required. The remaining fields shape retrieval scoring and the enforcement check.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-retrieval">How does retrieval work?</h3><div class="qa-answer"><p>Field-weighted keyword overlap, fully deterministic:</p>
+<pre><code>score =
+    overlap(query, decision)      * 1.0
+  + overlap(query, scope)         * 2.0
+  + overlap(query, constraints)   * 1.5
+  + overlap(query, anti_patterns) * 1.5
+  + overlap(query, rationale)     * 0.5</code></pre>
+<p>The top N decisions by score are injected (default <code>DEFAULT_MAX_DECISIONS = 3</code>). Rules and anti-patterns always surface regardless of query relevance. Same query plus same memory file produces byte-identical retrieval order on every run.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-no-embeddings">Why no embeddings?</h3><div class="qa-answer"><p>Three reasons. First, determinism: same query plus same memory must produce identical output, run to run. Embeddings drift with model updates. Second, debuggability: a keyword match is reconstructable; a vector similarity is not. Third, scope: governance corpora are small (tens to low hundreds of decisions). Embeddings solve a problem you don't have at this scale and cost reproducibility you can't afford to lose.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-adr">What is an ADR in Mneme HQ?</h3><div class="qa-answer"><p>An Architectural Decision Record. Mneme HQ's ADR format is YAML frontmatter plus markdown body:</p>
+<pre><code>---
+id: ADR-001
+title: Use JSON file storage
+status: accepted          # proposed | accepted | deprecated | superseded
+priority: foundational    # foundational | normal | exception
+date: 2026-01-10
+scope: storage            # dotted path; empty string = global
+supersedes: []
+---
+
+Body markdown follows.</code></pre>
+<p>ADRs are the source of truth; the ADR compiler is the deterministic rule for turning them into the constraints the runtime injects.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-precedence">How does ADR precedence resolution work?</h3><div class="qa-answer"><p>When two ADRs cover the same scope, the compiler resolves them in a strict order: first, explicit <code>supersedes</code> references remove ADRs from consideration (chain-aware, including N-node chains). Second, within the same scope, higher priority wins (<code>foundational</code> &gt; <code>normal</code> &gt; <code>exception</code>). Third, same scope and same priority, newer <code>date</code> wins. If still ambiguous, the compiler raises <code>ADRPrecedenceError</code> rather than silently picking a winner. Broader and narrower scopes coexist; output is sorted most-specific-first.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-validation">What does corpus validation check?</h3><div class="qa-answer"><p><code>validate_corpus</code> aggregates every detected problem before raising — one pass surfaces every error so maintainers fix the corpus once instead of discovering problems serially. Checks include: required fields present, ADR id format and uniqueness, valid <code>status</code> and <code>priority</code> enum values, ISO 8601 date, scope grammar (lowercase dotted path, no leading or trailing dot), <code>supersedes</code> references resolving to known ADRs, and no supersession cycles (self-cycles, two-node cycles, and N-node cycles all detected).</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-obsolete-decision">How does Mneme HQ handle a decision that becomes obsolete?</h3><div class="qa-answer"><p>Mark the corresponding ADR with <code>status: deprecated</code> or <code>status: superseded</code>, and (in the superseded case) add the superseding ADR's id to the new ADR's <code>supersedes</code> array. The compiler will remove deprecated and superseded ADRs from the active constraint set automatically. The history stays in the corpus — the active set updates.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-good-decision-record">How do I write a good Decision record?</h3><div class="qa-answer"><p>Three properties matter. First, specificity: the <code>decision</code> field should be unambiguous and falsifiable ("Use JSON file storage" beats "Be careful with storage"). Second, scope: the <code>scope</code> array names the modules or domains where the decision applies, used by the retriever to surface the decision when relevant queries come in. Third, the <code>constraints</code> and <code>anti_patterns</code> arrays should list the terms an LLM would use when violating the decision — these are what the conflict detector matches against. A Decision with rich <code>anti_patterns</code> enforces; a Decision with only <code>decision</code> and <code>rationale</code> informs but cannot block.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-constraint-vs-antipattern">What's the difference between a constraint and an anti-pattern?</h3><div class="qa-answer"><p>In the Decision schema, both are flagged by the conflict detector. The distinction is editorial: <code>constraints</code> describe what must be true ("REST only", "no external database"); <code>anti_patterns</code> describe what must not be done ("introduce ORM", "add migration layer"). Both fields contribute to retrieval scoring with weight 1.5.</p></div></li>
+
+        </ol>
+      </section>
+
+      <section class="qa-section" id="s-enforcement" data-section>
+        <div class="qa-section-label">Enforcement &middot; 7 questions</div>
+        <h3 class="qa-section-title">Enforcement</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-enforcement-modes">What are enforcement modes?</h3><div class="qa-answer"><p><code>strict</code> and <code>warn</code>. In <code>strict</code> mode, <code>mneme check</code> exits non-zero on any violation and the Claude Code hook blocks the write. In <code>warn</code> mode, violations are surfaced without blocking — useful for adopting Mneme HQ on an existing repo where you want visibility before turning on enforcement. The default Claude Code hook mode is strict; the default GitHub Actions workflow mode is warn (so PRs see governance feedback without blocking merges during rollout).</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-mneme-check"><span>What does <code>mneme check</code> actually do?</span></h3><div class="qa-answer"><p>It runs a governance pass over a diff or working tree. For each changed file, it derives a query from the file path, retrieves the relevant decisions, and runs the conflict detector against the file contents. Output is a list of verdicts: which decision matched, which rule triggered, which term in the input fired it. In strict mode, any violation exits non-zero. In warn mode, violations are printed and the exit code is zero.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-conflict-detection">How does conflict detection work?</h3><div class="qa-answer"><p><code>ConflictDetector</code> scans the LLM response (or the post-edit file contents) for constraint and anti-pattern terms drawn from the injected decisions. A term is flagged when it appears with a positive recommendation signal and no negation nearby. <code>"Do not use Postgres"</code> is not a conflict. <code>"Switch to Postgres"</code> is. Each conflict carries the violated decision id, the reason, and a snippet for human review.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-no-model-in-verdict">Is there a model in the verdict loop?</h3><div class="qa-answer"><p>No. The retrieval, the injection, the conflict detection, and the verdict are all deterministic. The model is in the <em>generation</em> loop (it's the thing being governed), but the governance verdict itself is reconstructable without any model call. This is intentional: "deterministic &gt; clever" is a charter principle. The upgrade path to a model-based judge is explicit in the code (replace two functions) and remains opt-in.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-auto-fix">Can Mneme HQ auto-fix violations?</h3><div class="qa-answer"><p>No. Mneme HQ blocks. The human or model fixes. Auto-fixing is explicitly out of scope: a deterministic governance layer cannot also be the thing that decides how to comply, or it becomes the same kind of opinionated agent it's meant to govern.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-strict-violation">How do I handle a violation in strict mode?</h3><div class="qa-answer"><p>The Claude Code hook blocks the write and surfaces the violation. Options: amend the prompt to comply with the decision, override the verdict if the decision needs to evolve (and update the ADR first, with a <code>supersedes</code> if applicable), or temporarily set <code>MNEME_HOOK_MODE=warn</code> if you're in the middle of an intentional architectural change that the corpus hasn't caught up to. Strict mode is meant to make you stop and think — not to be circumvented as a workflow habit.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-performance">Does Mneme HQ slow down my AI coding agent?</h3><div class="qa-answer"><p>The hook adds milliseconds, not seconds. Retrieval is keyword scoring over a small JSON file; injection is a string concatenation; conflict detection is regex over the post-edit file. The variable cost is the LLM call itself, which Mneme HQ does not perform — it just shapes the prompt and checks the result.</p></div></li>
+
+        </ol>
+      </section>
+
+      <section class="qa-section" id="s-benchmarks" data-section>
+        <div class="qa-section-label">Benchmarks &middot; 5 questions</div>
+        <h3 class="qa-section-title">Benchmarks</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-layer-1-freeze">What's the Layer 1 freeze?</h3><div class="qa-answer"><p>The Mneme HQ core mechanism — retrieval mechanics, enforcement semantics, benchmark methodology — is pinned at commit <code>e73ff7d</code>. No behavioral change is permitted to those modules without an explicit charter amendment. The freeze exists because validation requires a stable mechanism: you cannot prove a governance layer prevents drift if the layer itself drifts.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-layer-2">What is Layer 2 and why is it deferred?</h3><div class="qa-answer"><p>Layer 2 covers multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, and deeper IDE integrations (LSP, JetBrains). All explicitly out of scope for Layer 1. It opens only after Layer 1 exit criteria are met: real-world drift prevention, design-partner feedback, governance wedge validation. The discipline is deliberate — Layer 1 is a wedge, not a platform.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-benchmark-suite">What is the benchmark suite?</h3><div class="qa-answer"><p>A regression and integrity instrument, not a generalization claim. It uses canned LLM responses, fixed retrieval, and rule-text matching to make every change to retrieval or enforcement visible. Two-layer scoring: Layer 1 (retrieval) and Layer 2 (enforcement) are recorded independently per scenario. The <code>WEAK_RETRIEVAL</code> verdict explicitly flags coincidental passes — cases where enforcement happened to succeed without the relevant decision actually being retrieved. Recall@1 is reported but never optimized against.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-recall-3">What does recall@3 = 1.00 actually mean?</h3><div class="qa-answer"><p>For every scenario in the benchmark fixture set, the relevant decision appears in the top three retrieved decisions. K=3 is the canonical injection cutoff — the enforcer reads the top three retrieved decisions and only those. Recall@3 = 1.00 means no scenario in the suite has its critical decision pushed below the injection cutoff by the retriever.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-recall-1">Why is recall@1 reported but not optimized?</h3><div class="qa-answer"><p>Recall@1 is the sharpest tuning dial under fixed methodology. Optimizing against it on a small fixture set leads to overfitting — you end up with a retriever that aces the suite and fails on real corpora. Reporting without optimizing keeps the dial visible (so a regression shows up) without rewarding suite-specific tweaks.</p></div></li>
+
+        </ol>
+      </section>
+
+      <section class="qa-section" id="s-comparisons" data-section>
+        <div class="qa-section-label">Comparisons &middot; 4 questions</div>
+        <h3 class="qa-section-title">Comparisons</h3>
+        <ol class="qa-list">
+
+        <li class="qa-item"><h3 class="qa-question" id="q-vs-cursor-claudemd">What problem does Mneme HQ solve that Cursor Rules and CLAUDE.md don't?</h3><div class="qa-answer"><p>Cursor Rules and CLAUDE.md are unstructured text blobs pasted into the prompt. They have no precedence semantics, no validation, no conflict detection, and no enforcement. When two rules contradict each other, the model picks one — usually whichever appears later or sounds more confident. There is no audit trail of what was injected, no way to verify it ran, and no scoring of whether the output followed the rules. Mneme HQ replaces this with a typed schema (Decisions and ADRs), deterministic retrieval, deterministic precedence resolution, pre-flight enforcement, and post-response conflict detection — every step reconstructable from artifacts.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-vs-rag">How is this different from RAG?</h3><div class="qa-answer"><p>RAG retrieves information. Mneme HQ retrieves decisions. RAG's goal is to inform the response; Mneme HQ's goal is to shape the response. RAG asks "did the model use the right source?"; Mneme HQ asks "did the model respect the constraint?" RAG is fuzzy by design (vector similarity, top-k chunks); Mneme HQ is deterministic by design (same query plus same memory always returns the same ranking).</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-vs-linter">How is this different from a linter?</h3><div class="qa-answer"><p>A linter checks syntax, style, and known bug patterns against the source code after it's written. Mneme HQ checks proposed changes against architectural decisions before generation. Linters operate on syntax; Mneme HQ operates on intent. A linter cannot block "rebuild the retrieval system with embeddings" because there's no syntactic signature for that decision — but Mneme HQ can.</p></div></li>
+
+        <li class="qa-item"><h3 class="qa-question" id="q-vs-llm-judge">How is this different from an LLM-as-judge evaluation framework?</h3><div class="qa-answer"><p>LLM-as-judge introduces a second model to evaluate the first model's output. It's powerful but nondeterministic — the judge's verdict varies run to run and degrades with model updates. Mneme HQ's evaluator is deterministic by design. The upgrade path to a model judge is explicit in the code (replace two functions) but is opt-in and not the default. In Layer 1, the deterministic evaluator is canonical.</p></div></li>
+
+        </ol>
+      </section>
+    </section>
+
+    <section class="section-block" id="glossary" data-section>
+      <div class="section-label">Reference &middot; 47 terms</div>
+      <h2 class="section-title">Glossary</h2>
+
+      <dl class="glossary">
+        <dt id="g-adr">ADR (Architectural Decision Record)</dt>
+        <dd>A versioned markdown document describing an architectural choice, its context, and its consequences. In Mneme HQ, ADRs use YAML frontmatter (<code>id</code>, <code>title</code>, <code>status</code>, <code>priority</code>, <code>date</code>, <code>scope</code>, <code>supersedes</code>) plus body markdown. ADRs are the source of truth for the active constraint set.</dd>
+
+        <dt id="g-adr-compiler">ADR compiler</dt>
+        <dd>The pipeline that turns an ADR corpus into an active constraint set. Three stages: parse (YAML frontmatter parsing, structural validation), validate (required fields, references, no cycles), resolve precedence (status filter → supersession chains → priority → date). Implemented in <code>mneme/adr_compiler.py</code>.</dd>
+
+        <dt id="g-active-constraint-set">Active constraint set</dt>
+        <dd>The deterministically resolved subset of an ADR corpus that applies at a given point in time. Computed by the ADR compiler from the full corpus, filtering out deprecated and superseded ADRs and resolving same-scope conflicts via precedence rules. Same corpus always produces the same active constraint set.</dd>
+
+        <dt id="g-alignment-score">Alignment score</dt>
+        <dd>A deterministic score (0.00 to 1.00) representing the fraction of injected decisions that the LLM response did not violate. Computed by the evaluator over the rules and decisions actually injected (not the full corpus). 1.00 means no violations detected.</dd>
+
+        <dt id="g-anti-pattern">Anti-pattern</dt>
+        <dd>A field on the Decision schema listing things the decision rules out. The conflict detector flags any anti-pattern term that appears in a response with a positive recommendation signal and no negation nearby. Contributes weight 1.5 to retrieval scoring.</dd>
+
+        <dt id="g-architectural-drift">Architectural drift</dt>
+        <dd>The gradual erosion of architectural decisions as code is added without enforcement. Drift is invisible in any single change but compounds. AI-assisted development accelerates drift because code output increases faster than review capacity.</dd>
+
+        <dt id="g-architectural-governance">Architectural governance</dt>
+        <dd>The practice of enforcing architectural decisions across a codebase at the point of change. Distinct from code review (after the fact) and linting (syntactic). Mneme HQ implements governance-before-generation: enforcement at the prompt boundary, before the model produces code.</dd>
+
+        <dt id="g-auditable">Auditable</dt>
+        <dd>A property of governance verdicts: reconstructable from artifacts. For any Mneme HQ verdict, a human can trace which decision matched, which rule triggered, and which term in the input fired it. A charter principle.</dd>
+
+        <dt id="g-benchmark-methodology">Benchmark methodology</dt>
+        <dd>The framework Mneme HQ uses to make every change to retrieval or enforcement visible and reproducible. Canned LLM responses (no live model variance in the suite), fixed retrieval, rule-text matching, two-layer scoring (retrieval and enforcement independently recorded). Full methodology at <a href="https://mnemehq.com/docs/benchmark-methodology/">mnemehq.com/docs/benchmark-methodology/</a>.</dd>
+
+        <dt id="g-charter">Charter</dt>
+        <dd>The set of load-bearing principles that govern Mneme HQ's design: deterministic over clever, auditable over autonomous, prevention before review. Every feature is judged against the charter. Changes to charter-level modules require an explicit amendment procedure.</dd>
+
+        <dt id="g-claude-code-hook">Claude Code hook</dt>
+        <dd>A <code>PreToolUse</code> hook for Claude Code that intercepts every <code>Edit</code>, <code>Write</code>, and <code>MultiEdit</code> operation. Reconstructs the post-edit file, runs <code>mneme check</code>, blocks (strict) or warns (warn) based on configured mode. Shipped in v0.3.2. Install with <code>python scripts/install_claude_code.py</code>.</dd>
+
+        <dt id="g-conflict-detector">Conflict detector</dt>
+        <dd>The module (<code>mneme/conflict_detector.py</code>) that scans an LLM response for constraint and anti-pattern violations after the call. Detector, not blocker — produces a <code>Conflict(violated_decision_id, reason, snippet)</code> for each match.</dd>
+
+        <dt id="g-constraint">Constraint</dt>
+        <dd>A field on the Decision schema listing things that must be true. Functionally similar to an anti-pattern in the conflict detector but editorially distinct (constraints are positive requirements; anti-patterns are negative prohibitions). Both contribute weight 1.5 to retrieval scoring.</dd>
+
+        <dt id="g-context-packet">Context packet</dt>
+        <dd>A compact, structured representation of the decisions injected into an LLM call. Built by <code>format_context_packet</code> from the top-N retrieved decisions plus always-surfaced rules. Passed as the system prompt.</dd>
+
+        <dt id="g-decision">Decision</dt>
+        <dd>The atomic unit of governance in Mneme HQ. A typed record with <code>id</code>, <code>decision</code>, optional <code>rationale</code>, <code>scope</code>, <code>constraints</code>, <code>anti_patterns</code>. Decisions can be authored directly in <code>project_memory.json</code> or compiled from ADRs.</dd>
+
+        <dt id="g-decision-example">Decision example</dt>
+        <dd>A record of a past decision with three fields: <code>task</code> (the situation that prompted the decision), <code>decision</code> (what was decided), <code>rationale</code> (why). Injected as prior decisions so the model learns how the project reasons, not just what it decided.</dd>
+
+        <dt id="g-decision-retriever">Decision retriever</dt>
+        <dd>The v0.2+ retriever (<code>mneme/decision_retriever.py</code>) that scores Decision records against a query using field-weighted keyword overlap. Deterministic. Top-N scoring decisions are passed to the context builder.</dd>
+
+        <dt id="g-deterministic-retrieval">Deterministic retrieval</dt>
+        <dd>A retrieval mechanism where same query plus same memory file produces byte-identical retrieval order on every run. Mneme HQ's retriever is deterministic by design. Same property: no model drift, full debuggability, reproducible benchmarks.</dd>
+
+        <dt id="g-enforcement-mode">Enforcement mode</dt>
+        <dd>A configuration governing how <code>mneme check</code> and the Claude Code hook respond to violations. <code>strict</code> exits non-zero and blocks writes; <code>warn</code> surfaces violations without blocking. Shipped in v0.3.</dd>
+
+        <dt id="g-evaluator">Evaluator</dt>
+        <dd>The deterministic alignment checker that scores an LLM response against the rules that were actually injected. Two checks: rule check (extracts forbidden terms from each rule or anti-pattern, fires on positive recommendation signal without nearby negation) and decision check (for past decisions where the project said "no," fires if the response recommends the declined subject anyway).</dd>
+
+        <dt id="g-field-weighted-scoring">Field-weighted scoring</dt>
+        <dd>The retrieval algorithm where each field in a Decision contributes to the relevance score with a different weight. Mneme HQ's weights: decision title 1.0, scope 2.0, constraints 1.5, anti_patterns 1.5, rationale 0.5. Tuned for governance retrieval, not for information retrieval.</dd>
+
+        <dt id="g-freeze-artifact">Freeze artifact</dt>
+        <dd>The document (<code>docs/architecture/layer1-freeze-e73ff7d.md</code>) that pins the Layer 1 mechanism to a specific commit and enumerates what can change without amendment and what cannot. The freeze artifact is the contract between the maintainers and the community during validation.</dd>
+
+        <dt id="g-governance-before-generation">Governance before generation</dt>
+        <dd>The intervention pattern at the heart of Mneme HQ: enforce architectural decisions at the prompt boundary, before the model generates code, rather than catching drift in code review. Defined formally on the <a href="/concepts/governance-before-generation/">mnemehq.com concepts hub</a>.</dd>
+
+        <dt id="g-governance-infrastructure">Governance infrastructure</dt>
+        <dd>The category Mneme HQ defines: deterministic, auditable, reproducible enforcement of architectural decisions in AI-assisted development workflows. Distinct from AI safety, code review automation, and LLM evaluation. Defined formally on the <a href="/concepts/">mnemehq.com concepts hub</a>.</dd>
+
+        <dt id="g-layer-1">Layer 1</dt>
+        <dd>The current phase of Mneme HQ: local-repo, single-developer, project-scoped architectural governance. Mechanism frozen at commit <code>e73ff7d</code>. Open exit criteria: real-world drift prevention, design-partner feedback, governance wedge validation.</dd>
+
+        <dt id="g-layer-2">Layer 2</dt>
+        <dd>Out-of-scope-until-Layer-1-exits work: multi-repo governance, team policy synchronization, shared policy packs, org-wide policy distribution, deeper IDE integrations (LSP, JetBrains). Listed explicitly to prevent scope creep.</dd>
+
+        <dt id="g-memory-store">MemoryStore</dt>
+        <dd>The module (<code>mneme/memory_store.py</code>) that loads <code>project_memory.json</code> into typed Python objects. Handles auto-migration of legacy rule and anti_pattern items into Decision objects at load time so existing JSON files keep working with the v0.2+ pipeline.</dd>
+
+        <dt id="g-mneme-check"><code>mneme check</code></dt>
+        <dd>The CLI command that runs a governance pass over a diff or working tree. Supports <code>--mode warn</code> (surfaces violations, exits zero) and <code>--mode strict</code> (fails on any violation). Used by the GitHub Actions workflow and the Claude Code hook.</dd>
+
+        <dt id="g-mneme-dir"><code>.mneme/</code> directory</dt>
+        <dd>The canonical location for repo-level enforcement memory in a Mneme-governed repository. Shipped in v0.5. Contains the source-of-truth <code>project_memory.json</code> and any repo-specific configuration. Mirrors the role of <code>.git/</code> for source control or <code>.github/</code> for CI configuration.</dd>
+
+        <dt id="g-negation-signal">Negation signal</dt>
+        <dd>A term near a flagged anti-pattern or constraint that turns a potential violation into a non-violation. "Do not use Postgres" contains the negation "Do not" and is not flagged. "Switch to Postgres" lacks negation and is flagged. Implemented as a small set of negation phrases checked within a window of the matched term.</dd>
+
+        <dt id="g-pipeline">Pipeline</dt>
+        <dd>The orchestrating module (<code>mneme/pipeline.py</code>) that wires MemoryStore → DecisionRetriever → injection → LLM call → ConflictDetector. Used by the demo and the API layer. Single entry point for programmatic use of Mneme HQ.</dd>
+
+        <dt id="g-precedence-resolution">Precedence resolution</dt>
+        <dd>The deterministic procedure for resolving conflicts between ADRs covering the same scope: explicit <code>supersedes</code> references first (chain-aware), then priority (foundational &gt; normal &gt; exception), then date (newer wins). If still ambiguous, raises <code>ADRPrecedenceError</code>. Never silently picks a winner.</dd>
+
+        <dt id="g-pre-flight-enforcement">Pre-flight enforcement</dt>
+        <dd>Running governance checks before the LLM generates output, not after. The hook fires on the proposed edit, reconstructs the post-edit state, runs <code>mneme check</code>, and decides whether to allow the write. Contrast: post-flight review, which catches drift in code review after the diff exists.</dd>
+
+        <dt id="g-pretooluse-hook"><code>PreToolUse</code> hook</dt>
+        <dd>The Claude Code hook surface that runs before any tool invocation. Mneme HQ uses this surface to intercept <code>Edit</code>, <code>Write</code>, and <code>MultiEdit</code> calls, reconstruct the post-edit file, and apply governance. Documented in the Claude Code agent SDK.</dd>
+
+        <dt id="g-prevention-before-review">Prevention before review</dt>
+        <dd>A Mneme HQ charter principle: the intervention point is the prompt boundary, not code review. Prevention is cheaper than detection; both are cheaper than rollback.</dd>
+
+        <dt id="g-priority-adr">Priority (ADR)</dt>
+        <dd>A field on ADR frontmatter governing same-scope precedence. Values: <code>foundational</code>, <code>normal</code>, <code>exception</code>. When two ADRs cover the same scope, higher priority wins. Foundational decisions are core architectural choices; exceptions are documented carve-outs.</dd>
+
+        <dt id="g-project-memory-json"><code>project_memory.json</code></dt>
+        <dd>The human-editable JSON file holding a project's architectural decisions. Three top-level arrays: <code>items</code> (legacy types, auto-migrated), <code>examples</code> (decision examples), <code>decisions</code> (modern Decision schema). Plain JSON, no tooling required.</dd>
+
+        <dt id="g-recall-k">Recall@k</dt>
+        <dd>A retrieval metric: the fraction of scenarios where the relevant decision appears in the top-k retrieved decisions. Mneme HQ's benchmark reports recall@3 (the canonical injection cutoff) at 1.00 over the fixture suite. Recall@1 is reported but not optimized.</dd>
+
+        <dt id="g-retrieval-cutoff">Retrieval cutoff (K)</dt>
+        <dd>The number of top-scoring decisions passed from the retriever to the context builder. Default <code>DEFAULT_MAX_DECISIONS = 3</code>. K is a property of the system, not a benchmark parameter — it stays fixed across runs.</dd>
+
+        <dt id="g-rule-legacy">Rule (legacy)</dt>
+        <dd>A pre-v0.2 type in <code>project_memory.json</code> describing a hard constraint. Auto-migrated to a Decision with appropriate constraints and anti_patterns at load time. Maintained for backward compatibility; new corpora should use Decisions directly.</dd>
+
+        <dt id="g-scope">Scope</dt>
+        <dd>A dotted-path string (or array, on Decision records) naming the modules or domains where a decision applies. Used by the retriever to surface decisions when relevant queries come in. Empty string scope means global; nested scopes like <code>storage.backend</code> apply to that subtree.</dd>
+
+        <dt id="g-slash-commands">Slash commands (Claude Code)</dt>
+        <dd>Four commands shipped by the Mneme HQ Claude Code installer: <code>/mneme-check</code> (run a governance pass), <code>/mneme-context</code> (inspect what would be injected for a query), <code>/mneme-record</code> (record a new decision from the current conversation), <code>/mneme-review</code> (review the active constraint set).</dd>
+
+        <dt id="g-status-adr">Status (ADR)</dt>
+        <dd>A field on ADR frontmatter: <code>proposed</code>, <code>accepted</code>, <code>deprecated</code>, <code>superseded</code>. Only accepted ADRs enter the active constraint set; deprecated and superseded ADRs are filtered out at compile time.</dd>
+
+        <dt id="g-supersession">Supersession</dt>
+        <dd>The mechanism by which a new ADR replaces an older one. The new ADR's <code>supersedes</code> array lists the older ADR ids. The compiler removes superseded ADRs from the active constraint set, including chain-aware supersession (ADR-003 supersedes ADR-002 which superseded ADR-001 → only ADR-003 is active). Supersession cycles are detected at validation time.</dd>
+
+        <dt id="g-verification-contract">Verification contract</dt>
+        <dd>A category-level concept defined on the mnemehq.com concepts hub: the explicit, reproducible commitment that a governance layer makes about what it will and will not check, and under what conditions. Mneme HQ's verification contract is the freeze artifact plus the benchmark methodology.</dd>
+
+        <dt id="g-warn-mode">Warn mode</dt>
+        <dd>An enforcement mode where violations are surfaced (logged, printed, posted to the PR) but do not fail the check. Used during adoption to give teams visibility before turning on strict mode. The default mode for the GitHub Actions workflow.</dd>
+
+        <dt id="g-wedge">Wedge</dt>
+        <dd>The narrow, intentional initial scope of Mneme HQ: explicit recorded decisions, deterministically retrieved, enforced before generation. The wedge is defined by what it excludes (autonomous agents, vector stores, long context, model-based judges in Layer 1) as much as by what it includes.</dd>
+      </dl>
+    </section>
+
+    <section class="section-block" id="related-concepts">
+      <div class="section-label">Cross-reference</div>
+      <h2 class="section-title">Related concepts</h2>
+      <p>For deeper treatment of the category-defining concepts, see the Mneme HQ concepts hub:</p>
+      <ul>
+        <li><a href="/concepts/governance-before-generation/">Governance before generation</a></li>
+        <li><a href="/concepts/verification-contracts/">Verification contracts</a></li>
+        <li><a href="/concepts/architectural-drift/">Architectural drift</a></li>
+        <li><a href="/concepts/">Governance infrastructure (concepts hub)</a></li>
+      </ul>
+      <p>These concept pages are the canonical references for the category Mneme HQ defines. This Q&amp;A and glossary document is the practitioner-facing reference for the project specifically.</p>
+    </section>
+
+    <section class="section-block" id="how-to-cite">
+      <div class="section-label">Citation</div>
+      <h2 class="section-title">How to cite</h2>
+      <div class="cite-block">
+        <div class="cite-label">Canonical citation</div>
+        <p>Mneme HQ. <em>Q&amp;A and Glossary</em>. mnemehq.com. 2026. Available at: <a href="https://mnemehq.com/qa-glossary/">https://mnemehq.com/qa-glossary/</a> and <a href="https://github.com/TheoV823/mneme">https://github.com/TheoV823/mneme</a>.</p>
+        <p>MIT License. Reproduction and citation encouraged.</p>
+      </div>
+    </section>
+  </div>
+</article>
+</main>
+
+<footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">
+  <div style="max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 2.5rem 2rem;">
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Product</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/use-cases/" style="color:var(--muted);text-decoration:none;">Use cases</a></li>
+        <li><a href="/works-with/" style="color:var(--muted);text-decoration:none;">Works with</a></li>
+        <li><a href="/platforms/" style="color:var(--muted);text-decoration:none;">Platforms</a></li>
+        <li><a href="/integrations/" style="color:var(--muted);text-decoration:none;">Integrations</a></li>
+        <li><a href="/compare/" style="color:var(--muted);text-decoration:none;">Compare</a></li>
+        <li><a href="/demo/" style="color:var(--muted);text-decoration:none;">Demo</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Learn</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/insights/" style="color:var(--muted);text-decoration:none;">Insights</a></li>
+        <li><a href="/qa-glossary/" style="color:var(--muted);text-decoration:none;">Q&amp;A and Glossary</a></li>
+        <li><a href="/standards/" style="color:var(--muted);text-decoration:none;">Standards</a></li>
+        <li><a href="/benchmark/" style="color:var(--muted);text-decoration:none;">Benchmark</a></li>
+        <li><a href="/docs/" style="color:var(--muted);text-decoration:none;">Docs</a></li>
+        <li><a href="/docs/cli/" style="color:var(--muted);text-decoration:none;">CLI reference</a></li>
+        <li><a href="/supported-languages/" style="color:var(--muted);text-decoration:none;">Supported languages</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Company</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/pilot/" style="color:var(--accent);text-decoration:none;">Request pilot</a></li>
+        <li><a href="/for/" style="color:var(--muted);text-decoration:none;">For teams</a></li>
+        <li><a href="/founder/" style="color:var(--muted);text-decoration:none;">Founder</a></li>
+        <li><a href="/about/" style="color:var(--muted);text-decoration:none;">About</a></li>
+        <li><a href="/roadmap/" style="color:var(--muted);text-decoration:none;">Roadmap</a></li>
+        <li><a href="/contact/" style="color:var(--muted);text-decoration:none;">Contact</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Code</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="https://github.com/TheoV823/mneme" style="color:var(--muted);text-decoration:none;">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;">LinkedIn</a></li>
+        <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;">DEV.to</a></li>
+        <li><a href="/privacy/" style="color:var(--muted);text-decoration:none;">Privacy</a></li>
+      </ul>
+    </div>
+  </div>
+  <div style="max-width: 1080px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
+    <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
+    <span>&copy; 2026</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<script>
+(function(){
+  // Scroll-spy: highlight the section-nav link for whichever section is in view
+  var sections = Array.prototype.slice.call(document.querySelectorAll('[data-section]'));
+  var links = Array.prototype.slice.call(document.querySelectorAll('.section-nav a[data-target]'));
+  if (!sections.length || !links.length || !('IntersectionObserver' in window)) return;
+  var byId = {};
+  links.forEach(function(l){ byId[l.getAttribute('data-target')] = l; });
+  var visible = {};
+  function update(){
+    var firstVisibleId = null;
+    sections.forEach(function(s){
+      if (visible[s.id] && !firstVisibleId) firstVisibleId = s.id;
+    });
+    links.forEach(function(l){ l.classList.remove('active'); });
+    if (firstVisibleId && byId[firstVisibleId]) {
+      byId[firstVisibleId].classList.add('active');
+      // Auto-scroll the sub-nav so the active link stays in view on mobile
+      var nav = document.querySelector('.section-nav');
+      var link = byId[firstVisibleId];
+      if (nav && link) {
+        var navRect = nav.getBoundingClientRect();
+        var lr = link.getBoundingClientRect();
+        if (lr.left < navRect.left || lr.right > navRect.right) {
+          nav.scrollTo({ left: link.offsetLeft - navRect.width/2 + lr.width/2, behavior: 'smooth' });
+        }
+      }
+    }
+  }
+  var io = new IntersectionObserver(function(entries){
+    entries.forEach(function(e){ visible[e.target.id] = e.isIntersecting; });
+    update();
+  }, { rootMargin: '-120px 0px -55% 0px', threshold: 0 });
+  sections.forEach(function(s){ io.observe(s); });
+})();
+(function(){
+  var btn = document.querySelector('.nav-hamburger');
+  var links = document.querySelector('.nav-links');
+  if (!btn || !links) return;
+  function setOpen(open){
+    links.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', String(open));
+    document.body.classList.toggle('menu-open', open);
+  }
+  btn.addEventListener('click', function(e){
+    e.stopPropagation();
+    setOpen(!links.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e){
+    if (!links.classList.contains('open')) return;
+    if (links.contains(e.target) || btn.contains(e.target)) return;
+    setOpen(false);
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && links.classList.contains('open')) setOpen(false);
+  });
+  links.addEventListener('click', function(e){
+    if (e.target.tagName === 'A') setOpen(false);
+  });
+  window.addEventListener('resize', function(){
+    if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false);
+  });
+})();
+</script>
+</body>
+</html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -540,4 +540,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://mnemehq.com/qa-glossary/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.85</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- New top-level practitioner reference at **mnemehq.com/qa-glossary/**: 43 Q&A entries and 47 glossary terms covering governance-before-generation, ADR enforcement, the Claude Code hook, and comparisons against RAG, linters, LLM-as-judge, and Cursor Rules.
- Optimized for LLM citation (AEO/GEO): self-contained answers, plain noun definitions, no marketing voice. JSON-LD includes `FAQPage` (43 `Question` entities), `DefinedTermSet` (47 `DefinedTerm` entities), `BreadcrumbList`, and `Article` &mdash; the canonical schema patterns AI Overviews and Perplexity extract from.
- Q&A organized into 6 topical sections + Glossary, with a sticky in-page anchor sub-nav under the main site nav. IntersectionObserver-based scroll-spy highlights the active section; the sub-nav is horizontally scrollable on mobile and auto-scrolls the active link into view.
- Adds `docs/qa-glossary.md` as source-of-truth markdown for future edits.
- Adds `sitemap.xml` entry and a `Q&A` link in the homepage top nav between Insights and Roadmap.

## Files
- **New:** `site/qa-glossary/index.html`, `docs/qa-glossary.md`
- **Modified:** `site/index.html` (one-line nav addition), `site/sitemap.xml` (one entry)

## Strategy
Per discussion in the source thread, this page is positioned as the **canonical practitioner reference** &mdash; one authoritative URL for AI assistants to cite when answering questions about Mneme HQ. Follow-up worth considering once authority builds: graduate high-intent questions (governance-before-generation, vs-RAG, vs-Cursor-Rules) into standalone concept/comparison pages, with this page remaining the canonical reference and linking out.

## Test plan
- [ ] Open `/qa-glossary/` &mdash; confirm sticky sub-nav, scroll-spy highlighting, all 43 Q&A render across 6 sections, glossary &lt;dl&gt; alphabetized with 47 terms.
- [ ] Paste rendered HTML into Google's Rich Results Test &mdash; confirm `FAQPage`, `BreadcrumbList`, and `DefinedTermSet` parse cleanly.
- [ ] Mobile viewport &le; 768px: sub-nav scrolls horizontally, active link auto-scrolls into view.
- [ ] Homepage top nav shows the new `Q&A` link between Insights and Roadmap.
- [ ] `sitemap.xml` parses (`xmllint --noout site/sitemap.xml`).
- [ ] Post-deploy: submit URL to Google Search Console and Bing IndexNow.

## Dependencies
Independent of #125 (sticky-nav fix). Both PRs target `main` directly.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)