### PR TITLE
site: add Grok Build CLI + Hermes ecosystem cards; make navigation cards site-wide clickable

### DIFF
--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -93,7 +93,7 @@
     .hub-intro { font-size: 0.88rem; color: var(--muted); line-height: 1.8; max-width: 660px; margin: 0 auto 3rem; }
     .cards-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.25rem; }
 
-    .compare-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.65rem; transition: border-color 0.15s; }
+    .compare-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.65rem; transition: border-color 0.15s, transform 0.15s, background 0.15s; }
     .compare-card:hover { border-color: var(--border2); }
     .compare-card.coming-soon { opacity: 0.55; }
     .card-meta { display: flex; align-items: center; gap: 0.6rem; }
@@ -105,6 +105,13 @@
     .read-link { color: var(--accent); font-size: 0.82rem; text-decoration: none; }
     .read-link:hover { color: var(--accent-dim); }
     .soon-label { color: var(--muted); font-size: 0.78rem; font-family: 'DM Mono', monospace; }
+
+    /* Whole-card clickable wrapper (mirrors insights .insight-card-link pattern) */
+    .compare-card-link { display: block; text-decoration: none; color: inherit; border-radius: 12px; }
+    .compare-card-link:hover .compare-card { border-color: var(--border2); transform: translateY(-2px); background: rgba(200,240,96,0.025); }
+    .compare-card-link:hover .read-link { color: var(--accent-dim); }
+    .compare-card-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+    .compare-card-link:focus-visible .compare-card { border-color: var(--accent); }
 
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
     footer a { color: var(--muted); text-decoration: none; }
@@ -242,104 +249,122 @@
 
   <div class="cards-grid">
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Native integration</span>
+    <a href="/integrations/claude-code/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Native integration</span>
+        </div>
+        <h3>Governing Claude Code Workflows</h3>
+        <p>Hook-level enforcement for every Edit, Write, and MultiEdit Claude Code attempts. Violations block before they reach disk — no PR required.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Governing Claude Code Workflows</h3>
-      <p>Hook-level enforcement for every Edit, Write, and MultiEdit Claude Code attempts. Violations block before they reach disk — no PR required.</p>
-      <div class="card-footer">
-        <a href="/integrations/claude-code/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Rules export</span>
+    <a href="/integrations/cursor/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Rules export</span>
+        </div>
+        <h3>Mneme HQ + Cursor</h3>
+        <p>Keep architectural decisions in Mneme's structured corpus. Export to Cursor Rules for every session — one authoritative source, two surfaces.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Mneme HQ + Cursor</h3>
-      <p>Keep architectural decisions in Mneme's structured corpus. Export to Cursor Rules for every session — one authoritative source, two surfaces.</p>
-      <div class="card-footer">
-        <a href="/integrations/cursor/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">CI enforcement</span>
+    <a href="/integrations/github-actions/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">CI enforcement</span>
+        </div>
+        <h3>Architectural Governance in GitHub Actions</h3>
+        <p>Run Mneme's enforcement checks against every PR diff. Block merges that violate architectural decisions — a second enforcement layer after generation.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Architectural Governance in GitHub Actions</h3>
-      <p>Run Mneme's enforcement checks against every PR diff. Block merges that violate architectural decisions — a second enforcement layer after generation.</p>
-      <div class="card-footer">
-        <a href="/integrations/github-actions/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Corpus import</span>
+    <a href="/integrations/adr-import/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Corpus import</span>
+        </div>
+        <h3>Import Existing ADRs</h3>
+        <p>Bring your existing ADR corpus into Mneme's enforcement pipeline. Import, parse, and activate decisions in one command — no manual rewriting.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Import Existing ADRs</h3>
-      <p>Bring your existing ADR corpus into Mneme's enforcement pipeline. Import, parse, and activate decisions in one command — no manual rewriting.</p>
-      <div class="card-footer">
-        <a href="/integrations/adr-import/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Corpus + CI gate</span>
+    <a href="/integrations/copilot/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Corpus + CI gate</span>
+        </div>
+        <h3>Mneme HQ + GitHub Copilot</h3>
+        <p>Copilot generates in VS Code and JetBrains. Mneme HQ is the constraint layer above it &mdash; one structured decision corpus, enforced at the CI gate and exportable as Cursor Rules.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more &rarr;</span>
+        </div>
       </div>
-      <h3>Mneme HQ + GitHub Copilot</h3>
-      <p>Copilot generates in VS Code and JetBrains. Mneme HQ is the constraint layer above it &mdash; one structured decision corpus, enforced at the CI gate and exportable as Cursor Rules.</p>
-      <div class="card-footer">
-        <a href="/integrations/copilot/" class="read-link">Learn more &rarr;</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Native integration</span>
+    <a href="/integrations/vscode/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Native integration</span>
+        </div>
+        <h3>Mneme HQ + VS Code</h3>
+        <p>VS Code is the host for Claude Code and Copilot. Mneme's PreToolUse hook governs every Edit, Write, and MultiEdit a Claude Code session attempts &mdash; no extension required.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Mneme HQ + VS Code</h3>
-      <p>VS Code is the host for Claude Code and Copilot. Mneme's PreToolUse hook governs every Edit, Write, and MultiEdit a Claude Code session attempts &mdash; no extension required.</p>
-      <div class="card-footer">
-        <a href="/integrations/vscode/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">CI enforcement</span>
+    <a href="/integrations/gitlab/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">CI enforcement</span>
+        </div>
+        <h3>Architectural Governance in GitLab CI</h3>
+        <p>Run Mneme's enforcement checks against every merge request diff. Block pipelines that violate architectural decisions — the same CI gate pattern as GitHub Actions, native to GitLab.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more &rarr;</span>
+        </div>
       </div>
-      <h3>Architectural Governance in GitLab CI</h3>
-      <p>Run Mneme's enforcement checks against every merge request diff. Block pipelines that violate architectural decisions — the same CI gate pattern as GitHub Actions, native to GitLab.</p>
-      <div class="card-footer">
-        <a href="/integrations/gitlab/" class="read-link">Learn more &rarr;</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Corpus + CI gate</span>
+    <a href="/integrations/jetbrains/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Corpus + CI gate</span>
+        </div>
+        <h3>Mneme HQ + JetBrains IDEs</h3>
+        <p>JetBrains AI Assistant runs across IntelliJ, PyCharm, WebStorm, and the rest of the family. Mneme HQ's decision corpus is the constraint layer those sessions read &mdash; enforced via <code style="font-family:'DM Mono',monospace;font-size:0.82em;">mneme check</code> in CI regardless of the IDE.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more &rarr;</span>
+        </div>
       </div>
-      <h3>Mneme HQ + JetBrains IDEs</h3>
-      <p>JetBrains AI Assistant runs across IntelliJ, PyCharm, WebStorm, and the rest of the family. Mneme HQ's decision corpus is the constraint layer those sessions read &mdash; enforced via <code style="font-family:'DM Mono',monospace;font-size:0.82em;">mneme check</code> in CI regardless of the IDE.</p>
-      <div class="card-footer">
-        <a href="/integrations/jetbrains/" class="read-link">Learn more &rarr;</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Works alongside</span>
+    <a href="/integrations/warp/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Works alongside</span>
+        </div>
+        <h3>Warp AI Terminal Governance</h3>
+        <p>Warp orchestrates Agent Mode and autonomous execution. Mneme HQ preserves the architectural invariants underneath those loops &mdash; enforced at the file-write boundary regardless of which agent Warp spawns.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more &rarr;</span>
+        </div>
       </div>
-      <h3>Warp AI Terminal Governance</h3>
-      <p>Warp orchestrates Agent Mode and autonomous execution. Mneme HQ preserves the architectural invariants underneath those loops &mdash; enforced at the file-write boundary regardless of which agent Warp spawns.</p>
-      <div class="card-footer">
-        <a href="/integrations/warp/" class="read-link">Learn more &rarr;</a>
-      </div>
-    </div>
+    </a>
 
     <div class="compare-card coming-soon">
       <div class="card-meta">
@@ -359,16 +384,18 @@
 
   <div class="cards-grid" style="max-width: 900px; margin: 0 auto;">
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">Works alongside</span>
+    <a href="/integrations/perplexity/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">Works alongside</span>
+        </div>
+        <h3>Perplexity Enterprise</h3>
+        <p>Perplexity gives teams cited, up-to-date answers about technology choices. Mneme takes those choices and makes them enforceable — closing the gap between research rationale and governance constraint.</p>
+        <div class="card-footer">
+          <span class="read-link">Learn more →</span>
+        </div>
       </div>
-      <h3>Perplexity Enterprise</h3>
-      <p>Perplexity gives teams cited, up-to-date answers about technology choices. Mneme takes those choices and makes them enforceable — closing the gap between research rationale and governance constraint.</p>
-      <div class="card-footer">
-        <a href="/integrations/perplexity/" class="read-link">Learn more →</a>
-      </div>
-    </div>
+    </a>
 
   </div>
 

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -143,16 +143,23 @@
     .hero-sub { font-size: 0.95rem; color: var(--muted); max-width: 520px; margin: 0 auto; }
     .cards-wrap { max-width: 900px; margin: 0 auto; padding: 0 2rem 6rem; }
     .cards-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.25rem; margin-top: 3rem; }
-    .case-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.75rem; transition: border-color 0.15s; }
+    .case-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.75rem; transition: border-color 0.15s, transform 0.15s, background 0.15s; }
     .case-card:hover { border-color: var(--border2); }
     .case-card-eyebrow { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
     .case-card h3 { font-family: 'Inter', sans-serif; font-size: 1.15rem; font-weight: 600; letter-spacing: -0.01em; line-height: 1.3; }
     .case-card p { font-size: 0.82rem; color: var(--muted); line-height: 1.7; flex: 1; }
-    .case-card a.read-link { color: var(--accent); font-size: 0.82rem; text-decoration: none; margin-top: 0.5rem; }
-    .case-card a.read-link:hover { color: var(--accent-dim); }
+    .case-card .read-link { color: var(--accent); font-size: 0.82rem; text-decoration: none; margin-top: 0.5rem; display: inline-block; }
+    .case-card .read-link:hover { color: var(--accent-dim); }
     .case-card-upcoming { border-style: dashed; opacity: 0.85; }
     .case-card-upcoming .case-card-eyebrow { color: var(--teal); }
     .case-card .read-link.upcoming { color: var(--teal); font-size: 0.82rem; margin-top: 0.5rem; cursor: default; }
+
+    /* Whole-card clickable wrapper (mirrors insights .insight-card-link pattern) */
+    .case-card-link { display: block; text-decoration: none; color: inherit; border-radius: 12px; }
+    .case-card-link:hover .case-card { border-color: var(--border2); transform: translateY(-2px); background: rgba(200,240,96,0.025); }
+    .case-card-link:hover .read-link { color: var(--accent-dim); }
+    .case-card-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+    .case-card-link:focus-visible .case-card { border-color: var(--accent); }
 
     .hub-intro { font-size: 0.88rem; color: var(--muted); line-height: 1.8; max-width: 660px; margin: 0 auto; padding-bottom: 0; }
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
@@ -441,53 +448,67 @@
     <p class="hub-intro">Mneme HQ enforces architectural, security, design, and workflow decisions wherever AI generates code or structured output. These reference architectures show how teams apply pre-generation governance across different LLM-powered workflows.</p>
     <div class="cards-grid">
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Coding Assistant Governance</h3>
-        <p>Prevent Cursor, Claude Code, and Copilot from violating architecture rules — session after session. Enforce ADRs, service boundaries, and naming conventions at prompt time.</p>
-        <a href="/use-cases/coding-assistant-governance/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/coding-assistant-governance/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Coding Assistant Governance</h3>
+          <p>Prevent Cursor, Claude Code, and Copilot from violating architecture rules — session after session. Enforce ADRs, service boundaries, and naming conventions at prompt time.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Legacy Codebase Memory</h3>
-        <p>Give every coding assistant access to the undocumented rules that only your longest-tenured engineers know. Capture tribal knowledge once — enforce it forever.</p>
-        <a href="/use-cases/legacy-codebase-memory/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/legacy-codebase-memory/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Legacy Codebase Memory</h3>
+          <p>Give every coding assistant access to the undocumented rules that only your longest-tenured engineers know. Capture tribal knowledge once — enforce it forever.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Security &amp; Compliance Guardrails</h3>
-        <p>Enforce PII handling rules, auth requirements, and compliance controls before the LLM generates a single line of non-compliant code. GDPR, SOC 2, and beyond.</p>
-        <a href="/use-cases/security-compliance-guardrails/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/security-compliance-guardrails/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Security &amp; Compliance Guardrails</h3>
+          <p>Enforce PII handling rules, auth requirements, and compliance controls before the LLM generates a single line of non-compliant code. GDPR, SOC 2, and beyond.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Data Platform Governance</h3>
-        <p>Keep AI assistants aligned with warehouse layer boundaries, naming conventions, and pipeline constraints. Prevent raw table writes and schema drift before code is written.</p>
-        <a href="/use-cases/data-platform-governance/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/data-platform-governance/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Data Platform Governance</h3>
+          <p>Keep AI assistants aligned with warehouse layer boundaries, naming conventions, and pipeline constraints. Prevent raw table writes and schema drift before code is written.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Design System Governance</h3>
-        <p>Stop AI from inventing colors, breaking component hierarchy, and ignoring accessibility rules when generating UI. Enforce design tokens and WCAG requirements at prompt time.</p>
-        <a href="/use-cases/design-system-governance/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/design-system-governance/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Design System Governance</h3>
+          <p>Stop AI from inventing colors, breaking component hierarchy, and ignoring accessibility rules when generating UI. Enforce design tokens and WCAG requirements at prompt time.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <div class="case-card-eyebrow">Reference Architecture</div>
-        <h3>Multi-Agent Workflow Governance</h3>
-        <p>Give every agent in your pipeline — planner, coder, reviewer — a shared memory of architectural decisions. One decision store enforced at every stage.</p>
-        <a href="/use-cases/multi-agent-workflow-governance/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/multi-agent-workflow-governance/" class="case-card-link">
+        <div class="case-card">
+          <div class="case-card-eyebrow">Reference Architecture</div>
+          <h3>Multi-Agent Workflow Governance</h3>
+          <p>Give every agent in your pipeline — planner, coder, reviewer — a shared memory of architectural decisions. One decision store enforced at every stage.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
-      <div class="case-card">
-        <h3>CI Governance for AI-Generated Code</h3>
-        <p>The deterministic gate that catches what reviewer attention can't. Mneme's enforcement checks run against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code.</p>
-        <a href="/use-cases/ci-governance-for-ai-generated-code/" class="read-link">Read →</a>
-      </div>
+      <a href="/use-cases/ci-governance-for-ai-generated-code/" class="case-card-link">
+        <div class="case-card">
+          <h3>CI Governance for AI-Generated Code</h3>
+          <p>The deterministic gate that catches what reviewer attention can't. Mneme's enforcement checks run against every PR diff in GitHub Actions or GitLab CI — blocking merges that violate architectural decisions, regardless of which agent produced the code.</p>
+          <span class="read-link">Read →</span>
+        </div>
+      </a>
 
       <div class="case-card case-card-upcoming">
         <div class="case-card-eyebrow">Coming up</div>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -86,7 +86,7 @@
     .group-lede { font-size: 0.86rem; color: var(--muted); line-height: 1.8; max-width: 660px; margin: 0 0 1.5rem; }
     .cards-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.25rem; }
 
-    .compare-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.65rem; transition: border-color 0.15s; }
+    .compare-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem 1.75rem; display: flex; flex-direction: column; gap: 0.65rem; transition: border-color 0.15s, transform 0.15s, background 0.15s; }
     .compare-card:hover { border-color: var(--border2); }
     .compare-card .card-meta { display: flex; align-items: center; gap: 0.6rem; }
     .compare-card .card-tag { font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); font-family: 'DM Mono', monospace; }
@@ -97,6 +97,13 @@
     .compare-card .card-footer { display: flex; align-items: center; justify-content: space-between; margin-top: 0.25rem; }
     .compare-card .read-link { color: var(--accent); font-size: 0.82rem; text-decoration: none; }
     .compare-card .read-link:hover { color: var(--accent-dim); }
+
+    /* Whole-card clickable wrapper (mirrors insights .insight-card-link pattern) */
+    .compare-card-link { display: block; text-decoration: none; color: inherit; border-radius: 12px; }
+    .compare-card-link:hover .compare-card { border-color: var(--border2); transform: translateY(-2px); background: rgba(200,240,96,0.025); }
+    .compare-card-link:hover .read-link { color: var(--accent-dim); }
+    .compare-card-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+    .compare-card-link:focus-visible .compare-card { border-color: var(--accent); }
 
     .messaging-block { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.2rem 1.5rem; margin: 2rem 0 0; font-size: 0.88rem; color: var(--muted); line-height: 1.75; max-width: 900px; }
     .messaging-block strong { color: var(--accent); }
@@ -333,6 +340,14 @@
       <p>Llama-class models served via vLLM, Ollama, Together, Groq, and similar runtimes.</p>
     </div>
 
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">Open weight &middot; designed to support</span>
+      </div>
+      <h3>Nous Hermes</h3>
+      <p>Nous Research's open-weight Hermes models accessed via hosted or self-hosted inference. Mneme is model-agnostic; the decision corpus is injected at the runtime seam regardless of which Hermes variant the agent is running.</p>
+    </div>
+
   </div>
 
   <div class="messaging-block">
@@ -344,27 +359,31 @@
 
   <div class="cards-grid">
 
-    <div class="compare-card native">
-      <div class="card-meta">
-        <span class="card-tag">Native integration</span>
+    <a href="/integrations/claude-code/" class="compare-card-link">
+      <div class="compare-card native">
+        <div class="card-meta">
+          <span class="card-tag">Native integration</span>
+        </div>
+        <h3>Claude Code</h3>
+        <p>Hook-level enforcement via SessionStart, PreToolUse, and PostToolUse. One of the three documented native integrations.</p>
+        <div class="card-footer">
+          <span class="read-link">Integration page &rarr;</span>
+        </div>
       </div>
-      <h3>Claude Code</h3>
-      <p>Hook-level enforcement via SessionStart, PreToolUse, and PostToolUse. One of the three documented native integrations.</p>
-      <div class="card-footer">
-        <a href="/integrations/claude-code/" class="read-link">Integration page &rarr;</a>
-      </div>
-    </div>
+    </a>
 
-    <div class="compare-card native">
-      <div class="card-meta">
-        <span class="card-tag">Native integration</span>
+    <a href="/integrations/cursor/" class="compare-card-link">
+      <div class="compare-card native">
+        <div class="card-meta">
+          <span class="card-tag">Native integration</span>
+        </div>
+        <h3>Cursor</h3>
+        <p>Rules export from the Mneme decision corpus into Cursor's rules system. One of the three documented native integrations.</p>
+        <div class="card-footer">
+          <span class="read-link">Integration page &rarr;</span>
+        </div>
       </div>
-      <h3>Cursor</h3>
-      <p>Rules export from the Mneme decision corpus into Cursor's rules system. One of the three documented native integrations.</p>
-      <div class="card-footer">
-        <a href="/integrations/cursor/" class="read-link">Integration page &rarr;</a>
-      </div>
-    </div>
+    </a>
 
     <div class="compare-card">
       <div class="card-meta">
@@ -404,6 +423,14 @@
       </div>
       <h3>Roo Code</h3>
       <p>Works alongside Roo Code's agent surface for governance across its editing and execution paths.</p>
+    </div>
+
+    <div class="compare-card">
+      <div class="card-meta">
+        <span class="card-tag">CLI agent &middot; designed to support</span>
+      </div>
+      <h3>Grok Build CLI</h3>
+      <p>xAI's CLI coding agent. No documented native integration today; designed to be governable at the file-write boundary like other CLI agents &mdash; the architectural corpus stays enforceable at the CI gate regardless of which agent produced the diff.</p>
     </div>
 
   </div>
@@ -487,16 +514,18 @@
       <p>Runs alongside the developer's editor and CLI agents; governance enforced before the file is written.</p>
     </div>
 
-    <div class="compare-card">
-      <div class="card-meta">
-        <span class="card-tag">AI-native terminal &middot; works alongside</span>
+    <a href="/integrations/warp/" class="compare-card-link">
+      <div class="compare-card">
+        <div class="card-meta">
+          <span class="card-tag">AI-native terminal &middot; works alongside</span>
+        </div>
+        <h3>Warp</h3>
+        <p>Works alongside Warp&rsquo;s AI-native terminal and autonomous execution workflows. Warp accelerates how teams run agents and orchestrate tasks; Mneme preserves the architectural invariants underneath those execution loops.</p>
+        <div class="card-footer">
+          <span class="read-link">Integration page &rarr;</span>
+        </div>
       </div>
-      <h3>Warp</h3>
-      <p>Works alongside Warp&rsquo;s AI-native terminal and autonomous execution workflows. Warp accelerates how teams run agents and orchestrate tasks; Mneme preserves the architectural invariants underneath those execution loops.</p>
-      <div class="card-footer">
-        <a href="/integrations/warp/" class="read-link">Integration page &rarr;</a>
-      </div>
-    </div>
+    </a>
 
     <div class="compare-card">
       <div class="card-meta">
@@ -506,16 +535,18 @@
       <p>Compatible with standard CI runners as a pre-merge governance check on AI-generated diffs.</p>
     </div>
 
-    <div class="compare-card native">
-      <div class="card-meta">
-        <span class="card-tag">Native integration</span>
+    <a href="/integrations/github-actions/" class="compare-card-link">
+      <div class="compare-card native">
+        <div class="card-meta">
+          <span class="card-tag">Native integration</span>
+        </div>
+        <h3>GitHub Actions</h3>
+        <p><code style="font-family:'DM Mono',monospace;font-size:0.82em;background:var(--surface2);border:1px solid var(--border);border-radius:4px;padding:0.05rem 0.4rem;color:var(--text);">mneme check</code> on every PR diff. One of the three documented native integrations.</p>
+        <div class="card-footer">
+          <span class="read-link">Integration page &rarr;</span>
+        </div>
       </div>
-      <h3>GitHub Actions</h3>
-      <p><code style="font-family:'DM Mono',monospace;font-size:0.82em;background:var(--surface2);border:1px solid var(--border);border-radius:4px;padding:0.05rem 0.4rem;color:var(--text);">mneme check</code> on every PR diff. One of the three documented native integrations.</p>
-      <div class="card-footer">
-        <a href="/integrations/github-actions/" class="read-link">Integration page &rarr;</a>
-      </div>
-    </div>
+    </a>
 
     <div class="compare-card">
       <div class="card-meta">


### PR DESCRIPTION
## Summary
- `/works-with/`: added **Nous Hermes** to open-weight models and **Grok Build CLI** (xAI) to coding-agent ecosystem. Conservative positioning — both flagged "designed to support," neither claims native integration.
- Whole-card clickable navigation, mirroring the existing `.insight-card-link` pattern on `/insights/`:
  - `/works-with/`: 4 native/integration cards wrapped (Claude Code, Cursor, GitHub Actions, Warp)
  - `/integrations/`: 10 integration cards wrapped (Claude Code, Cursor, GitHub Actions, ADR Import, Copilot, VS Code, GitLab, JetBrains, Warp, Perplexity)
  - `/use-cases/`: 7 case cards wrapped (the 6 existing + the new CI Governance card from PR #136)
- Inner `<a class="read-link">` anchors converted to `<span>` to prevent nested-anchor HTML errors.
- Added `:hover` (subtle accent tint + translate) and `:focus-visible` (accent outline + border) CSS so cards are keyboard-accessible.

## Validation
- [x] Zero nested-anchor HTML errors across all three changed files
- [x] `check_sticky_nav.py` — OK
- [x] `check_encoding.py` — OK (297 files)
- [x] `check_insights.py` — OK (43 articles, no regression)
- [x] Footer audit: 0 pages reference `/works-with/` without also referencing `/use-cases/`
- [x] All `.cta-card` instances site-wide already `<a>` — no changes needed
- [ ] CI green

## Test plan
- [ ] Tab through `/works-with/`, `/integrations/`, `/use-cases/` with keyboard — confirm focus ring + Enter navigates
- [ ] Click anywhere on a card (not just the "Read →" text) — confirm whole card is clickable
- [ ] Verify hover state (translate + subtle tint) on each card pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)