### PR TITLE
fix: stop propagating the mobile-sticky-nav CSS bug to new pages

### DIFF
--- a/.github/workflows/sticky-nav-check.yml
+++ b/.github/workflows/sticky-nav-check.yml
@@ -1,0 +1,33 @@
+name: sticky-nav check
+
+# Catches the mobile-sticky-nav CSS bug that demotes the main top nav
+# from sticky on viewports under 900px. The bug has been fixed three
+# times (e5970e2, a9d27a3, PR #125) but kept reappearing as new pages
+# were scaffolded from older buggy ones. This lint exists to catch the
+# fourth reintroduction at PR time, not on the live site.
+#
+# See scripts/check_sticky_nav.py for the exact patterns and rationale.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-sticky-nav:
+    name: Scan site/ for the mobile-sticky-nav regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run sticky-nav check
+        run: python scripts/check_sticky_nav.py

--- a/scripts/check_sticky_nav.py
+++ b/scripts/check_sticky_nav.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Fail CI on HTML files that reintroduce the mobile-sticky-nav bug.
+
+The main top nav must remain sticky on viewports under 900px. Two CSS
+patterns inside the mobile media queries demote it from sticky and have
+been reintroduced three separate times despite repeated fix commits:
+
+  1. `nav { position: relative; padding: 1rem 1.25rem; }` (and variants
+     with the `nav, nav.site-nav` or `nav.site` selectors) inside
+     `@media (max-width: 900px)`. Overrides the desktop sticky rule.
+  2. Orphan `nav { position: relative; }` lines inside
+     `@media (max-width: 640px)`. Same effect at the smallest breakpoint.
+
+Prior fix attempts: commits e5970e2, a9d27a3, and PR #125.
+
+This lint exists because the bug keeps reappearing as new pages are
+scaffolded from older ones. Catching it at PR time is cheaper than
+discovering it on the live site for the fourth time.
+
+Usage:
+  python scripts/check_sticky_nav.py            # scan site/
+  python scripts/check_sticky_nav.py site docs  # scan specific roots
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ROOTS = ["site"]
+
+# Pattern A: any of the three selector variants paired with
+# `position: relative; padding: 1rem 1.25rem;` (the combined form that
+# tends to appear inside @media (max-width: 900px)).
+PATTERN_A = re.compile(
+    r'\b(?:nav|nav, nav\.site-nav|nav\.site) \{ position: relative; padding: 1rem 1\.25rem; \}'
+)
+
+# Pattern B: orphan `nav { position: relative; }` line on its own,
+# typically indented inside @media (max-width: 640px).
+PATTERN_B = re.compile(r'^[ \t]*nav \{ position: relative; \}\s*$', re.MULTILINE)
+
+
+def scan(roots: list[str]) -> list[tuple[Path, str, int]]:
+    findings: list[tuple[Path, str, int]] = []
+    for root_name in roots:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        for path in root.rglob("*.html"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for label, pat in (("combined", PATTERN_A), ("orphan", PATTERN_B)):
+                for m in pat.finditer(text):
+                    line = text.count("\n", 0, m.start()) + 1
+                    findings.append((path.relative_to(REPO_ROOT), label, line))
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    roots = argv[1:] if len(argv) > 1 else DEFAULT_ROOTS
+    findings = scan(roots)
+    if not findings:
+        print(f"check_sticky_nav: OK (scanned {', '.join(roots)})")
+        return 0
+    print("check_sticky_nav: FAIL")
+    print(f"  Found {len(findings)} occurrence(s) of the mobile-sticky-nav bug.")
+    print("  Each line below should be removed (it overrides the desktop sticky declaration):")
+    print()
+    for path, label, line in findings:
+        print(f"  {path}:{line}  [{label}]")
+    print()
+    print("  Fix: drop `position: relative;` from the matched rule. Keep the")
+    print("       padding if present. See PR #125 and scripts/check_sticky_nav.py")
+    print("       for context.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/create_mneme_article.py
+++ b/scripts/create_mneme_article.py
@@ -36,8 +36,16 @@ def cpanel_put(path, content):
         d = json.loads(r.read().decode())
         return d.get('status') == 1
 
-# Fetch index to extract nav HTML (reuse structure)
-index = cpanel_get('index.html')
+# Source the template structure from the local repo (NOT live cPanel).
+#
+# Why: when this script fetched `index.html` over the cPanel API, every new
+# article inherited whatever HTML was live on the production server at the
+# moment of generation. That created a propagation path for any CSS bug
+# present on production — including the mobile-sticky-nav bug that took three
+# fix attempts to land (commits e5970e2, a9d27a3, and PR #125). After this
+# change, the template structure is bound to the repo's reviewed state.
+_repo_index = Path(__file__).parent.parent / 'site' / 'index.html'
+index = _repo_index.read_text(encoding='utf-8')
 
 # Extract nav block
 nav_start = index.find('<nav ')


### PR DESCRIPTION
## Summary
The mobile-sticky-nav bug has been fixed three times so far ([e5970e2](https://github.com/TheoV823/mneme/commit/e5970e2), [a9d27a3](https://github.com/TheoV823/mneme/commit/a9d27a3), [#125](https://github.com/TheoV823/mneme/pull/125)) and kept coming back. Investigation traced this to **two propagation paths** that this PR closes:

### Path 1: script fix
`scripts/create_mneme_article.py` was fetching \`index.html\` **live from the cPanel production server** and splicing its full \`<head>\` block into every new article. Whatever was deployed at the moment of generation became the template &mdash; including any CSS still buggy on production. This PR points the template source at the local repo (\`site/index.html\`) instead, binding article generation to the repo's reviewed state.

### Path 2: CI lint
New pages were also being hand-scaffolded by copying nearby older pages whose \`<style>\` blocks still contained the bug. There's no way to programmatically prevent that, so this PR adds a CI lint that catches the reintroduction at PR time:

- \`scripts/check_sticky_nav.py\` &mdash; greps \`site/**/*.html\` for the two known bug variants and exits non-zero on any hit (mirrors the existing \`scripts/check_encoding.py\` pattern).
- \`.github/workflows/sticky-nav-check.yml\` &mdash; runs the lint on every PR to \`main\` and on direct push to \`main\`.

## Dependency on PR #125
This PR's lint will **fail CI on origin/main** until [#125](https://github.com/TheoV823/mneme/pull/125) lands, because \`origin/main\` still has 59 files with the buggy pattern. **Merge order: #125 first, then this PR.** After #125 merges and this branch is rebased, CI will pass and the lint becomes a permanent guard.

## Files
- **Modified:** \`scripts/create_mneme_article.py\` (one block replaced, +8 lines of explanatory comment)
- **New:** \`scripts/check_sticky_nav.py\` (80 lines), \`.github/workflows/sticky-nav-check.yml\` (33 lines)

## Test plan
- [ ] Verify the lint exits 1 when a buggy pattern is present (smoke-tested locally: \`python scripts/check_sticky_nav.py\` against current origin/main returns exit 1 and lists 59 hits).
- [ ] Verify the lint exits 0 when the buggy pattern is absent (smoke-tested locally: after applying the #125 fix in-place, the lint returns OK and exit 0).
- [ ] After #125 merges and this branch is rebased, the workflow run on the PR should be green.
- [ ] Manually run \`python scripts/create_mneme_article.py\` (if you have the cPanel token) and confirm the generated article's HEAD now matches the repo's \`site/index.html\` rather than whatever is live.

## Out of scope
A canonical \`site/_template/concept-page.html\` scaffold &mdash; recommended for fully killing the human-driven propagation path but lifted to a separate discussion since it touches contributor workflow. The CI lint here gives equivalent protection at a fraction of the change surface.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)