### PR TITLE
site: SEO-strengthen Tier-4 integration surfaces and add Warp + CI-governance pages

### DIFF
--- a/scripts/generate_og_images.py
+++ b/scripts/generate_og_images.py
@@ -65,6 +65,8 @@ TEMPLATE_MAP = {
     "og-integration-adr-import.html": "integrations/adr-import/og.png",
     "og-integration-copilot.html": "integrations/copilot/og.png",
     "og-integration-jetbrains.html": "integrations/jetbrains/og.png",
+    "og-integration-warp.html": "integrations/warp/og.png",
+    "og-ci-governance.html": "use-cases/ci-governance-for-ai-generated-code/og.png",
 
     # Insights — new
     "og-insights-genai-stack.html": "insights/generative-ai-software-engineering-stack/og.png",

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mneme HQ + Cursor — Mneme HQ</title>
+  <title>Cursor Governance: ADR Enforcement via Rules Export — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta name="description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/integrations/cursor/" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
-  <meta property="og:title" content="Mneme HQ + Cursor" />
-  <meta property="og:description" content="Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta property="og:title" content="Cursor Governance — Mneme HQ" />
+  <meta property="og:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
   <meta property="og:url" content="https://mnemehq.com/integrations/cursor/" />
   <meta property="og:image" content="https://mnemehq.com/integrations/cursor/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Mneme HQ + Cursor" />
-  <meta name="twitter:description" content="Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta name="twitter:title" content="Cursor Governance — Mneme HQ" />
+  <meta name="twitter:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
   <meta name="twitter:image" content="https://mnemehq.com/integrations/cursor/og.png" />
   <meta name="author" content="Theo Valmis" />
   <meta property="article:published_time" content="2026-05-07T00:00:00Z" />
@@ -290,7 +290,7 @@
       <span class="eyebrow-dot"></span>
       <span class="eyebrow-meta">4 min read &nbsp;·&nbsp; May 2026</span>
     </div>
-    <h1>Mneme HQ + Cursor</h1>
+    <h1>Cursor Governance</h1>
     <p class="article-lede">Cursor coordinates execution; Mneme enforces architectural intent. Cursor Rules are one surface that intent shows up on &mdash; generated from the decision corpus, structured, versioned, and resolved across conflicting rules before they reach Cursor. The two run side by side: Cursor as the harness, Mneme as the governance layer underneath it.</p>
     <p class="byline" style="font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem;">
       By <a href="/founder/" style="color:var(--muted); text-decoration:none;">Theo Valmis</a>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Architectural Governance in GitHub Actions — Mneme HQ</title>
+  <title>GitHub Actions AI Governance: PR-Level Architectural Enforcement — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Run Mneme HQ's checks in your CI pipeline. Block pull requests that violate architectural decisions before they merge — direct enforcement after generation." />
+  <meta name="description" content="GitHub Actions AI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff and block merges that violate architectural decisions — direct enforcement after generation." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/integrations/github-actions/" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
-  <meta property="og:title" content="Architectural Governance in GitHub Actions" />
-  <meta property="og:description" content="Run Mneme HQ's checks in your CI pipeline. Block pull requests that violate architectural decisions before they merge — direct enforcement after generation." />
+  <meta property="og:title" content="GitHub Actions AI Governance — Mneme HQ" />
+  <meta property="og:description" content="GitHub Actions AI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff and block merges that violate architectural decisions — direct enforcement after generation." />
   <meta property="og:url" content="https://mnemehq.com/integrations/github-actions/" />
   <meta property="og:image" content="https://mnemehq.com/integrations/github-actions/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Architectural Governance in GitHub Actions" />
-  <meta name="twitter:description" content="Run Mneme HQ's checks in your CI pipeline. Block pull requests that violate architectural decisions before they merge — direct enforcement after generation." />
+  <meta name="twitter:title" content="GitHub Actions AI Governance — Mneme HQ" />
+  <meta name="twitter:description" content="GitHub Actions AI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff and block merges that violate architectural decisions — direct enforcement after generation." />
   <meta name="twitter:image" content="https://mnemehq.com/integrations/github-actions/og.png" />
   <meta name="author" content="Theo Valmis" />
   <meta property="article:published_time" content="2026-05-07T00:00:00Z" />
@@ -290,7 +290,7 @@
       <span class="eyebrow-dot"></span>
       <span class="eyebrow-meta">4 min read &nbsp;&middot;&nbsp; May 2026</span>
     </div>
-    <h1>Architectural Governance in GitHub Actions</h1>
+    <h1>GitHub Actions AI Governance</h1>
     <p class="article-lede">Pre-generation enforcement catches most violations before code is written. CI enforcement catches the rest &mdash; running Mneme's checks against every PR diff, blocking merges that violate architectural decisions.</p>
     <p class="byline" style="font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem;">
       By <a href="/founder/" style="color:var(--muted); text-decoration:none;">Theo Valmis</a>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -56,7 +56,8 @@
           {"@type": "WebPage", "name": "ADR Import", "url": "https://mnemehq.com/integrations/adr-import/"},
           {"@type": "WebPage", "name": "GitHub Copilot", "url": "https://mnemehq.com/integrations/copilot/"},
           {"@type": "WebPage", "name": "JetBrains", "url": "https://mnemehq.com/integrations/jetbrains/"},
-          {"@type": "WebPage", "name": "Perplexity Enterprise", "url": "https://mnemehq.com/integrations/perplexity/"}
+          {"@type": "WebPage", "name": "Perplexity Enterprise", "url": "https://mnemehq.com/integrations/perplexity/"},
+          {"@type": "WebPage", "name": "Warp", "url": "https://mnemehq.com/integrations/warp/"}
         ]
       }
     ]
@@ -326,6 +327,17 @@
       <p>JetBrains AI Assistant runs across IntelliJ, PyCharm, WebStorm, and the rest of the family. Mneme HQ's decision corpus is the constraint layer those sessions read &mdash; enforced via <code style="font-family:'DM Mono',monospace;font-size:0.82em;">mneme check</code> in CI regardless of the IDE.</p>
       <div class="card-footer">
         <a href="/integrations/jetbrains/" class="read-link">Learn more &rarr;</a>
+      </div>
+    </div>
+
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">Works alongside</span>
+      </div>
+      <h3>Warp AI Terminal Governance</h3>
+      <p>Warp orchestrates Agent Mode and autonomous execution. Mneme HQ preserves the architectural invariants underneath those loops &mdash; enforced at the file-write boundary regardless of which agent Warp spawns.</p>
+      <div class="card-footer">
+        <a href="/integrations/warp/" class="read-link">Learn more &rarr;</a>
       </div>
     </div>
 

--- a/site/integrations/warp/index.html
+++ b/site/integrations/warp/index.html
@@ -3,27 +3,27 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Claude Code Governance: Hook-Level Architectural Enforcement — Mneme HQ</title>
+  <title>Warp AI Terminal Governance: Architectural Invariants for Autonomous Workflows — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
+  <meta name="description" content="Warp AI terminal governance for autonomous coding workflows. Mneme HQ preserves the architectural invariants underneath Warp's Agent Mode and execution loops — enforced at the file-write boundary, not the terminal." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
-  <link rel="canonical" href="https://mnemehq.com/integrations/claude-code/" />
+  <link rel="canonical" href="https://mnemehq.com/integrations/warp/" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
-  <meta property="og:title" content="Claude Code Governance — Mneme HQ" />
-  <meta property="og:description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
-  <meta property="og:url" content="https://mnemehq.com/integrations/claude-code/" />
-  <meta property="og:image" content="https://mnemehq.com/integrations/claude-code/og.png" />
+  <meta property="og:title" content="Warp AI Terminal Governance — Mneme HQ" />
+  <meta property="og:description" content="Warp AI terminal governance for autonomous coding workflows. Mneme HQ preserves the architectural invariants underneath Warp's Agent Mode and execution loops — enforced at the file-write boundary, not the terminal." />
+  <meta property="og:url" content="https://mnemehq.com/integrations/warp/" />
+  <meta property="og:image" content="https://mnemehq.com/integrations/warp/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Claude Code Governance — Mneme HQ" />
-  <meta name="twitter:description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
-  <meta name="twitter:image" content="https://mnemehq.com/integrations/claude-code/og.png" />
+  <meta name="twitter:title" content="Warp AI Terminal Governance — Mneme HQ" />
+  <meta name="twitter:description" content="Warp AI terminal governance for autonomous coding workflows. Mneme HQ preserves the architectural invariants underneath Warp's Agent Mode and execution loops — enforced at the file-write boundary, not the terminal." />
+  <meta name="twitter:image" content="https://mnemehq.com/integrations/warp/og.png" />
   <meta name="author" content="Theo Valmis" />
-  <meta property="article:published_time" content="2026-05-07T00:00:00Z" />
+  <meta property="article:published_time" content="2026-05-26T00:00:00Z" />
   <meta property="article:author" content="https://mnemehq.com/founder/" />
   <meta property="article:section" content="Integration" />
 
@@ -60,21 +60,6 @@
     .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
     .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
     .article-lede { font-size: 1.1rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
-    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
-    .byline a { color: var(--muted); text-decoration: none; }
-    .byline a:hover { color: var(--text); }
-    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
-
-    .faq-list { margin-top: 1.5rem; }
-    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
-    .faq-item:last-child { border-bottom: 1px solid var(--border); }
-    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
-    .faq-item summary::-webkit-details-marker { display: none; }
-    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
-    .faq-item[open] summary::after { content: '\2212'; }
-    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
-    .faq-body a { color: var(--accent); text-decoration: none; }
-    .faq-body a:hover { color: var(--accent-dim); }
 
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
@@ -102,13 +87,6 @@
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
-
-    .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
-    .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
-    .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
-    .comparison-table td:first-child { color: var(--muted); white-space: nowrap; font-family: 'DM Mono', monospace; font-size: 0.82rem; }
-    .comparison-table td:nth-child(2) { color: var(--text); }
-    .comparison-table td:nth-child(3) { color: var(--teal); }
 
     .article-footer { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
     .back-link { color: var(--muted); font-size: 0.82rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; }
@@ -143,82 +121,49 @@
       .nav-links a:not(.btn-nav-cta) { display: block; color: var(--text); font-size: 0.88rem; padding: 0.7rem 0; border-bottom: 1px solid var(--border); }
       .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
     }
-/* === Nav upgrade (injected, overrides existing) === */
-.nav-hamburger {
-  display: none;
-  background: none;
-  border: 1px solid var(--border2);
-  color: var(--text);
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  gap: 4px;
-  transition: border-color 0.15s, background 0.15s;
-}
-.nav-hamburger:hover { border-color: var(--accent); }
-.nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.nav-hamburger span {
-  display: block;
-  width: 18px;
-  height: 2px;
-  background: currentColor;
-  border-radius: 1px;
-  transition: transform 0.25s ease, opacity 0.18s ease;
-  transform-origin: center;
-}
-.nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .faq-list { margin: 1.5rem 0 0; }
+    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
+    .faq-item[open] summary::after { content: '\2212'; }
+    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
 
 @media (max-width: 900px) {
-  html, body { overflow-x: clip; }
+  html, body { overflow-x: hidden; }
   body.menu-open { overflow: hidden; }
   nav, nav.site-nav { padding: 1rem 1.25rem; }
-  .nav-hamburger { display: flex; }
+  .nav-hamburger { display: flex; flex-direction: column; gap: 4px; width: 40px; height: 40px; border-radius: 8px; }
+  .nav-hamburger span { display: block; width: 18px; height: 2px; background: currentColor; border-radius: 1px; transition: transform 0.25s ease, opacity 0.18s ease; transform-origin: center; }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
   .nav-links {
-    display: flex !important;
-    flex-direction: column;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    gap: 0;
-    background: rgba(12,12,13,0.98);
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--border);
-    padding: 0 1.25rem;
-    z-index: 99;
-    max-height: 0;
-    overflow: hidden;
-    opacity: 0;
-    visibility: hidden;
+    display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0;
+    gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99;
+    max-height: 0; overflow: hidden; opacity: 0; visibility: hidden;
     transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s;
   }
   .nav-links.open {
-    max-height: 80vh;
-    opacity: 1;
-    visibility: visible;
-    padding: 0.5rem 1.25rem 1.25rem;
+    max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem;
     transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s;
     overflow-y: auto;
   }
   .nav-links a:not(.btn-nav-cta) {
-    display: block;
-    color: var(--text);
-    font-size: 0.92rem;
-    padding: 0.85rem 0;
-    border-bottom: 1px solid var(--border);
+    display: block; color: var(--text); font-size: 0.92rem;
+    padding: 0.85rem 0; border-bottom: 1px solid var(--border);
   }
   .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
   .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
 }
-      /* === Related reading === */
+
+    /* Related reading */
     h2#related-reading { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 400; margin-top: 3.5rem; margin-bottom: 0.75rem; }
     h2#related-reading + ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
     h2#related-reading + ul li { margin: 0; }
@@ -226,7 +171,7 @@
     h2#related-reading + ul li a::after { content: '\2192'; opacity: 0.35; transition: opacity 0.15s, transform 0.15s; display: inline-block; margin-left: 0.5rem; }
     h2#related-reading + ul li a:hover { background: var(--surface2); color: var(--accent); }
     h2#related-reading + ul li a:hover::after { opacity: 1; transform: translateX(3px); }
-  
+
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
   <script type="application/ld+json">
@@ -238,39 +183,27 @@
         "itemListElement": [
           {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
           {"@type": "ListItem", "position": 2, "name": "Integrations", "item": "https://mnemehq.com/integrations/"},
-          {"@type": "ListItem", "position": 3, "name": "Claude Code", "item": "https://mnemehq.com/integrations/claude-code/"}
+          {"@type": "ListItem", "position": 3, "name": "Warp", "item": "https://mnemehq.com/integrations/warp/"}
         ]
       },
       {
         "@type": "Article",
-        "headline": "Governing Claude Code Workflows",
-        "description": "Mneme HQ hooks into every Edit, Write, and MultiEdit Claude Code attempts — intercepting architectural violations before they reach your codebase.",
-        "url": "https://mnemehq.com/integrations/claude-code/",
-        "datePublished": "2026-05-07",
-        "dateModified": "2026-05-07",
+        "headline": "Warp AI Terminal Governance",
+        "description": "Warp AI terminal governance for autonomous coding workflows. Mneme HQ preserves the architectural invariants underneath Warp's Agent Mode and execution loops — enforced at the file-write boundary, not the terminal.",
+        "url": "https://mnemehq.com/integrations/warp/",
+        "datePublished": "2026-05-26",
+        "dateModified": "2026-05-26",
         "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
         "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
-        "image": "https://mnemehq.com/integrations/claude-code/og.png",
-        "mainEntityOfPage": "https://mnemehq.com/integrations/claude-code/"
+        "image": "https://mnemehq.com/integrations/warp/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/integrations/warp/"
       },
       {
         "@type": "FAQPage",
         "mainEntity": [
-          {"@type": "Question", "name": "How is the Mneme hook different from CLAUDE.md?", "acceptedAnswer": {"@type": "Answer", "text": "CLAUDE.md is static context: text injected at session start that the model is asked to respect. The Mneme hook runs as a PreToolUse hook — it intercepts every Edit, Write, and MultiEdit before they touch the filesystem and can return exit code 2 to block the operation outright. CLAUDE.md is advisory; the hook is enforcement. The two are complementary: CLAUDE.md gives the model context, Mneme blocks violations regardless of whether the model attended to that context."}},
-          {"@type": "Question", "name": "Does the hook slow down Claude Code sessions?", "acceptedAnswer": {"@type": "Answer", "text": "The retriever is deterministic keyword scoring with no embedding model and no vector store, so per-call latency is in the low milliseconds for typical projects. The hook runs locally; there is no network round trip. For projects with very large decision corpora, scope filters and tag indices keep retrieval bounded."}},
-          {"@type": "Question", "name": "What happens if Mneme itself fails?", "acceptedAnswer": {"@type": "Answer", "text": "The hook is designed fail-open: if the Mneme process errors, returns invalid output, or times out, Claude Code is allowed to proceed rather than being blocked. This is a deliberate safety choice — a broken governance layer should not lock the team out of editing their codebase. Strict mode (mneme check --mode strict) in CI is where hard-blocking lives; the editor-time hook prioritizes availability."}},
-          {"@type": "Question", "name": "Can I use the hook without committing project_memory.json?", "acceptedAnswer": {"@type": "Answer", "text": "Technically yes, but you lose the value. The decision corpus is the source of truth; committing it to the repo means every team member sees the same enforcement, and changes to architectural rules show up in PR review like any other change. Local-only memory recreates the per-engineer drift problem the layer exists to solve."}}
-        ]
-      },
-      {
-        "@type": "HowTo",
-        "name": "Wire Mneme HQ into Claude Code",
-        "description": "Install Mneme, register the PreToolUse hook with Claude Code, and verify enforcement on a test diff.",
-        "step": [
-          {"@type": "HowToStep", "name": "Install", "text": "pip install mneme && mneme init scaffolds project_memory.json at the repo root."},
-          {"@type": "HowToStep", "name": "Register the hook", "text": "Add the mneme-hook command as a PreToolUse hook in your Claude Code hooks configuration so Edit, Write, and MultiEdit operations check the corpus before applying changes."},
-          {"@type": "HowToStep", "name": "Populate decisions", "text": "Replace the placeholder ADRs in project_memory.json with the team's real decisions, including scope (file globs), status, and rationale."},
-          {"@type": "HowToStep", "name": "Verify enforcement", "text": "Trigger a test edit that violates one of the decisions. The hook should block the edit and surface the decision id as feedback. Adjust mode (warn / strict) per environment."}
+          {"@type": "Question", "name": "Is this a native Warp integration?", "acceptedAnswer": {"@type": "Answer", "text": "No. Mneme HQ does not hook into Warp itself. It governs the agents and processes Warp runs — Claude Code via its PreToolUse hook, CI runs via mneme check, and any tool that writes to disk via repo-level enforcement. Warp orchestrates execution; Mneme governs the architectural intent underneath."}},
+          {"@type": "Question", "name": "Does Mneme slow down Warp Agent Mode?", "acceptedAnswer": {"@type": "Answer", "text": "Enforcement runs at the file-write boundary, not on every terminal command. Latency is bounded by the agent's edit path, not Warp's orchestration speed. Most violations surface immediately as a blocked tool call with the decision id and rationale."}},
+          {"@type": "Question", "name": "What about Warp workflows that don't use Claude Code?", "acceptedAnswer": {"@type": "Answer", "text": "The CI gate still applies. mneme check runs in GitHub Actions against every PR diff regardless of which agent or tool produced it. For interactive enforcement with non-Claude agents, the Cursor Rules export or repo-level conventions are the available surfaces today."}}
         ]
       }
     ]
@@ -287,10 +220,8 @@
   <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
   <div class="nav-links">
     <a href="/#how-it-works">How it works</a>
-    <a href="/concepts/">Concepts</a>
     <a href="/use-cases/">Use cases</a>
     <a href="/insights/">Insights</a>
-    <a href="/qa-glossary/">Q&amp;A</a>
     <a href="/roadmap/">Roadmap</a>
     <a href="/demo/">Demo</a>
     <a href="/benchmark/">Benchmark</a>
@@ -304,234 +235,119 @@
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
     <li><a href="/integrations/">Integrations</a></li>
-    <li aria-current="page">Claude Code</li>
+    <li aria-current="page">Warp</li>
   </ol>
 </nav>
 <article class="article-wrap">
   <header class="article-header">
     <div class="article-eyebrow">
-      <span class="eyebrow-tag">Integration &middot; Claude Code</span>
+      <span class="eyebrow-tag">Integration &middot; Warp</span>
       <span class="eyebrow-dot"></span>
-      <span class="eyebrow-meta">6 min read &nbsp;·&nbsp; May 2026</span>
+      <span class="eyebrow-meta">4 min read &nbsp;&middot;&nbsp; May 2026</span>
     </div>
-    <h1>Claude Code Governance</h1>
-    <p class="article-lede">Mneme HQ registers a PreToolUse hook with Claude Code. Every Edit, Write, and MultiEdit is intercepted before it reaches disk &mdash; violations surface the decision id as feedback and exit 2 (block). Claude Code adjusts its approach without manual intervention.</p>
-    <p style="font-size:0.92rem;color:var(--muted);line-height:1.85;margin-top:1rem;max-width:680px;">Claude Code is a harness &mdash; it coordinates execution, tool use, and the agent loop. Mneme is the governance layer that runs alongside it, enforcing the architectural intent the harness has no opinion about. They are different layers of the runtime stack, and they run side by side. The argument in full: <a href="/insights/harness-engineering-still-needs-governance/" style="color:var(--teal);">Harness Engineering Still Needs Governance</a>.</p>
+    <h1>Warp AI Terminal Governance</h1>
+    <p class="article-lede">Warp's AI-native terminal accelerates how engineering teams run agents and orchestrate execution. Mneme HQ preserves the architectural invariants underneath those loops &mdash; the decisions that must remain true regardless of which agent Warp spawns, which model it routes to, or how many parallel sessions it coordinates.</p>
     <p class="byline">
       By <a href="/founder/">Theo Valmis</a>
       <span class="sep">&middot;</span>
-      <time datetime="2026-05-07">Published May 2026</time>
-      <span class="sep">&middot;</span>
-      <time datetime="2026-05-10">Updated May 2026</time>
+      <time datetime="2026-05-26">Published May 2026</time>
     </p>
   </header>
 
   <div class="article-body">
 
-    <h2>How the hook works</h2>
+    <h2>Where Mneme fits in a Warp workflow</h2>
 
-    <p>Every Edit, Write, or MultiEdit Claude Code attempts is intercepted by <code>mneme-hook</code> before it writes to disk. The hook reconstructs the full post-edit file content, checks it against your recorded decisions, and returns a verdict.</p>
+    <p>Warp's strength is execution: an engineer issues intent, Warp orchestrates the agents, processes, and tool invocations that fulfill it. Agent Mode pushes that further &mdash; autonomous loops that read, plan, edit, and verify across many shells in parallel.</p>
 
-    <p>The exit code semantics are deterministic: <strong>exit 0 allows the edit</strong>; <strong>exit 2 blocks it</strong> and surfaces the violated decision id as feedback to Claude Code. Claude Code sees the block as an error message, reads the decision id and rule, and adjusts its approach without you having to intervene.</p>
-
-    <pre><code>on Edit / Write / MultiEdit:
-  content = reconstruct_full_file(tool_input)
-  result  = mneme check --file &lt;path&gt; &lt;content&gt;
-  if result.violation:
-    exit 2   # block — surfaces decision_id to Claude Code
-  else:
-    exit 0   # allow</code></pre>
+    <p>That orchestration is upstream of the file-write boundary. Mneme HQ enforces at the file-write boundary. The two compose: Warp coordinates how work happens; Mneme constrains what work is allowed to land in the codebase.</p>
 
     <div class="callout">
-      <p><strong>Fail-open by design.</strong> The hook never blocks on Mneme malfunction. If <code>mneme</code> is not found, the file can't be read, or <code>mneme check</code> times out (10 s limit), the hook exits 0 and allows the edit.</p>
+      <p><strong>This is not a native Warp integration.</strong> Mneme does not have a Warp-specific hook. It governs the agents Warp runs &mdash; Claude Code via its PreToolUse hook, CI runs via <code>mneme check</code>, and any tool that writes to disk via the repo-level decision corpus.</p>
     </div>
 
-    <h2>Install</h2>
+    <h2>What gets enforced regardless of how Warp executes</h2>
 
-    <ol>
-      <li>
-        <strong>Install the package</strong>
-        <pre><code>pip install mneme</code></pre>
-      </li>
-      <li>
-        <strong>Initialise project memory (if you don't have one yet)</strong>
-        <pre><code>mkdir .mneme
-# Create .mneme/project_memory.json — see examples/project_memory.json for the schema.</code></pre>
-      </li>
-      <li>
-        <strong>Run the installer</strong>
-        <p>Project-scoped (recommended — only affects this project):</p>
-        <pre><code>python scripts/install_claude_code.py</code></pre>
-        <p>User-scoped (applies to all Claude Code sessions):</p>
-        <pre><code>python scripts/install_claude_code.py --user</code></pre>
-        <p>The installer is idempotent — safe to run again after updates.</p>
-      </li>
-      <li>
-        <strong>Verify</strong>
-        <p>Open Claude Code in your project, make an edit that violates a recorded decision, and confirm the hook blocks it and surfaces the decision id.</p>
-      </li>
-    </ol>
+    <ul>
+      <li><strong>ADRs and architectural decisions.</strong> Recorded in <code>.mneme/project_memory.json</code>, enforced at every edit attempt — whether the edit originates from Warp Agent Mode, an interactive Claude Code session inside a Warp pane, or a CLI tool a Warp workflow spawned.</li>
+      <li><strong>Forbidden dependencies and approved patterns.</strong> Catalogued as anti-patterns and constraints; surfaced as feedback when an agent attempts a violating edit.</li>
+      <li><strong>Path and boundary rules.</strong> Module-level constraints (e.g. "no direct database access from controllers") that hold regardless of which session produced the diff.</li>
+      <li><strong>The CI gate.</strong> <code>mneme check</code> runs against every PR diff in GitHub Actions or GitLab CI &mdash; the final line of defense after generation, independent of which terminal launched the work.</li>
+    </ul>
 
-    <h2>Slash commands</h2>
+    <h2>The seam: Warp orchestrates, Mneme governs</h2>
 
-    <p>After installing, four slash commands are available in Claude Code:</p>
+    <p>Warp Agent Mode coordinates parallel agents in dedicated panes. Each agent eventually writes to disk through a tool call. Mneme operates at that boundary:</p>
 
-    <div style="overflow-x:auto;margin:2rem 0;">
-    <table class="comparison-table">
-      <thead>
-        <tr>
-          <th>Command</th>
-          <th>Purpose</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>/mneme-context</td>
-          <td>Retrieve decisions relevant to your current task</td>
-        </tr>
-        <tr>
-          <td>/mneme-check</td>
-          <td>Check a file or draft against project memory</td>
-        </tr>
-        <tr>
-          <td>/mneme-record</td>
-          <td>Record a new architectural decision</td>
-        </tr>
-        <tr>
-          <td>/mneme-review</td>
-          <td>Audit all pending diff changes against decisions</td>
-        </tr>
-      </tbody>
-    </table>
+    <ul>
+      <li>If the agent is <strong>Claude Code</strong>, the Mneme PreToolUse hook intercepts every <code>Edit</code>, <code>Write</code>, and <code>MultiEdit</code> before disk &mdash; violations exit 2 with the decision id, and Claude Code adjusts.</li>
+      <li>If the agent is <strong>Cursor</strong> running inside or alongside a Warp pane, the Mneme-generated <code>.cursor/rules/mneme.mdc</code> file is what the session reads as context.</li>
+      <li>If the agent is <strong>any other tool</strong> that writes to the repo, the CI gate catches the diff at PR time.</li>
+    </ul>
+
+    <p>None of these paths require Warp itself to know about Mneme. The governance layer sits below the orchestration layer.</p>
+
+    <h2>Setup</h2>
+
+    <pre><code>pip install mneme
+mneme init
+# Wire Claude Code hook (if using Claude Code in Warp panes)
+mneme hooks install
+# Wire CI gate
+mneme check --mode warn   # try locally first</code></pre>
+
+    <p>From there, every agent Warp runs inherits the same enforcement &mdash; no per-agent configuration, no Warp-side install.</p>
+
+    <h2>If you use Warp Agent Mode with Claude Code</h2>
+
+    <p>This is the most common combination today. Warp coordinates multiple Agent Mode panes, each running Claude Code against a slice of work. Mneme's PreToolUse hook applies in every pane simultaneously:</p>
+
+    <ul>
+      <li>Each Claude Code session reads the same <code>project_memory.json</code></li>
+      <li>Each <code>Edit</code> or <code>Write</code> tool call is intercepted before disk</li>
+      <li>Violations surface in the agent's own feedback loop &mdash; not as a post-hoc PR comment</li>
+      <li>Parallel sessions cannot diverge architecturally because they all defer to the same corpus</li>
+    </ul>
+
+    <div class="callout">
+      <p><strong>Why this matters as agents scale horizontally.</strong> When Warp runs four Claude Code agents in parallel, the failure mode without governance is four mutually-inconsistent diffs that all "pass" because each agent only sees its own slice. Mneme makes the architectural corpus the shared invariant they all read against.</p>
     </div>
-
-    <h2>Modes</h2>
-
-    <div style="overflow-x:auto;margin:2rem 0;">
-    <table class="comparison-table">
-      <thead>
-        <tr>
-          <th>Mode</th>
-          <th>Behaviour</th>
-          <th>Set via</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>strict (default)</td>
-          <td>Block on any non-zero verdict from <code>mneme check</code></td>
-          <td><code>export MNEME_HOOK_MODE=strict</code></td>
-        </tr>
-        <tr>
-          <td>warn</td>
-          <td>Surface warning to Claude, never block</td>
-          <td><code>export MNEME_HOOK_MODE=warn</code></td>
-        </tr>
-      </tbody>
-    </table>
-    </div>
-
-    <p>Switch to <code>warn</code> while you're iterating on decisions to avoid friction:</p>
-    <pre><code>export MNEME_HOOK_MODE=warn</code></pre>
-
-    <h2>Retrieval: what the hook checks and what it misses</h2>
-
-    <p>The hook query is <code>"edit to &lt;file_path&gt;"</code> — tokens from the target file name determine which decisions are retrieved and checked. Decisions are scored by keyword overlap between the query and their <code>scope</code>, <code>id</code>, decision text, and anti-pattern fields.</p>
-
-    <p><strong>What this means in practice:</strong></p>
-
-    <ul>
-      <li>A decision with <code>scope: ["storage", "database"]</code> and a file named <code>storage_layer.py</code> will reliably be retrieved — "storage" appears in both the query and the scope.</li>
-      <li>The same decision may <strong>not</strong> be retrieved for an edit to <code>models.py</code> — neither token overlaps with the scope.</li>
-      <li>Generic file names like <code>utils.py</code> or <code>helpers.py</code> will rarely retrieve any decisions at all.</li>
-    </ul>
-
-    <p><strong>Mitigations:</strong></p>
-
-    <ol>
-      <li>Choose scope keywords when recording decisions that match file names in your project. Use <code>/mneme-record</code> and follow the scope tip in the command.</li>
-      <li>Run <code>/mneme-context</code> before non-trivial edits with a descriptive phrase describing the domain (e.g. "storage layer", "auth middleware"). This uses a richer query than the hook and surfaces decisions the hook might miss.</li>
-      <li>Run <code>/mneme-review</code> after a batch of edits to catch violations the per-edit hook missed due to retrieval gaps.</li>
-    </ol>
-
-    <p>The hook is a first line of defence, not a complete audit. Use the slash commands for coverage on domains where file names are not self-describing.</p>
-
-    <h2>Fail-open guarantees</h2>
-
-    <p>The hook <strong>never blocks</strong> on execution errors. It exits 0 (allow) when:</p>
-
-    <ul>
-      <li><code>mneme</code> is not found on <code>$PATH</code></li>
-      <li>The target file cannot be read (common for Write — the file doesn't exist yet)</li>
-      <li><code>mneme check</code> times out (limit: 10 s)</li>
-      <li>Any other OS-level error occurs</li>
-    </ul>
-
-    <p>Only a real verdict returned by <code>mneme check</code> can cause a block.</p>
-
-    <h2>Troubleshooting</h2>
-
-    <h3>Hook is not firing</h3>
-    <ul>
-      <li>Confirm <code>mneme-hook</code> is on <code>$PATH</code>: <code>which mneme-hook</code> (or <code>where mneme-hook</code> on Windows).</li>
-      <li>If not, the pip scripts directory may not be on <code>$PATH</code>. Add it, or install with <code>pipx</code>.</li>
-      <li>Confirm <code>.claude/settings.json</code> contains the <code>PreToolUse</code> entry (run the installer again).</li>
-    </ul>
-
-    <h3>Hook fires but nothing is blocked</h3>
-    <ul>
-      <li>Confirm <code>.mneme/project_memory.json</code> exists in the project root (or a parent directory).</li>
-      <li>Check your decision scope keywords against the file names being edited — see the retrieval section above.</li>
-      <li>Switch to warn mode temporarily and check stderr output from <code>mneme-hook</code> for clues.</li>
-    </ul>
-
-    <h3>Too many false positives / blocks</h3>
-    <ul>
-      <li>Switch to <code>MNEME_HOOK_MODE=warn</code> while refining your decisions.</li>
-      <li>Review the triggered anti-patterns with <code>/mneme-context</code> to see if they're too broad.</li>
-    </ul>
 
     <h2>FAQ</h2>
 
     <div class="faq-list">
       <details class="faq-item">
-        <summary>How is the Mneme hook different from CLAUDE.md?</summary>
-        <div class="faq-body">CLAUDE.md is static context: text injected at session start that the model is asked to respect. The Mneme hook runs as a PreToolUse hook &mdash; it intercepts every Edit, Write, and MultiEdit before they touch the filesystem and can return exit code 2 to block the operation outright. CLAUDE.md is advisory; the hook is enforcement. The two are complementary: CLAUDE.md gives the model context, Mneme blocks violations regardless of whether the model attended to that context. See <a href="/insights/why-prompt-memory-fails-at-scale/">why prompt memory fails at scale</a>.</div>
+        <summary>Is this a native Warp integration?</summary>
+        <div class="faq-body">No. Mneme HQ does not hook into Warp itself. It governs the agents and processes Warp runs &mdash; Claude Code via its PreToolUse hook, CI runs via <code>mneme check</code>, and any tool that writes to disk via repo-level enforcement. Warp orchestrates execution; Mneme governs the architectural intent underneath.</div>
       </details>
-
       <details class="faq-item">
-        <summary>Does the hook slow down Claude Code sessions?</summary>
-        <div class="faq-body">The retriever is deterministic keyword scoring with no embedding model and no vector store, so per-call latency is in the low milliseconds for typical projects. The hook runs locally; there is no network round trip. For projects with very large decision corpora, scope filters and tag indices keep retrieval bounded.</div>
+        <summary>Does Mneme slow down Warp Agent Mode?</summary>
+        <div class="faq-body">Enforcement runs at the file-write boundary, not on every terminal command. Latency is bounded by the agent's edit path, not Warp's orchestration speed. Most violations surface immediately as a blocked tool call with the decision id and rationale.</div>
       </details>
-
       <details class="faq-item">
-        <summary>What happens if Mneme itself fails?</summary>
-        <div class="faq-body">The hook is designed fail-open: if the Mneme process errors, returns invalid output, or times out, Claude Code is allowed to proceed rather than being blocked. This is a deliberate safety choice &mdash; a broken governance layer should not lock the team out of editing their codebase. Strict mode (<code>mneme check --mode strict</code>) in CI is where hard-blocking lives; the editor-time hook prioritizes availability.</div>
-      </details>
-
-      <details class="faq-item">
-        <summary>Can I use the hook without committing project_memory.json?</summary>
-        <div class="faq-body">Technically yes, but you lose the value. The decision corpus is the source of truth; committing it to the repo means every team member sees the same enforcement, and changes to architectural rules show up in PR review like any other change. Local-only memory recreates the per-engineer drift problem the layer exists to solve.</div>
+        <summary>What about Warp workflows that don't use Claude Code?</summary>
+        <div class="faq-body">The CI gate still applies. <code>mneme check</code> runs in GitHub Actions or GitLab CI against every PR diff regardless of which agent or tool produced it. For interactive enforcement with non-Claude agents, the Cursor Rules export or repo-level conventions are the available surfaces today.</div>
       </details>
     </div>
 
   </div>
 
-  
-    <h2 id="related-reading">Related reading</h2>
-    <ul>
-        <li><a href="/integrations/cursor/">the Cursor integration</a></li>
-        <li><a href="/integrations/github-actions/">the GitHub Actions enforcement gate</a></li>
-    </ul>
+  <h2 id="related-reading">Related reading</h2>
+  <ul>
+    <li><a href="/integrations/claude-code/">Claude Code governance</a></li>
+    <li><a href="/integrations/github-actions/">GitHub Actions AI governance</a></li>
+    <li><a href="/use-cases/multi-agent-workflow-governance/">Multi-agent workflow governance</a></li>
+    <li><a href="/works-with/">Works with &mdash; the full ecosystem map</a></li>
+  </ul>
 
   <footer class="article-footer">
     <a href="/integrations/" class="back-link">&#8592; All integrations</a>
 
     <div class="cta-block">
-      <h3>Start enforcing architectural decisions in Claude Code</h3>
-      <p>Open source, self-hosted. Install takes under five minutes.</p>
+      <h3>One corpus. Every agent Warp runs.</h3>
+      <p>Architectural decisions stay enforceable underneath whatever Warp orchestrates &mdash; Agent Mode, parallel Claude Code panes, autonomous workflows.</p>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
-      <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt Engineering Is Not Governance &rarr;</a>
+      <a href="/works-with/" class="cta-secondary">See the full ecosystem &rarr;</a>
     </div>
   </footer>
 </article>
@@ -556,7 +372,6 @@
         <li><a href="/concepts/">Concepts</a></li>
         <li><a href="/architecture/">Architecture</a></li>
         <li><a href="/insights/">Insights</a></li>
-        <li><a href="/qa-glossary/">Q&amp;A and Glossary</a></li>
         <li><a href="/standards/">Standards</a></li>
         <li><a href="/benchmark/">Benchmark</a></li>
         <li><a href="/docs/">Docs</a></li>
@@ -606,7 +421,7 @@
   </div>
 </footer>
 
-<script><!-- nav-active -->
+<script>
 (function(){
   var path = window.location.pathname;
   document.querySelectorAll('.nav-links a').forEach(function(a){

--- a/site/og-ci-governance.html
+++ b/site/og-ci-governance.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 1200px;
+    height: 630px;
+    background: #0c0c0d;
+    font-family: 'DM Mono', monospace;
+    overflow: hidden;
+    position: relative;
+  }
+  .grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(200,240,96,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(200,240,96,0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    pointer-events: none;
+  }
+  .glow {
+    position: absolute;
+    top: -120px;
+    left: -120px;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle at top left, rgba(200,240,96,0.08), transparent 70%);
+    pointer-events: none;
+  }
+  .container {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 44px 52px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  .top { display: flex; align-items: center; justify-content: space-between; }
+  .logo { font-family: 'Instrument Serif', serif; font-size: 26px; color: #e8e8ec; letter-spacing: -0.3px; }
+  .tag {
+    font-family: 'DM Mono', monospace; font-size: 11px; font-weight: 500;
+    color: #c8f060; background: rgba(200,240,96,0.08);
+    border: 1px solid rgba(200,240,96,0.25); border-radius: 100px;
+    padding: 5px 14px; letter-spacing: 0.04em; text-transform: uppercase;
+  }
+  .middle { flex: 1; display: flex; flex-direction: column; justify-content: center; max-width: 940px; padding-top: 8px; }
+  .heading { font-family: 'Instrument Serif', serif; font-size: 56px; line-height: 1.08; color: #e8e8ec; letter-spacing: -1px; margin-bottom: 20px; }
+  .heading em { font-style: italic; color: #c8f060; }
+  .subtitle { font-family: 'DM Mono', monospace; font-size: 15px; line-height: 1.65; color: #88889a; font-weight: 300; max-width: 760px; }
+  .bottom { display: flex; align-items: flex-end; justify-content: flex-end; }
+  .url { font-family: 'DM Mono', monospace; font-size: 12px; color: #55555f; letter-spacing: 0.01em; white-space: nowrap; }
+</style>
+</head>
+<body>
+  <div class="grid"></div>
+  <div class="glow"></div>
+  <div class="container">
+    <div class="top">
+      <span class="logo">Mneme HQ</span>
+      <span class="tag">Use case</span>
+    </div>
+    <div class="middle">
+      <div class="heading">CI Governance for <em>AI-Generated Code</em></div>
+      <div class="subtitle">The deterministic gate that catches what reviewer<br>attention can't, on every PR diff.</div>
+    </div>
+    <div class="bottom">
+      <div class="url">mnemehq.com/use-cases/ci-governance-for-ai-generated-code</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/og-integration-warp.html
+++ b/site/og-integration-warp.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 1200px;
+    height: 630px;
+    background: #0c0c0d;
+    font-family: 'DM Mono', monospace;
+    overflow: hidden;
+    position: relative;
+  }
+  .grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(200,240,96,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(200,240,96,0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    pointer-events: none;
+  }
+  .glow {
+    position: absolute;
+    top: -120px;
+    left: -120px;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle at top left, rgba(200,240,96,0.08), transparent 70%);
+    pointer-events: none;
+  }
+  .container {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 44px 52px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  .top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .logo {
+    font-family: 'Instrument Serif', serif;
+    font-size: 26px;
+    color: #e8e8ec;
+    letter-spacing: -0.3px;
+  }
+  .tag {
+    font-family: 'DM Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    color: #c8f060;
+    background: rgba(200,240,96,0.08);
+    border: 1px solid rgba(200,240,96,0.25);
+    border-radius: 100px;
+    padding: 5px 14px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .middle {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 880px;
+    padding-top: 8px;
+  }
+  .heading {
+    font-family: 'Instrument Serif', serif;
+    font-size: 60px;
+    line-height: 1.08;
+    color: #e8e8ec;
+    letter-spacing: -1px;
+    margin-bottom: 20px;
+  }
+  .heading em {
+    font-style: italic;
+    color: #c8f060;
+  }
+  .subtitle {
+    font-family: 'DM Mono', monospace;
+    font-size: 15px;
+    line-height: 1.65;
+    color: #88889a;
+    font-weight: 300;
+    max-width: 720px;
+  }
+  .bottom {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
+  .url {
+    font-family: 'DM Mono', monospace;
+    font-size: 12px;
+    color: #55555f;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+  <div class="grid"></div>
+  <div class="glow"></div>
+  <div class="container">
+    <div class="top">
+      <span class="logo">Mneme HQ</span>
+      <span class="tag">Integration</span>
+    </div>
+    <div class="middle">
+      <div class="heading">Warp <em>AI Terminal</em> Governance</div>
+      <div class="subtitle">Architectural invariants underneath Warp's Agent Mode<br>and autonomous execution loops.</div>
+    </div>
+    <div class="bottom">
+      <div class="url">mnemehq.com/integrations/warp</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -76,6 +76,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://mnemehq.com/insights/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
@@ -337,6 +342,11 @@
   </url>
   <url>
     <loc>https://mnemehq.com/integrations/claude-agent-sdk/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://mnemehq.com/integrations/warp/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/site/use-cases/ci-governance-for-ai-generated-code/index.html
+++ b/site/use-cases/ci-governance-for-ai-generated-code/index.html
@@ -3,29 +3,29 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Claude Code Governance: Hook-Level Architectural Enforcement — Mneme HQ</title>
+  <title>CI Governance for AI-Generated Code: PR-Level Architectural Enforcement — Mneme HQ</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
+  <meta name="description" content="CI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
-  <link rel="canonical" href="https://mnemehq.com/integrations/claude-code/" />
+  <link rel="canonical" href="https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
-  <meta property="og:title" content="Claude Code Governance — Mneme HQ" />
-  <meta property="og:description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
-  <meta property="og:url" content="https://mnemehq.com/integrations/claude-code/" />
-  <meta property="og:image" content="https://mnemehq.com/integrations/claude-code/og.png" />
+  <meta property="og:title" content="CI Governance for AI-Generated Code — Mneme HQ" />
+  <meta property="og:description" content="CI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code." />
+  <meta property="og:url" content="https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/" />
+  <meta property="og:image" content="https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Claude Code Governance — Mneme HQ" />
-  <meta name="twitter:description" content="Claude Code governance via PreToolUse hooks. Mneme HQ intercepts every Edit, Write, and MultiEdit Claude Code attempts and blocks architectural violations before they reach your codebase. Zero setup." />
-  <meta name="twitter:image" content="https://mnemehq.com/integrations/claude-code/og.png" />
+  <meta name="twitter:title" content="CI Governance for AI-Generated Code — Mneme HQ" />
+  <meta name="twitter:description" content="CI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code." />
+  <meta name="twitter:image" content="https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/og.png" />
   <meta name="author" content="Theo Valmis" />
-  <meta property="article:published_time" content="2026-05-07T00:00:00Z" />
+  <meta property="article:published_time" content="2026-05-26T00:00:00Z" />
   <meta property="article:author" content="https://mnemehq.com/founder/" />
-  <meta property="article:section" content="Integration" />
+  <meta property="article:section" content="Use case" />
 
     <!-- Consent defaults -->
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
@@ -60,21 +60,6 @@
     .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
     .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
     .article-lede { font-size: 1.1rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
-    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
-    .byline a { color: var(--muted); text-decoration: none; }
-    .byline a:hover { color: var(--text); }
-    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
-
-    .faq-list { margin-top: 1.5rem; }
-    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
-    .faq-item:last-child { border-bottom: 1px solid var(--border); }
-    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
-    .faq-item summary::-webkit-details-marker { display: none; }
-    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
-    .faq-item[open] summary::after { content: '\2212'; }
-    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
-    .faq-body a { color: var(--accent); text-decoration: none; }
-    .faq-body a:hover { color: var(--accent-dim); }
 
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
@@ -102,13 +87,6 @@
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
-
-    .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
-    .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
-    .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
-    .comparison-table td:first-child { color: var(--muted); white-space: nowrap; font-family: 'DM Mono', monospace; font-size: 0.82rem; }
-    .comparison-table td:nth-child(2) { color: var(--text); }
-    .comparison-table td:nth-child(3) { color: var(--teal); }
 
     .article-footer { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
     .back-link { color: var(--muted); font-size: 0.82rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; }
@@ -143,82 +121,48 @@
       .nav-links a:not(.btn-nav-cta) { display: block; color: var(--text); font-size: 0.88rem; padding: 0.7rem 0; border-bottom: 1px solid var(--border); }
       .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
     }
-/* === Nav upgrade (injected, overrides existing) === */
-.nav-hamburger {
-  display: none;
-  background: none;
-  border: 1px solid var(--border2);
-  color: var(--text);
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  gap: 4px;
-  transition: border-color 0.15s, background 0.15s;
-}
-.nav-hamburger:hover { border-color: var(--accent); }
-.nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.nav-hamburger span {
-  display: block;
-  width: 18px;
-  height: 2px;
-  background: currentColor;
-  border-radius: 1px;
-  transition: transform 0.25s ease, opacity 0.18s ease;
-  transform-origin: center;
-}
-.nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .faq-list { margin: 1.5rem 0 0; }
+    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
+    .faq-item[open] summary::after { content: '\2212'; }
+    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
 
 @media (max-width: 900px) {
-  html, body { overflow-x: clip; }
+  html, body { overflow-x: hidden; }
   body.menu-open { overflow: hidden; }
   nav, nav.site-nav { padding: 1rem 1.25rem; }
-  .nav-hamburger { display: flex; }
+  .nav-hamburger { display: flex; flex-direction: column; gap: 4px; width: 40px; height: 40px; border-radius: 8px; }
+  .nav-hamburger span { display: block; width: 18px; height: 2px; background: currentColor; border-radius: 1px; transition: transform 0.25s ease, opacity 0.18s ease; transform-origin: center; }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+  .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
   .nav-links {
-    display: flex !important;
-    flex-direction: column;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    gap: 0;
-    background: rgba(12,12,13,0.98);
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--border);
-    padding: 0 1.25rem;
-    z-index: 99;
-    max-height: 0;
-    overflow: hidden;
-    opacity: 0;
-    visibility: hidden;
+    display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0;
+    gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99;
+    max-height: 0; overflow: hidden; opacity: 0; visibility: hidden;
     transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s;
   }
   .nav-links.open {
-    max-height: 80vh;
-    opacity: 1;
-    visibility: visible;
-    padding: 0.5rem 1.25rem 1.25rem;
+    max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem;
     transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s;
     overflow-y: auto;
   }
   .nav-links a:not(.btn-nav-cta) {
-    display: block;
-    color: var(--text);
-    font-size: 0.92rem;
-    padding: 0.85rem 0;
-    border-bottom: 1px solid var(--border);
+    display: block; color: var(--text); font-size: 0.92rem;
+    padding: 0.85rem 0; border-bottom: 1px solid var(--border);
   }
   .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
   .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
 }
-      /* === Related reading === */
+
     h2#related-reading { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 400; margin-top: 3.5rem; margin-bottom: 0.75rem; }
     h2#related-reading + ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
     h2#related-reading + ul li { margin: 0; }
@@ -226,7 +170,7 @@
     h2#related-reading + ul li a::after { content: '\2192'; opacity: 0.35; transition: opacity 0.15s, transform 0.15s; display: inline-block; margin-left: 0.5rem; }
     h2#related-reading + ul li a:hover { background: var(--surface2); color: var(--accent); }
     h2#related-reading + ul li a:hover::after { opacity: 1; transform: translateX(3px); }
-  
+
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
   <script type="application/ld+json">
@@ -237,40 +181,28 @@
         "@type": "BreadcrumbList",
         "itemListElement": [
           {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
-          {"@type": "ListItem", "position": 2, "name": "Integrations", "item": "https://mnemehq.com/integrations/"},
-          {"@type": "ListItem", "position": 3, "name": "Claude Code", "item": "https://mnemehq.com/integrations/claude-code/"}
+          {"@type": "ListItem", "position": 2, "name": "Use cases", "item": "https://mnemehq.com/use-cases/"},
+          {"@type": "ListItem", "position": 3, "name": "CI Governance for AI-Generated Code", "item": "https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/"}
         ]
       },
       {
         "@type": "Article",
-        "headline": "Governing Claude Code Workflows",
-        "description": "Mneme HQ hooks into every Edit, Write, and MultiEdit Claude Code attempts — intercepting architectural violations before they reach your codebase.",
-        "url": "https://mnemehq.com/integrations/claude-code/",
-        "datePublished": "2026-05-07",
-        "dateModified": "2026-05-07",
+        "headline": "CI Governance for AI-Generated Code",
+        "description": "CI governance for AI-generated code. Run Mneme HQ's enforcement checks against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code.",
+        "url": "https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/",
+        "datePublished": "2026-05-26",
+        "dateModified": "2026-05-26",
         "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
         "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
-        "image": "https://mnemehq.com/integrations/claude-code/og.png",
-        "mainEntityOfPage": "https://mnemehq.com/integrations/claude-code/"
+        "image": "https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/"
       },
       {
         "@type": "FAQPage",
         "mainEntity": [
-          {"@type": "Question", "name": "How is the Mneme hook different from CLAUDE.md?", "acceptedAnswer": {"@type": "Answer", "text": "CLAUDE.md is static context: text injected at session start that the model is asked to respect. The Mneme hook runs as a PreToolUse hook — it intercepts every Edit, Write, and MultiEdit before they touch the filesystem and can return exit code 2 to block the operation outright. CLAUDE.md is advisory; the hook is enforcement. The two are complementary: CLAUDE.md gives the model context, Mneme blocks violations regardless of whether the model attended to that context."}},
-          {"@type": "Question", "name": "Does the hook slow down Claude Code sessions?", "acceptedAnswer": {"@type": "Answer", "text": "The retriever is deterministic keyword scoring with no embedding model and no vector store, so per-call latency is in the low milliseconds for typical projects. The hook runs locally; there is no network round trip. For projects with very large decision corpora, scope filters and tag indices keep retrieval bounded."}},
-          {"@type": "Question", "name": "What happens if Mneme itself fails?", "acceptedAnswer": {"@type": "Answer", "text": "The hook is designed fail-open: if the Mneme process errors, returns invalid output, or times out, Claude Code is allowed to proceed rather than being blocked. This is a deliberate safety choice — a broken governance layer should not lock the team out of editing their codebase. Strict mode (mneme check --mode strict) in CI is where hard-blocking lives; the editor-time hook prioritizes availability."}},
-          {"@type": "Question", "name": "Can I use the hook without committing project_memory.json?", "acceptedAnswer": {"@type": "Answer", "text": "Technically yes, but you lose the value. The decision corpus is the source of truth; committing it to the repo means every team member sees the same enforcement, and changes to architectural rules show up in PR review like any other change. Local-only memory recreates the per-engineer drift problem the layer exists to solve."}}
-        ]
-      },
-      {
-        "@type": "HowTo",
-        "name": "Wire Mneme HQ into Claude Code",
-        "description": "Install Mneme, register the PreToolUse hook with Claude Code, and verify enforcement on a test diff.",
-        "step": [
-          {"@type": "HowToStep", "name": "Install", "text": "pip install mneme && mneme init scaffolds project_memory.json at the repo root."},
-          {"@type": "HowToStep", "name": "Register the hook", "text": "Add the mneme-hook command as a PreToolUse hook in your Claude Code hooks configuration so Edit, Write, and MultiEdit operations check the corpus before applying changes."},
-          {"@type": "HowToStep", "name": "Populate decisions", "text": "Replace the placeholder ADRs in project_memory.json with the team's real decisions, including scope (file globs), status, and rationale."},
-          {"@type": "HowToStep", "name": "Verify enforcement", "text": "Trigger a test edit that violates one of the decisions. The hook should block the edit and surface the decision id as feedback. Adjust mode (warn / strict) per environment."}
+          {"@type": "Question", "name": "Why isn't code review enough for AI-generated code?", "acceptedAnswer": {"@type": "Answer", "text": "Code review is a human-throughput process; AI generation is not. As agent-produced volume scales, manual review degrades into shallow approval. CI governance is the deterministic check that does not depend on reviewer attention — it runs on every diff, every time, against an explicit corpus of architectural decisions."}},
+          {"@type": "Question", "name": "Does this replace pre-generation enforcement?", "acceptedAnswer": {"@type": "Answer", "text": "No. Pre-generation enforcement (via Claude Code hooks or Cursor Rules) catches most violations before code is written. CI governance is the second layer, catching what slipped past — diffs from agents without hook integration, edits made outside an enforced session, or human edits that violate ADRs."}},
+          {"@type": "Question", "name": "Will it block all my PRs in warn mode?", "acceptedAnswer": {"@type": "Answer", "text": "No. mneme check --mode warn reports violations as PR comments without blocking the merge. Teams use this to baseline existing drift before promoting to strict mode on the repos where the architectural corpus is stable."}}
         ]
       }
     ]
@@ -287,10 +219,8 @@
   <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
   <div class="nav-links">
     <a href="/#how-it-works">How it works</a>
-    <a href="/concepts/">Concepts</a>
     <a href="/use-cases/">Use cases</a>
     <a href="/insights/">Insights</a>
-    <a href="/qa-glossary/">Q&amp;A</a>
     <a href="/roadmap/">Roadmap</a>
     <a href="/demo/">Demo</a>
     <a href="/benchmark/">Benchmark</a>
@@ -303,235 +233,160 @@
 <nav aria-label="Breadcrumb" class="breadcrumb-nav">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li><a href="/integrations/">Integrations</a></li>
-    <li aria-current="page">Claude Code</li>
+    <li><a href="/use-cases/">Use cases</a></li>
+    <li aria-current="page">CI governance for AI-generated code</li>
   </ol>
 </nav>
 <article class="article-wrap">
   <header class="article-header">
     <div class="article-eyebrow">
-      <span class="eyebrow-tag">Integration &middot; Claude Code</span>
+      <span class="eyebrow-tag">Use case &middot; CI governance</span>
       <span class="eyebrow-dot"></span>
-      <span class="eyebrow-meta">6 min read &nbsp;·&nbsp; May 2026</span>
+      <span class="eyebrow-meta">5 min read &nbsp;&middot;&nbsp; May 2026</span>
     </div>
-    <h1>Claude Code Governance</h1>
-    <p class="article-lede">Mneme HQ registers a PreToolUse hook with Claude Code. Every Edit, Write, and MultiEdit is intercepted before it reaches disk &mdash; violations surface the decision id as feedback and exit 2 (block). Claude Code adjusts its approach without manual intervention.</p>
-    <p style="font-size:0.92rem;color:var(--muted);line-height:1.85;margin-top:1rem;max-width:680px;">Claude Code is a harness &mdash; it coordinates execution, tool use, and the agent loop. Mneme is the governance layer that runs alongside it, enforcing the architectural intent the harness has no opinion about. They are different layers of the runtime stack, and they run side by side. The argument in full: <a href="/insights/harness-engineering-still-needs-governance/" style="color:var(--teal);">Harness Engineering Still Needs Governance</a>.</p>
+    <h1>CI Governance for AI-Generated Code</h1>
+    <p class="article-lede">AI agents produce code at far higher volume than reviewers can manually inspect. CI governance is the deterministic gate that catches what slipped through &mdash; architectural violations in AI-generated diffs, regardless of which agent produced them.</p>
     <p class="byline">
       By <a href="/founder/">Theo Valmis</a>
       <span class="sep">&middot;</span>
-      <time datetime="2026-05-07">Published May 2026</time>
-      <span class="sep">&middot;</span>
-      <time datetime="2026-05-10">Updated May 2026</time>
+      <time datetime="2026-05-26">Published May 2026</time>
     </p>
   </header>
 
   <div class="article-body">
 
-    <h2>How the hook works</h2>
+    <h2>Why AI-generated code needs a CI gate</h2>
 
-    <p>Every Edit, Write, or MultiEdit Claude Code attempts is intercepted by <code>mneme-hook</code> before it writes to disk. The hook reconstructs the full post-edit file content, checks it against your recorded decisions, and returns a verdict.</p>
+    <p>Code review evolved as a human-throughput process. One author writes; one or two reviewers read. The economics work because the production rate matches the review rate.</p>
 
-    <p>The exit code semantics are deterministic: <strong>exit 0 allows the edit</strong>; <strong>exit 2 blocks it</strong> and surfaces the violated decision id as feedback to Claude Code. Claude Code sees the block as an error message, reads the decision id and rule, and adjusts its approach without you having to intervene.</p>
+    <p>Agent-assisted development breaks that ratio. A single engineer running Claude Code, Cursor, Copilot, or a multi-agent harness can produce more reviewable diff in an afternoon than a reviewer can deeply assess in a week. The natural failure mode is not malicious code &mdash; it is <em>shallow approval</em>: reviews that scan for surface signals because the volume forecloses the time for architectural depth.</p>
 
-    <pre><code>on Edit / Write / MultiEdit:
-  content = reconstruct_full_file(tool_input)
-  result  = mneme check --file &lt;path&gt; &lt;content&gt;
-  if result.violation:
-    exit 2   # block — surfaces decision_id to Claude Code
-  else:
-    exit 0   # allow</code></pre>
+    <p>CI governance is the deterministic check that does not depend on reviewer attention. It runs on every diff, every time, against an explicit corpus of architectural decisions. Whatever the agent generates, whichever model produced it, however many parallel sessions ran &mdash; the gate is the same.</p>
 
     <div class="callout">
-      <p><strong>Fail-open by design.</strong> The hook never blocks on Mneme malfunction. If <code>mneme</code> is not found, the file can't be read, or <code>mneme check</code> times out (10 s limit), the hook exits 0 and allows the edit.</p>
+      <p><strong>The argument expanded.</strong> For the case that review and governance are different layers and one cannot substitute for the other, see <a href="/insights/review-is-not-governance/">Review is not governance</a> and <a href="/insights/ai-code-review-does-not-scale-linearly/">AI code review does not scale linearly</a>.</p>
     </div>
 
-    <h2>Install</h2>
+    <h2>What CI governance catches that prompt engineering misses</h2>
+
+    <p>Prompt-side context (system prompts, <code>CLAUDE.md</code>, <code>.cursorrules</code>) is upstream of generation. It works when the agent reads it, attends to it, and respects it. CI governance is downstream of generation and is independent of all three.</p>
+
+    <ul>
+      <li><strong>Drift from agents you don't control.</strong> Contractor laptops, agentic workflows triggered from issues, autonomous PR bots &mdash; whatever produced the diff still has to clear the gate.</li>
+      <li><strong>Hallucinated dependencies.</strong> The agent imports a package nobody approved; the gate sees an import that violates the dependency policy and blocks the merge.</li>
+      <li><strong>Bypassed architectural boundaries.</strong> "Just this one place" cross-module access that prompt context didn't catch because the diff looked locally reasonable. The gate evaluates against the structural corpus, not the local read.</li>
+      <li><strong>Decisions made after the agent's training cut-off.</strong> A model that knows nothing about your team's ADR-027 from last month still cannot land code that violates it, because the corpus is read at check time, not at training time.</li>
+    </ul>
+
+    <h2>The two-layer model</h2>
+
+    <p>Mneme is designed to run as two enforcement layers, not one:</p>
 
     <ol>
-      <li>
-        <strong>Install the package</strong>
-        <pre><code>pip install mneme</code></pre>
-      </li>
-      <li>
-        <strong>Initialise project memory (if you don't have one yet)</strong>
-        <pre><code>mkdir .mneme
-# Create .mneme/project_memory.json — see examples/project_memory.json for the schema.</code></pre>
-      </li>
-      <li>
-        <strong>Run the installer</strong>
-        <p>Project-scoped (recommended — only affects this project):</p>
-        <pre><code>python scripts/install_claude_code.py</code></pre>
-        <p>User-scoped (applies to all Claude Code sessions):</p>
-        <pre><code>python scripts/install_claude_code.py --user</code></pre>
-        <p>The installer is idempotent — safe to run again after updates.</p>
-      </li>
-      <li>
-        <strong>Verify</strong>
-        <p>Open Claude Code in your project, make an edit that violates a recorded decision, and confirm the hook blocks it and surfaces the decision id.</p>
-      </li>
+      <li><strong>Pre-generation.</strong> The Claude Code <code>PreToolUse</code> hook intercepts <code>Edit</code>, <code>Write</code>, and <code>MultiEdit</code> before disk. Cursor Rules deliver the same corpus to Cursor sessions. Most violations never get written.</li>
+      <li><strong>Post-generation, pre-merge.</strong> <code>mneme check</code> runs in CI against every PR diff. Anything that slipped past the first layer &mdash; or originated outside an enforced session &mdash; is caught here.</li>
     </ol>
 
-    <h2>Slash commands</h2>
+    <p>The two layers share the same decision corpus (<code>.mneme/project_memory.json</code>). There is no per-tool duplication. A decision recorded once is enforced in both places.</p>
 
-    <p>After installing, four slash commands are available in Claude Code:</p>
-
-    <div style="overflow-x:auto;margin:2rem 0;">
-    <table class="comparison-table">
-      <thead>
-        <tr>
-          <th>Command</th>
-          <th>Purpose</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>/mneme-context</td>
-          <td>Retrieve decisions relevant to your current task</td>
-        </tr>
-        <tr>
-          <td>/mneme-check</td>
-          <td>Check a file or draft against project memory</td>
-        </tr>
-        <tr>
-          <td>/mneme-record</td>
-          <td>Record a new architectural decision</td>
-        </tr>
-        <tr>
-          <td>/mneme-review</td>
-          <td>Audit all pending diff changes against decisions</td>
-        </tr>
-      </tbody>
-    </table>
-    </div>
-
-    <h2>Modes</h2>
-
-    <div style="overflow-x:auto;margin:2rem 0;">
-    <table class="comparison-table">
-      <thead>
-        <tr>
-          <th>Mode</th>
-          <th>Behaviour</th>
-          <th>Set via</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>strict (default)</td>
-          <td>Block on any non-zero verdict from <code>mneme check</code></td>
-          <td><code>export MNEME_HOOK_MODE=strict</code></td>
-        </tr>
-        <tr>
-          <td>warn</td>
-          <td>Surface warning to Claude, never block</td>
-          <td><code>export MNEME_HOOK_MODE=warn</code></td>
-        </tr>
-      </tbody>
-    </table>
-    </div>
-
-    <p>Switch to <code>warn</code> while you're iterating on decisions to avoid friction:</p>
-    <pre><code>export MNEME_HOOK_MODE=warn</code></pre>
-
-    <h2>Retrieval: what the hook checks and what it misses</h2>
-
-    <p>The hook query is <code>"edit to &lt;file_path&gt;"</code> — tokens from the target file name determine which decisions are retrieved and checked. Decisions are scored by keyword overlap between the query and their <code>scope</code>, <code>id</code>, decision text, and anti-pattern fields.</p>
-
-    <p><strong>What this means in practice:</strong></p>
+    <h2>What gets enforced at the CI boundary</h2>
 
     <ul>
-      <li>A decision with <code>scope: ["storage", "database"]</code> and a file named <code>storage_layer.py</code> will reliably be retrieved — "storage" appears in both the query and the scope.</li>
-      <li>The same decision may <strong>not</strong> be retrieved for an edit to <code>models.py</code> — neither token overlaps with the scope.</li>
-      <li>Generic file names like <code>utils.py</code> or <code>helpers.py</code> will rarely retrieve any decisions at all.</li>
+      <li><strong>ADRs.</strong> Architectural Decision Records, parsed into structured decisions and enforced as constraints, not as docs.</li>
+      <li><strong>Forbidden dependencies.</strong> Packages, modules, or patterns the team has explicitly ruled out (with rationale and supersedes history).</li>
+      <li><strong>Approved architectural patterns.</strong> Layering rules, allowed transitive imports, framework-specific structure.</li>
+      <li><strong>Path and boundary rules.</strong> "No direct database access from controllers", "auth code stays in <code>/security/</code>", etc.</li>
+      <li><strong>Pattern-level invariants.</strong> Things that must be true across the codebase (e.g. error-handling convention, naming, logger usage).</li>
     </ul>
 
-    <p><strong>Mitigations:</strong></p>
+    <h2>Setup</h2>
+
+    <h3>GitHub Actions</h3>
+
+    <pre><code># .github/workflows/mneme.yml
+name: Mneme governance
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install mneme
+      - run: mneme check --mode warn</code></pre>
+
+    <p>See <a href="/integrations/github-actions/">GitHub Actions AI Governance</a> for the full integration page.</p>
+
+    <h3>GitLab CI</h3>
+
+    <pre><code># .gitlab-ci.yml
+mneme-check:
+  image: python:3.11
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - pip install mneme
+    - mneme check --mode warn</code></pre>
+
+    <p>See <a href="/integrations/gitlab/">GitLab CI integration</a> for the full page.</p>
+
+    <h2>Adoption sequence: warn before strict</h2>
+
+    <p>The recommended rollout is staged, so the team learns where the corpus is sharp and where it is approximate before the gate starts blocking merges.</p>
 
     <ol>
-      <li>Choose scope keywords when recording decisions that match file names in your project. Use <code>/mneme-record</code> and follow the scope tip in the command.</li>
-      <li>Run <code>/mneme-context</code> before non-trivial edits with a descriptive phrase describing the domain (e.g. "storage layer", "auth middleware"). This uses a richer query than the hook and surfaces decisions the hook might miss.</li>
-      <li>Run <code>/mneme-review</code> after a batch of edits to catch violations the per-edit hook missed due to retrieval gaps.</li>
+      <li><strong>Warn mode in CI.</strong> Run <code>mneme check --mode warn</code> on every PR. Violations surface as comments; merges proceed. Use this phase to harden the decision corpus against real diffs.</li>
+      <li><strong>Strict mode on the most stable repos first.</strong> Promote to <code>--mode strict</code> on services where the architectural corpus has settled. Other repos stay in warn.</li>
+      <li><strong>Pre-generation enforcement.</strong> Once the corpus is trusted, wire the Claude Code hook so violations fail fast in the editor, not at PR time.</li>
     </ol>
 
-    <p>The hook is a first line of defence, not a complete audit. Use the slash commands for coverage on domains where file names are not self-describing.</p>
-
-    <h2>Fail-open guarantees</h2>
-
-    <p>The hook <strong>never blocks</strong> on execution errors. It exits 0 (allow) when:</p>
-
-    <ul>
-      <li><code>mneme</code> is not found on <code>$PATH</code></li>
-      <li>The target file cannot be read (common for Write — the file doesn't exist yet)</li>
-      <li><code>mneme check</code> times out (limit: 10 s)</li>
-      <li>Any other OS-level error occurs</li>
-    </ul>
-
-    <p>Only a real verdict returned by <code>mneme check</code> can cause a block.</p>
-
-    <h2>Troubleshooting</h2>
-
-    <h3>Hook is not firing</h3>
-    <ul>
-      <li>Confirm <code>mneme-hook</code> is on <code>$PATH</code>: <code>which mneme-hook</code> (or <code>where mneme-hook</code> on Windows).</li>
-      <li>If not, the pip scripts directory may not be on <code>$PATH</code>. Add it, or install with <code>pipx</code>.</li>
-      <li>Confirm <code>.claude/settings.json</code> contains the <code>PreToolUse</code> entry (run the installer again).</li>
-    </ul>
-
-    <h3>Hook fires but nothing is blocked</h3>
-    <ul>
-      <li>Confirm <code>.mneme/project_memory.json</code> exists in the project root (or a parent directory).</li>
-      <li>Check your decision scope keywords against the file names being edited — see the retrieval section above.</li>
-      <li>Switch to warn mode temporarily and check stderr output from <code>mneme-hook</code> for clues.</li>
-    </ul>
-
-    <h3>Too many false positives / blocks</h3>
-    <ul>
-      <li>Switch to <code>MNEME_HOOK_MODE=warn</code> while refining your decisions.</li>
-      <li>Review the triggered anti-patterns with <code>/mneme-context</code> to see if they're too broad.</li>
-    </ul>
+    <div class="callout">
+      <p><strong>Why warn-then-strict.</strong> A corpus is only as useful as it is true. The warn phase is where ADRs that <em>should</em> be enforced but were never written down get surfaced and codified. Skipping it tends to produce a strict gate that the team works around &mdash; the worst of both layers.</p>
+    </div>
 
     <h2>FAQ</h2>
 
     <div class="faq-list">
       <details class="faq-item">
-        <summary>How is the Mneme hook different from CLAUDE.md?</summary>
-        <div class="faq-body">CLAUDE.md is static context: text injected at session start that the model is asked to respect. The Mneme hook runs as a PreToolUse hook &mdash; it intercepts every Edit, Write, and MultiEdit before they touch the filesystem and can return exit code 2 to block the operation outright. CLAUDE.md is advisory; the hook is enforcement. The two are complementary: CLAUDE.md gives the model context, Mneme blocks violations regardless of whether the model attended to that context. See <a href="/insights/why-prompt-memory-fails-at-scale/">why prompt memory fails at scale</a>.</div>
+        <summary>Why isn't code review enough for AI-generated code?</summary>
+        <div class="faq-body">Code review is a human-throughput process; AI generation is not. As agent-produced volume scales, manual review degrades into shallow approval. CI governance is the deterministic check that does not depend on reviewer attention &mdash; it runs on every diff, every time, against an explicit corpus of architectural decisions.</div>
       </details>
-
       <details class="faq-item">
-        <summary>Does the hook slow down Claude Code sessions?</summary>
-        <div class="faq-body">The retriever is deterministic keyword scoring with no embedding model and no vector store, so per-call latency is in the low milliseconds for typical projects. The hook runs locally; there is no network round trip. For projects with very large decision corpora, scope filters and tag indices keep retrieval bounded.</div>
+        <summary>Does this replace pre-generation enforcement?</summary>
+        <div class="faq-body">No. Pre-generation enforcement (via Claude Code hooks or Cursor Rules) catches most violations before code is written. CI governance is the second layer, catching what slipped past &mdash; diffs from agents without hook integration, edits made outside an enforced session, or human edits that violate ADRs.</div>
       </details>
-
       <details class="faq-item">
-        <summary>What happens if Mneme itself fails?</summary>
-        <div class="faq-body">The hook is designed fail-open: if the Mneme process errors, returns invalid output, or times out, Claude Code is allowed to proceed rather than being blocked. This is a deliberate safety choice &mdash; a broken governance layer should not lock the team out of editing their codebase. Strict mode (<code>mneme check --mode strict</code>) in CI is where hard-blocking lives; the editor-time hook prioritizes availability.</div>
-      </details>
-
-      <details class="faq-item">
-        <summary>Can I use the hook without committing project_memory.json?</summary>
-        <div class="faq-body">Technically yes, but you lose the value. The decision corpus is the source of truth; committing it to the repo means every team member sees the same enforcement, and changes to architectural rules show up in PR review like any other change. Local-only memory recreates the per-engineer drift problem the layer exists to solve.</div>
+        <summary>Will it block all my PRs in warn mode?</summary>
+        <div class="faq-body">No. <code>mneme check --mode warn</code> reports violations as PR comments without blocking the merge. Teams use this to baseline existing drift before promoting to strict mode on the repos where the architectural corpus is stable.</div>
       </details>
     </div>
 
   </div>
 
-  
-    <h2 id="related-reading">Related reading</h2>
-    <ul>
-        <li><a href="/integrations/cursor/">the Cursor integration</a></li>
-        <li><a href="/integrations/github-actions/">the GitHub Actions enforcement gate</a></li>
-    </ul>
+  <h2 id="related-reading">Related reading</h2>
+  <ul>
+    <li><a href="/integrations/github-actions/">GitHub Actions AI governance</a></li>
+    <li><a href="/integrations/gitlab/">GitLab CI governance</a></li>
+    <li><a href="/integrations/claude-code/">Claude Code governance</a></li>
+    <li><a href="/use-cases/coding-assistant-governance/">Coding assistant governance</a></li>
+    <li><a href="/insights/review-is-not-governance/">Review is not governance</a></li>
+  </ul>
 
   <footer class="article-footer">
-    <a href="/integrations/" class="back-link">&#8592; All integrations</a>
+    <a href="/use-cases/" class="back-link">&#8592; All use cases</a>
 
     <div class="cta-block">
-      <h3>Start enforcing architectural decisions in Claude Code</h3>
-      <p>Open source, self-hosted. Install takes under five minutes.</p>
+      <h3>Make AI-generated code answer to the corpus.</h3>
+      <p>Architectural decisions stay enforceable through CI &mdash; whichever agent produced the diff, whichever pipeline ran it.</p>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
-      <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt Engineering Is Not Governance &rarr;</a>
+      <a href="/integrations/github-actions/" class="cta-secondary">See the GitHub Actions setup &rarr;</a>
     </div>
   </footer>
 </article>
@@ -556,7 +411,6 @@
         <li><a href="/concepts/">Concepts</a></li>
         <li><a href="/architecture/">Architecture</a></li>
         <li><a href="/insights/">Insights</a></li>
-        <li><a href="/qa-glossary/">Q&amp;A and Glossary</a></li>
         <li><a href="/standards/">Standards</a></li>
         <li><a href="/benchmark/">Benchmark</a></li>
         <li><a href="/docs/">Docs</a></li>
@@ -606,7 +460,7 @@
   </div>
 </footer>
 
-<script><!-- nav-active -->
+<script>
 (function(){
   var path = window.location.pathname;
   document.querySelectorAll('.nav-links a').forEach(function(a){

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -51,14 +51,15 @@
         "mainEntity": {
           "@type": "ItemList",
           "itemListOrder": "https://schema.org/ItemListOrderAscending",
-          "numberOfItems": 6,
+          "numberOfItems": 7,
           "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "Coding Assistant Governance", "url": "https://mnemehq.com/use-cases/coding-assistant-governance/" },
             { "@type": "ListItem", "position": 2, "name": "Legacy Codebase Memory", "url": "https://mnemehq.com/use-cases/legacy-codebase-memory/" },
             { "@type": "ListItem", "position": 3, "name": "Security & Compliance Guardrails", "url": "https://mnemehq.com/use-cases/security-compliance-guardrails/" },
             { "@type": "ListItem", "position": 4, "name": "Data Platform Governance", "url": "https://mnemehq.com/use-cases/data-platform-governance/" },
             { "@type": "ListItem", "position": 5, "name": "Design System Governance", "url": "https://mnemehq.com/use-cases/design-system-governance/" },
-            { "@type": "ListItem", "position": 6, "name": "Multi-Agent Workflow Governance", "url": "https://mnemehq.com/use-cases/multi-agent-workflow-governance/" }
+            { "@type": "ListItem", "position": 6, "name": "Multi-Agent Workflow Governance", "url": "https://mnemehq.com/use-cases/multi-agent-workflow-governance/" },
+            { "@type": "ListItem", "position": 7, "name": "CI Governance for AI-Generated Code", "url": "https://mnemehq.com/use-cases/ci-governance-for-ai-generated-code/" }
           ]
         }
       },
@@ -480,6 +481,12 @@
         <h3>Multi-Agent Workflow Governance</h3>
         <p>Give every agent in your pipeline — planner, coder, reviewer — a shared memory of architectural decisions. One decision store enforced at every stage.</p>
         <a href="/use-cases/multi-agent-workflow-governance/" class="read-link">Read →</a>
+      </div>
+
+      <div class="case-card">
+        <h3>CI Governance for AI-Generated Code</h3>
+        <p>The deterministic gate that catches what reviewer attention can't. Mneme's enforcement checks run against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code.</p>
+        <a href="/use-cases/ci-governance-for-ai-generated-code/" class="read-link">Read →</a>
       </div>
 
       <div class="case-card case-card-upcoming">

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -493,6 +493,9 @@
       </div>
       <h3>Warp</h3>
       <p>Works alongside Warp&rsquo;s AI-native terminal and autonomous execution workflows. Warp accelerates how teams run agents and orchestrate tasks; Mneme preserves the architectural invariants underneath those execution loops.</p>
+      <div class="card-footer">
+        <a href="/integrations/warp/" class="read-link">Integration page &rarr;</a>
+      </div>
     </div>
 
     <div class="compare-card">


### PR DESCRIPTION
## Summary
- SEO-refresh `/integrations/claude-code/`, `/integrations/cursor/`, `/integrations/github-actions/` so titles, meta, OG/Twitter, and H1s lead with exact-match governance keywords. URL slugs unchanged to preserve link equity.
- New `/integrations/warp/` — Warp AI Terminal Governance, positioned honestly as "works alongside" (no native-Warp-hook claim).
- New `/use-cases/ci-governance-for-ai-generated-code/` — CI gate as the second enforcement layer for AI-generated code.
- Wiring: sitemap entries, `/integrations/` and `/use-cases/` hub cards (with JSON-LD updates), `/works-with/` Warp card deep-links to integration page, OG image templates registered in `scripts/generate_og_images.py`.

## What this does NOT do
- Build the Warp and CI-governance og.png files. Run `python scripts/generate_og_images.py` post-merge to produce them. Social previews will be broken until then; everything else ships cleanly.

## Test Plan
- [x] `python scripts/check_insights.py` — OK (43 insight articles fully registered, no regression)
- [x] `python scripts/check_encoding.py` — OK (297 files scanned)
- [x] `python scripts/check_sticky_nav.py` — OK (warp + ci-governance pages fixed during PR prep)
- [x] All cross-links from new pages verified to resolve to existing files
- [ ] CI green
- [ ] After merge, run `python scripts/generate_og_images.py` to produce the two new og.png files

🤖 Generated with [Claude Code](https://claude.com/claude-code)