### PR TITLE
feat: add warn-only ADR freshness detection to mneme check

### DIFF
--- a/docs/site/concept-publication.md
+++ b/docs/site/concept-publication.md
@@ -1,0 +1,146 @@
+# Concept Publication Runbook
+
+Reference checklist for publishing a new concept page to `/concepts/`. Run the
+validator in step 7 before opening the PR.
+
+---
+
+## 1. Create the concept page
+
+Create `site/concepts/{slug}/index.html`.
+
+- Slug is lowercase kebab-case matching the concept's canonical URL segment.
+- Include all required `<head>` metadata: `<title>`, `<meta name="description">`,
+  `<link rel="canonical">`, `og:*` and `twitter:*` tags, `article:published_time`.
+- Include the Schema.org `DefinedTerm` JSON-LD block.
+- Link back to the hub: breadcrumb `Concepts → {Concept Name}`.
+- Add at least one related-concept link in the body (see step 5).
+
+OG image: the publishing script generates `og.png` automatically — do not create
+it by hand.
+
+---
+
+## 2. Add the concept card to site/concepts/index.html
+
+Open `site/concepts/index.html`. Find the correct section grid
+(`Core concepts`, `Systems concepts`, or `Adjacent concepts`).
+
+Append the card inside the grid's `<div class="concepts-grid" role="list">`:
+
+```html
+<a href="/concepts/{slug}/" class="concept-card" role="listitem">
+  <div class="card-top">
+    <span class="card-num">{NN}</span>
+    <div>
+      <div class="card-title">{Concept Name}</div>
+    </div>
+  </div>
+  <p class="card-desc">{One-sentence description matching the page's meta description.}</p>
+  <span class="card-arrow">&rarr;</span>
+</a>
+```
+
+Rules:
+- `card-num` is a sequential two-digit display label within its section. It is
+  decorative — the validator does not check numbering. Keep it consistent with
+  neighbouring cards.
+- `card-desc` must match (or closely paraphrase) the `<meta name="description">`
+  on the concept page. This is the value the validator will eventually use for
+  generation (Phase 2).
+- Do not change the section a concept belongs to without updating the hub intro
+  copy and the SVG diagram caption if relevant.
+
+---
+
+## 3. Add the JSON-LD hasPart entry
+
+In the same file (`site/concepts/index.html`), find the `"hasPart"` array inside
+the `CollectionPage` block (around line 202). Add one entry:
+
+```json
+{"@type": "DefinedTerm", "name": "{Concept Name}", "url": "https://mnemehq.com/concepts/{slug}/"}
+```
+
+- `name` must match the `<title>` on the concept page (before the ` — Mneme HQ` suffix).
+- Maintain alphabetical order within the array, or append — either is acceptable,
+  but be consistent within a session.
+- Do not add a trailing comma to the last entry.
+
+---
+
+## 4. Update the SVG knowledge graph (if applicable)
+
+The SVG diagram in `site/concepts/index.html` (lines ~280–405) is **editorial**.
+Not every concept belongs in it. Before adding a node, decide:
+
+**Add an SVG node if** the concept occupies a structural position in the
+primitives → properties → outcomes architecture, or belongs in the failure rail.
+
+**Omit from SVG if** the concept is contextual, adjacent, or definitional without
+a fixed tier. Instead, add its slug to `docs/site/svg-omitted.txt` (one slug per
+line, no trailing slash) so the validator treats the omission as intentional.
+
+If you add a node:
+- Follow the tier conventions: `cmap-card-primitive` (teal border),
+  `cmap-card` (neutral), `cmap-card-outcome` (accent border), `cmap-card-fail`
+  (red dashed).
+- Add flow lines (`<line class="cmap-flow">`) connecting the new node to its
+  tier neighbors.
+- Update the `<desc>` element to describe the new node.
+- Update the `<figcaption>` if the overall diagram narrative changes.
+- Refer to `docs/contributing/diagram-conventions.md` for color roles and
+  accessibility requirements.
+
+---
+
+## 5. Add related-concept cross-links
+
+On the new concept page, add at least one `<a href="/concepts/{related-slug}/">`
+link to a conceptually adjacent concept. The reciprocal link on the related page
+is strongly encouraged but not required for publication.
+
+On the related concept page(s), add a cross-link back where it reads naturally.
+Prefer linking from the "related concepts" section or an inline reference in
+the body prose.
+
+---
+
+## 6. Update sitemap and internal link audit
+
+Open `site/sitemap.xml`. Add a `<url>` block for the new concept:
+
+```xml
+<url>
+  <loc>https://mnemehq.com/concepts/{slug}/</loc>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+</url>
+```
+
+Then do a quick internal link audit:
+- Search the site for any existing pages that reference the new concept by name
+  but do not link to it. Add links where the prose already calls it out.
+- Check the hub intro copy (`site/concepts/index.html` lines ~273–277). If the
+  new concept warrants a mention there, update it.
+
+---
+
+## 7. Run the validator before opening the PR
+
+```bash
+python scripts/check_concepts.py
+```
+
+Exit code 0 = clean. Any non-zero exit means there is actionable drift:
+
+| Code | Meaning |
+|------|---------|
+| 1 | ERROR — pages missing cards, cards missing JSON-LD, or JSON-LD pointing to absent pages |
+| 2 | WARN only — concepts without SVG nodes not listed in svg-omitted.txt |
+
+Fix all ERRORs before opening the PR. WARNs about SVG omission may be resolved
+by either adding the node or adding the slug to `docs/site/svg-omitted.txt`.
+
+The validator is also a good smoke-check after any bulk edit to the hub — run it
+whenever you touch `site/concepts/index.html`.

--- a/docs/site/concept-publication.md
+++ b/docs/site/concept-publication.md
@@ -11,7 +11,8 @@ Create `site/concepts/{slug}/index.html`.
 
 - Slug is lowercase kebab-case matching the concept's canonical URL segment.
 - Include all required `<head>` metadata: `<title>`, `<meta name="description">`,
-  `<link rel="canonical">`, `og:*` and `twitter:*` tags, `article:published_time`.
+  `<link rel="canonical">`, `og:*` and `twitter:*` tags,
+  `article:published_time` (ISO 8601, e.g. `2026-05-21T00:00:00Z`).
 - Include the Schema.org `DefinedTerm` JSON-LD block.
 - Link back to the hub: breadcrumb `Concepts → {Concept Name}`.
 - Add at least one related-concept link in the body (see step 5).
@@ -63,8 +64,8 @@ the `CollectionPage` block (around line 202). Add one entry:
 ```
 
 - `name` must match the `<title>` on the concept page (before the ` — Mneme HQ` suffix).
-- Maintain alphabetical order within the array, or append — either is acceptable,
-  but be consistent within a session.
+- Append the new entry at the end of the array. The existing array is not
+  alphabetical; do not attempt to re-sort it.
 - Do not add a trailing comma to the last entry.
 
 ---
@@ -87,7 +88,8 @@ If you add a node:
   (red dashed).
 - Add flow lines (`<line class="cmap-flow">`) connecting the new node to its
   tier neighbors.
-- Update the `<desc>` element to describe the new node.
+- Update the diagram-level `<desc id="cmap-desc">` to mention the new node
+  in the overall description.
 - Update the `<figcaption>` if the overall diagram narrative changes.
 - Refer to `docs/contributing/diagram-conventions.md` for color roles and
   accessibility requirements.

--- a/docs/site/svg-omitted.txt
+++ b/docs/site/svg-omitted.txt
@@ -1,0 +1,13 @@
+# Concepts intentionally absent from the SVG knowledge graph.
+# These are contextual or adjacent concepts that do not occupy a structural
+# position in the primitives -> properties -> outcomes architecture.
+# Add a slug here (one per line, no trailing slash) whenever a concept is
+# published without an SVG node.
+agent-verification
+agentic-development
+ai-native-sdlc
+decision-continuity
+execution-surfaces
+governance-provenance
+intent-debt
+reliable-delegation

--- a/mneme-project-memory/mneme/adr_freshness.py
+++ b/mneme-project-memory/mneme/adr_freshness.py
@@ -1,0 +1,262 @@
+"""
+adr_freshness.py -- Warn-only ADR freshness / change detection.
+
+Compares the active ADR corpus on disk against the imported decision
+provenance in a Mneme memory file and surfaces three kinds of drift:
+
+    ADR_UNIMPORTED  An active ADR file exists in the ADR directory but
+                    no decision in the memory file carries its id. The
+                    ADR has not been imported.
+    ADR_CHANGED     A decision references an ADR file whose current
+                    SHA-256 differs from the hash captured at import.
+                    The source has been edited since import.
+    ADR_MISSING     A decision references an ADR file that no longer
+                    exists on disk. The source has been deleted or
+                    renamed without re-importing.
+
+The checker is intentionally warn-only: it returns a list of issues that
+the caller (the ``mneme check`` CLI) is expected to print but never to
+escalate into a non-zero exit. It does NOT mutate the memory file, does
+NOT re-import, and does NOT change the runtime retrieval surface.
+
+Provenance shape
+----------------
+Each imported decision JSON entry may carry an optional ``source`` block::
+
+    {
+      "id": "ADR-123",
+      "decision": "...",
+      ...,
+      "source": {
+        "type":   "adr",
+        "path":   "<POSIX path relative to memory_path.parent>",
+        "sha256": "<hex digest of the ADR file's UTF-8 bytes>"
+      }
+    }
+
+Memory files written before this provenance block was introduced remain
+fully supported: an imported decision whose id matches an active ADR but
+which lacks ``source`` is treated as imported and produces no freshness
+diagnostics (silently passes -- there is no hash to compare).
+
+The checker reads the memory file raw (json.load) rather than via
+MemoryStore so the ``source`` block survives the round-trip; the
+Decision dataclass intentionally does not carry source provenance.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mneme.adr_import import project_decision_graph
+from mneme.adr_parser import parse_adr_directory
+
+
+ADR_UNIMPORTED = "ADR_UNIMPORTED"
+ADR_CHANGED = "ADR_CHANGED"
+ADR_MISSING = "ADR_MISSING"
+
+_SOURCE_TYPE_ADR = "adr"
+
+
+@dataclass(frozen=True)
+class FreshnessIssue:
+    """A single ADR freshness diagnostic.
+
+    Attributes:
+        code:    One of ADR_UNIMPORTED, ADR_CHANGED, ADR_MISSING.
+        adr_id:  The ADR id this issue refers to (e.g. "ADR-007"), or
+                 the decision id when the ADR file is missing.
+        path:    Path string the user should look at. Stored as written
+                 in the memory file (POSIX, relative to the memory
+                 file's parent) for MISSING / CHANGED, or as the
+                 ADR file's source path for UNIMPORTED.
+        message: Single-line human-readable explanation.
+    """
+
+    code: str
+    adr_id: str
+    path: str
+    message: str
+
+
+def compute_source_hash(adr_path: str | Path) -> str:
+    """Return the SHA-256 hex digest of an ADR file's UTF-8 bytes."""
+    data = Path(adr_path).read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def relative_source_path(adr_path: str | Path, memory_path: str | Path) -> str:
+    """Compute the POSIX path stored in ``source.path`` for an ADR.
+
+    The path is relative to the memory file's parent directory so the
+    provenance survives moves of the repo as a whole. ``os.path.relpath``
+    handles the ``..`` traversal that ``Path.relative_to`` refuses.
+    """
+    import os
+    memory_parent = Path(memory_path).resolve().parent
+    target = Path(adr_path).resolve()
+    return Path(os.path.relpath(str(target), str(memory_parent))).as_posix()
+
+
+def check_freshness(
+    memory_path: str | Path,
+    adr_dir: str | Path,
+) -> list[FreshnessIssue]:
+    """Compare on-disk ADRs against imported provenance in a memory file.
+
+    Args:
+        memory_path: Path to the ``project_memory.json`` file.
+        adr_dir:     Path to the directory containing ADR markdown files.
+
+    Returns:
+        A list of ``FreshnessIssue`` records, possibly empty. Order is
+        deterministic: UNIMPORTED first (sorted by ADR id), then CHANGED,
+        then MISSING.
+
+        If ``adr_dir`` does not exist, returns an empty list: the
+        checker cannot determine what is unimported without a corpus
+        to compare against.
+    """
+    memory_path = Path(memory_path)
+    adr_dir = Path(adr_dir)
+
+    if not adr_dir.is_dir():
+        return []
+    if not memory_path.is_file():
+        return []
+
+    raw_decisions = _load_raw_decisions(memory_path)
+    decisions_by_id: dict[str, dict] = {d["id"]: d for d in raw_decisions if "id" in d}
+
+    active_adr_ids, adrs_by_id = _active_adrs(adr_dir)
+
+    unimported: list[FreshnessIssue] = []
+    changed: list[FreshnessIssue] = []
+    missing: list[FreshnessIssue] = []
+
+    # ADR_UNIMPORTED + ADR_CHANGED: scan the on-disk active corpus.
+    for adr_id in sorted(active_adr_ids):
+        adr = adrs_by_id[adr_id]
+        decision = decisions_by_id.get(adr_id)
+        if decision is None:
+            unimported.append(FreshnessIssue(
+                code=ADR_UNIMPORTED,
+                adr_id=adr_id,
+                path=str(adr.source_path),
+                message=(
+                    f"{adr_id} exists in {adr.source_path} but no matching "
+                    f"decision is present in {memory_path.name}. Run "
+                    f"`mneme adr import` to import it."
+                ),
+            ))
+            continue
+
+        source = _coerce_source(decision.get("source"))
+        if source is None:
+            # Legacy memory file -- imported by id, no hash to compare.
+            continue
+        if source.get("sha256") is None:
+            continue
+
+        stored_hash = source["sha256"]
+        current_hash = compute_source_hash(adr.source_path)
+        if stored_hash != current_hash:
+            changed.append(FreshnessIssue(
+                code=ADR_CHANGED,
+                adr_id=adr_id,
+                path=str(source.get("path", adr.source_path)),
+                message=(
+                    f"{adr_id} source file changed since import "
+                    f"(hash mismatch). Re-run `mneme adr import` to "
+                    f"refresh the imported decision."
+                ),
+            ))
+
+    # ADR_MISSING: scan decisions for source paths that have vanished.
+    memory_parent = memory_path.resolve().parent
+    for decision in raw_decisions:
+        source = _coerce_source(decision.get("source"))
+        if source is None:
+            continue
+        if source.get("type") != _SOURCE_TYPE_ADR:
+            continue
+        rel = source.get("path")
+        if not rel:
+            continue
+        resolved = (memory_parent / rel).resolve()
+        if not resolved.is_file():
+            missing.append(FreshnessIssue(
+                code=ADR_MISSING,
+                adr_id=str(decision.get("id", "<unknown>")),
+                path=str(rel),
+                message=(
+                    f"Decision {decision.get('id', '<unknown>')!s} references "
+                    f"ADR source {rel!s} but that file does not exist. "
+                    f"Either restore the file or remove the decision."
+                ),
+            ))
+
+    return unimported + changed + missing
+
+
+# ── internals ─────────────────────────────────────────────────────────────────
+
+
+def _load_raw_decisions(memory_path: Path) -> list[dict]:
+    """Read decisions[] from the memory file as raw dicts.
+
+    Returns [] if the file is missing the decisions key or if it cannot
+    be parsed (the freshness checker is warn-only and never raises).
+    """
+    try:
+        data = json.loads(memory_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    raw = data.get("decisions") if isinstance(data, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [d for d in raw if isinstance(d, dict)]
+
+
+def _active_adrs(adr_dir: Path):
+    """Parse the ADR directory and return (active_id_set, adr_id_to_ADR_map).
+
+    "Active" mirrors the import contract: ``project_decision_graph`` marks
+    accepted-and-not-superseded ADRs as ``status == "active"``. Proposed,
+    deprecated, and superseded ADRs are not expected in memory and do not
+    trigger UNIMPORTED.
+
+    Parse errors are swallowed -- the freshness checker is warn-only and
+    must not crash an unrelated ``mneme check`` invocation.
+    """
+    try:
+        adrs = parse_adr_directory(adr_dir)
+    except Exception:
+        return set(), {}
+
+    nodes = project_decision_graph(adrs)
+    active_ids = {n.id for n in nodes if n.status == "active"}
+    by_id = {a.id: a for a in adrs}
+    return active_ids, by_id
+
+
+def _coerce_source(value: Any) -> dict | None:
+    """Return ``value`` if it is a dict, else None. Tolerates malformed input."""
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+__all__ = [
+    "ADR_UNIMPORTED",
+    "ADR_CHANGED",
+    "ADR_MISSING",
+    "FreshnessIssue",
+    "check_freshness",
+    "compute_source_hash",
+    "relative_source_path",
+]

--- a/mneme-project-memory/mneme/adr_import.py
+++ b/mneme-project-memory/mneme/adr_import.py
@@ -31,6 +31,10 @@ from mneme.adr_compiler import (
 from mneme.adr_parser import parse_adr_directory
 from mneme.schemas import Decision
 
+# Note: mneme.adr_freshness is imported lazily inside ``apply_import`` to
+# avoid a module-init cycle (adr_freshness needs project_decision_graph
+# from this module).
+
 
 GraphStatus = Literal["active", "superseded", "deprecated", "inactive"]
 
@@ -108,12 +112,19 @@ class ImportDiagnostic:
 
 @dataclass(frozen=True)
 class ImportReport:
-    """Output of `compile_for_import`."""
+    """Output of `compile_for_import`.
+
+    ``adr_sources_by_id`` carries the on-disk path of each active ADR so
+    ``apply_import`` can persist a provenance block (path + sha256) on
+    each written decision. Decisions that lack a matching entry get no
+    ``source`` block (e.g. legacy callers constructing reports by hand).
+    """
 
     active_nodes: list[DecisionNode]
     all_nodes: list[DecisionNode]
     decisions: list[Decision]
     diagnostics: list[ImportDiagnostic]
+    adr_sources_by_id: dict[str, str] = field(default_factory=dict)
 
 
 def compile_for_import(adr_dir: str | Path) -> ImportReport:
@@ -151,12 +162,14 @@ def compile_for_import(adr_dir: str | Path) -> ImportReport:
     active_ids = {a.id for a in active_adrs}
     active_nodes = [n for n in all_nodes if n.id in active_ids]
     decisions = adrs_to_decisions(active_adrs)
+    adr_sources_by_id = {a.id: a.source_path for a in active_adrs if a.source_path}
 
     return ImportReport(
         active_nodes=active_nodes,
         all_nodes=all_nodes,
         decisions=decisions,
         diagnostics=diagnostics,
+        adr_sources_by_id=adr_sources_by_id,
     )
 
 
@@ -296,6 +309,8 @@ def apply_import(
 
     Returns the list of ids actually written, in input order.
     """
+    from mneme.adr_freshness import compute_source_hash, relative_source_path
+
     target_path = Path(target_path)
 
     has_active_active = any(
@@ -324,6 +339,13 @@ def apply_import(
             "created_at": decision.created_at,
             "updated_at": decision.updated_at,
         }
+        source_path = report.adr_sources_by_id.get(decision.id)
+        if source_path:
+            entry["source"] = {
+                "type": "adr",
+                "path": relative_source_path(source_path, target_path),
+                "sha256": compute_source_hash(source_path),
+            }
         if decision.id in existing_idx:
             if not allow_update:
                 raise RuntimeError(

--- a/mneme-project-memory/mneme/cli.py
+++ b/mneme-project-memory/mneme/cli.py
@@ -30,6 +30,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from mneme.adr_freshness import FreshnessIssue, check_freshness
 from mneme.adr_import import (
     apply_import,
     compile_for_import,
@@ -144,8 +145,29 @@ def _cmd_check(args: argparse.Namespace) -> int:
             print(f"      {v.decision_text}")
         print()
 
+    # ADR freshness diagnostics are warn-only: they print to stdout but
+    # never influence the exit code. Skipped silently when adr_dir is
+    # absent so existing CLI output is unchanged for projects that do
+    # not use ADRs.
+    freshness = check_freshness(memory_path=args.memory, adr_dir=args.adr_dir)
+    if freshness:
+        for issue in freshness:
+            _print_freshness_issue(issue)
+        print()
+
     print(f"Result: {result.verdict.value}")
     return _EXIT_CODES_BY_MODE[args.mode][result.verdict]
+
+
+def _print_freshness_issue(issue: FreshnessIssue) -> None:
+    """Render one freshness diagnostic with a distinct ``ADR_*`` token.
+
+    Format is intentionally different from enforcement violations so
+    operators can grep ``mneme check`` output without ambiguity.
+    """
+    print(f"WARN  {issue.code:15}  [{issue.adr_id}] {issue.message}")
+    if issue.path:
+        print(f"      source: {issue.path}")
 
 
 # ── Subcommand: cursor generate ──────────────────────────────────────────────
@@ -297,6 +319,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.add_argument(
         "--mode", choices=["warn", "strict"], default="strict",
         help="warn: all verdicts exit 0; strict (default): WARN->1, FAIL->2",
+    )
+    p_check.add_argument(
+        "--adr-dir", dest="adr_dir", default="docs/adr",
+        help=(
+            "Directory containing ADR markdown files to check for freshness "
+            "drift (warn-only; never affects exit code). "
+            "Defaults to docs/adr; freshness is skipped silently if absent."
+        ),
     )
     p_check.set_defaults(func=_cmd_check)
 

--- a/mneme-project-memory/tests/test_adr_freshness.py
+++ b/mneme-project-memory/tests/test_adr_freshness.py
@@ -1,0 +1,236 @@
+"""Tests for ADR freshness detection in `mneme.adr_freshness`.
+
+Covers the four canonical states:
+  - ADR_UNIMPORTED   active ADR file present, no matching decision
+  - ADR_CHANGED      imported ADR file content differs from stored hash
+  - ADR_MISSING      imported decision references an ADR path that vanished
+  - clean            ADR + decision + hash all in sync -> no issues
+
+Plus backward-compatibility: legacy memory files where imported decisions
+lack the new ``source`` provenance block must not crash and must not
+produce spurious warnings.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from mneme.adr_freshness import (
+    ADR_CHANGED,
+    ADR_MISSING,
+    ADR_UNIMPORTED,
+    FreshnessIssue,
+    check_freshness,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _adr_text(adr_id: str, body: str = "Body content.", status: str = "accepted") -> str:
+    return (
+        f"---\n"
+        f"id: {adr_id}\n"
+        f"title: Test {adr_id}\n"
+        f"status: {status}\n"
+        f"priority: normal\n"
+        f"date: 2026-05-01\n"
+        f"scope: test_{adr_id.lower().replace('-', '_')}\n"
+        f"---\n\n"
+        f"{body}\n"
+    )
+
+
+def _write_adr(path: Path, adr_id: str, body: str = "Body content.",
+               status: str = "accepted") -> str:
+    """Write an ADR file and return the SHA-256 of its on-disk bytes.
+
+    Hashing the bytes the OS actually wrote (rather than the source
+    string) avoids false hash mismatches caused by Windows line-ending
+    translation in ``Path.write_text``.
+    """
+    text = _adr_text(adr_id, body=body, status=status)
+    path.write_text(text, encoding="utf-8")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_memory(path: Path, decisions: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "meta": {"name": "t", "description": "t"},
+                "items": [],
+                "examples": [],
+                "decisions": decisions,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _layout(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (memory_path, adr_dir) with conventional repo layout."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    return memory, adr_dir
+
+
+# ── ADR_UNIMPORTED ────────────────────────────────────────────────────────────
+
+
+def test_unimported_active_adr_produces_warning(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-001-foo.md", "ADR-001")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    unimported = [i for i in issues if i.code == ADR_UNIMPORTED]
+    assert len(unimported) == 1
+    assert unimported[0].adr_id == "ADR-001"
+
+
+def test_unimported_proposed_adr_does_not_warn(tmp_path):
+    """Proposed ADRs are intentionally not imported; do not flag them."""
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-099-draft.md", "ADR-099", status="proposed")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert [i for i in issues if i.code == ADR_UNIMPORTED] == []
+
+
+def test_unimported_does_not_trigger_for_non_adr_decisions(tmp_path):
+    """Non-ADR decisions in memory must not produce freshness diagnostics."""
+    memory, adr_dir = _layout(tmp_path)
+    _write_memory(memory, decisions=[{"id": "workflow-001", "decision": "manual"}])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert issues == []
+
+
+# ── ADR_CHANGED ───────────────────────────────────────────────────────────────
+
+
+def test_modified_adr_produces_changed_warning(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    original_hash = _write_adr(adr_dir / "ADR-002-bar.md", "ADR-002", body="Original.")
+
+    _write_memory(memory, decisions=[{
+        "id": "ADR-002",
+        "decision": "Test ADR-002",
+        "source": {
+            "type": "adr",
+            "path": "../docs/adr/ADR-002-bar.md",
+            "sha256": original_hash,
+        },
+    }])
+
+    # Modify the ADR after "import"
+    _write_adr(adr_dir / "ADR-002-bar.md", "ADR-002", body="Modified.")
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    changed = [i for i in issues if i.code == ADR_CHANGED]
+    assert len(changed) == 1
+    assert changed[0].adr_id == "ADR-002"
+
+
+def test_unchanged_adr_produces_no_changed_warning(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    sha = _write_adr(adr_dir / "ADR-004-aligned.md", "ADR-004")
+
+    _write_memory(memory, decisions=[{
+        "id": "ADR-004",
+        "decision": "Aligned",
+        "source": {
+            "type": "adr",
+            "path": "../docs/adr/ADR-004-aligned.md",
+            "sha256": sha,
+        },
+    }])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert issues == []
+
+
+# ── ADR_MISSING ───────────────────────────────────────────────────────────────
+
+
+def test_missing_adr_source_produces_missing_warning(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    # No ADR file written.
+
+    _write_memory(memory, decisions=[{
+        "id": "ADR-003",
+        "decision": "Gone",
+        "source": {
+            "type": "adr",
+            "path": "../docs/adr/ADR-003-gone.md",
+            "sha256": "0" * 64,
+        },
+    }])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    missing = [i for i in issues if i.code == ADR_MISSING]
+    assert len(missing) == 1
+    assert missing[0].adr_id == "ADR-003"
+
+
+# ── backward compatibility ────────────────────────────────────────────────────
+
+
+def test_decision_without_source_is_backward_compatible(tmp_path):
+    """A legacy decision whose id matches an ADR but has no `source` field
+    must not crash and must not produce a spurious UNIMPORTED warning.
+    Without a stored hash there is nothing to compare against, so the checker
+    is silent on freshness for that pairing.
+    """
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-005-legacy.md", "ADR-005")
+    _write_memory(memory, decisions=[{"id": "ADR-005", "decision": "Legacy"}])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    codes = [i.code for i in issues]
+    assert ADR_UNIMPORTED not in codes
+    assert ADR_CHANGED not in codes
+    assert ADR_MISSING not in codes
+
+
+def test_memory_file_without_decisions_key_does_not_crash(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    memory.parent.mkdir(parents=True, exist_ok=True)
+    memory.write_text(json.dumps({"meta": {"name": "t", "description": "t"}}),
+                      encoding="utf-8")
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    # No decisions, no ADRs -> no issues
+    assert issues == []
+
+
+def test_missing_adr_dir_returns_empty(tmp_path):
+    """When the adr_dir does not exist, the checker returns no issues
+    (it cannot say whether anything is unimported)."""
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    _write_memory(memory, decisions=[])
+    issues = check_freshness(memory_path=memory, adr_dir=tmp_path / "nope")
+    assert issues == []
+
+
+# ── output shape ──────────────────────────────────────────────────────────────
+
+
+def test_issue_carries_path_and_message(tmp_path):
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-006-shape.md", "ADR-006")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert len(issues) == 1
+    i = issues[0]
+    assert isinstance(i, FreshnessIssue)
+    assert i.code == ADR_UNIMPORTED
+    assert i.adr_id == "ADR-006"
+    assert "ADR-006-shape.md" in i.path
+    assert i.message  # non-empty

--- a/mneme-project-memory/tests/test_adr_import.py
+++ b/mneme-project-memory/tests/test_adr_import.py
@@ -187,6 +187,38 @@ def test_apply_import_appends_decisions_to_target_memory(tmp_path):
     assert "no mongodb" in by_id["ADR-101"]["constraints"]
 
 
+def test_apply_import_writes_source_provenance_block(tmp_path):
+    """Each imported decision must carry a `source` block with type/path/sha256
+    so `mneme.adr_freshness.check_freshness` can detect drift later.
+    """
+    import hashlib
+    from mneme.adr_import import apply_import, compile_for_import
+
+    target = tmp_path / "project_memory.json"
+    target.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "items": [], "examples": [], "decisions": [],
+    }), encoding="utf-8")
+
+    report = compile_for_import(FIXTURES / "adrs_import_basic")
+    apply_import(report, target_path=target, allow_update=False)
+
+    persisted = json.loads(target.read_text(encoding="utf-8"))
+    by_id = {d["id"]: d for d in persisted["decisions"]}
+
+    for adr_id in ("ADR-101", "ADR-102"):
+        source = by_id[adr_id].get("source")
+        assert source is not None, f"{adr_id} missing source block"
+        assert source["type"] == "adr"
+        assert source["path"].endswith(".md")
+        assert len(source["sha256"]) == 64  # SHA-256 hex digest
+
+        # Hash must match the bytes the importer actually read from disk.
+        resolved = (target.parent / source["path"]).resolve()
+        expected = hashlib.sha256(resolved.read_bytes()).hexdigest()
+        assert source["sha256"] == expected
+
+
 def test_apply_import_refuses_overwrite_without_allow_update(tmp_path):
     """Same-id collision must block apply unless allow_update=True."""
     from mneme.adr_import import apply_import, compile_for_import

--- a/mneme-project-memory/tests/test_cli_check_freshness.py
+++ b/mneme-project-memory/tests/test_cli_check_freshness.py
@@ -1,0 +1,158 @@
+"""CLI integration tests for ADR freshness warnings on `mneme check`.
+
+Freshness diagnostics are warn-only: they appear in stdout with an
+``ADR_<CODE>`` token so they are distinguishable from enforcement
+violations, and they do NOT influence the exit code returned by
+``mneme check``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from mneme.cli import main
+
+
+_ADR_TEXT_TEMPLATE = (
+    "---\n"
+    "id: {adr_id}\n"
+    "title: Test {adr_id}\n"
+    "status: accepted\n"
+    "priority: normal\n"
+    "date: 2026-05-01\n"
+    "scope: test\n"
+    "---\n\n"
+    "Body.\n"
+)
+
+
+def _write_adr(path: Path, adr_id: str) -> str:
+    text = _ADR_TEXT_TEMPLATE.format(adr_id=adr_id)
+    path.write_text(text, encoding="utf-8")
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _memory(tmp_path: Path) -> Path:
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [],
+        "decisions": [
+            {
+                "id": "storage_json",
+                "decision": "Use JSON storage only",
+                "rationale": "local-first",
+                "scope": ["storage"],
+                "constraints": ["no postgres"],
+                "anti_patterns": ["introduce ORM"],
+                "created_at": "2026-04-24T00:00:00Z",
+                "updated_at": "2026-04-24T00:00:00Z",
+            },
+        ],
+    }), encoding="utf-8")
+    return mem
+
+
+def _input(tmp_path: Path, content: str = "Store everything as flat JSON.") -> Path:
+    p = tmp_path / "prompt.txt"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ── --adr-dir flag wires freshness in ─────────────────────────────────────────
+
+
+def test_check_emits_unimported_diagnostic(tmp_path, capsys):
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    _write_adr(adr_dir / "ADR-101-new.md", "ADR-101")
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path)
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    assert "ADR_UNIMPORTED" in out
+    assert "ADR-101" in out
+    # Freshness is warn-only -> exit code follows enforcer verdict only.
+    assert code == 0
+
+
+def test_check_freshness_does_not_change_exit_code_in_strict_mode(tmp_path):
+    """An unimported ADR is warn-only; with a PASS prompt, strict mode stays 0."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    _write_adr(adr_dir / "ADR-200-fresh.md", "ADR-200")
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path, content="Store everything as flat JSON files.")
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "strict",
+        "--adr-dir", str(adr_dir),
+    ])
+    assert code == 0
+
+
+def test_check_clean_when_no_freshness_issues(tmp_path, capsys):
+    """When ADR dir is empty, no ADR_ tokens appear in output."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)  # empty
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path)
+
+    main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    assert "ADR_UNIMPORTED" not in out
+    assert "ADR_CHANGED" not in out
+    assert "ADR_MISSING" not in out
+
+
+def test_check_without_adr_dir_default_missing_is_silent(tmp_path, capsys):
+    """If --adr-dir is not provided and the default does not exist,
+    freshness output is silent (preserves existing CLI behavior)."""
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path)
+
+    # Run from a directory that has no docs/adr/.
+    import os
+    cwd_before = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        main([
+            "check",
+            "--memory", str(mem),
+            "--input", str(inp),
+            "--query", "storage",
+            "--mode", "warn",
+        ])
+    finally:
+        os.chdir(cwd_before)
+
+    out = capsys.readouterr().out
+    assert "ADR_UNIMPORTED" not in out
+    assert "ADR_CHANGED" not in out
+    assert "ADR_MISSING" not in out

--- a/scripts/check_concepts.py
+++ b/scripts/check_concepts.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Validates that site/concepts/index.html stays in sync with the concept pages.
+
+Checks:
+  ERROR  -- a concept page has no matching card on the hub
+  ERROR  -- a concept card has no matching JSON-LD hasPart entry
+  ERROR  -- a JSON-LD hasPart entry points to a concept page that does not exist
+  WARN   -- a concept page has no SVG node and is not listed in svg-omitted.txt
+
+Exit codes:  0 = clean   1 = errors found   2 = warnings only
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HUB = REPO_ROOT / "site" / "concepts" / "index.html"
+CONCEPTS_DIR = REPO_ROOT / "site" / "concepts"
+SVG_OMITTED = REPO_ROOT / "docs" / "site" / "svg-omitted.txt"
+
+
+def load_html(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_card_slugs(html: str) -> set:
+    """Return slugs for every <a class="concept-card"> on the hub."""
+    slugs = set()
+    for m in re.finditer(r'<a\s+([^>]+)>', html):
+        attrs = m.group(1)
+        if 'concept-card' not in attrs:
+            continue
+        href_m = re.search(r'href="/concepts/([^/"]+)/"', attrs)
+        if href_m:
+            slugs.add(href_m.group(1))
+    return slugs
+
+
+def extract_jsonld_slugs(html: str) -> set:
+    """Return slugs from every hasPart entry in the CollectionPage JSON-LD block."""
+    slugs = set()
+    ld_m = re.search(
+        r'<script\s+type="application/ld\+json">(.*?)</script>',
+        html,
+        re.DOTALL,
+    )
+    if not ld_m:
+        return slugs
+    try:
+        data = json.loads(ld_m.group(1))
+    except json.JSONDecodeError as exc:
+        print(f"  ERROR  JSON-LD parse failed: {exc}", file=sys.stderr)
+        return slugs
+    graph = data.get("@graph", [data])
+    for node in graph:
+        if node.get("@type") == "CollectionPage":
+            for part in node.get("hasPart", []):
+                url = part.get("url", "")
+                m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
+                if m:
+                    slugs.add(m.group(1))
+    return slugs
+
+
+def extract_svg_slugs(html: str) -> set:
+    """Return slugs for every concept linked from an SVG cmap-link node."""
+    slugs = set()
+    fig_m = re.search(
+        r'<figure\s+class="concept-map"[^>]*>(.*?)</figure>',
+        html,
+        re.DOTALL,
+    )
+    if not fig_m:
+        return slugs
+    fig_html = fig_m.group(1)
+    for m in re.finditer(r'<a\s+([^>]+)>', fig_html):
+        attrs = m.group(1)
+        if 'cmap-link' not in attrs:
+            continue
+        href_m = re.search(r'href="/concepts/([^/"]+)/"', attrs)
+        if href_m:
+            slugs.add(href_m.group(1))
+    return slugs
+
+
+def page_slugs() -> set:
+    """Return slugs for every concept that has a page (index.html exists)."""
+    slugs = set()
+    for child in CONCEPTS_DIR.iterdir():
+        if child.is_dir() and (child / "index.html").exists():
+            slugs.add(child.name)
+    return slugs
+
+
+def svg_omitted() -> set:
+    """Return slugs explicitly listed as SVG-omitted (empty set if file absent)."""
+    if not SVG_OMITTED.exists():
+        return set()
+    return {
+        line.strip().strip("/")
+        for line in SVG_OMITTED.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def main() -> int:
+    if not HUB.exists():
+        print(f"ERROR  Hub not found: {HUB}", file=sys.stderr)
+        return 1
+
+    hub_html = load_html(HUB)
+    pages = page_slugs()
+    cards = extract_card_slugs(hub_html)
+    jsonld = extract_jsonld_slugs(hub_html)
+    svg = extract_svg_slugs(hub_html)
+    omitted = svg_omitted()
+
+    errors = []
+    warnings = []
+
+    # Check 1: every page has a card
+    for slug in sorted(pages - cards):
+        errors.append(f"  page has no card:        /concepts/{slug}/")
+
+    # Check 2: every card has a JSON-LD entry
+    for slug in sorted(cards - jsonld):
+        errors.append(f"  card has no JSON-LD:     /concepts/{slug}/")
+
+    # Check 3: every JSON-LD entry points to an existing page
+    for slug in sorted(jsonld - pages):
+        errors.append(f"  JSON-LD points nowhere:  /concepts/{slug}/")
+
+    # Check 4 (warn): every page has an SVG node or is explicitly omitted
+    svg_gap = pages - svg - omitted
+    for slug in sorted(svg_gap):
+        warnings.append(
+            f"  no SVG node (add node or list in docs/site/svg-omitted.txt):  {slug}"
+        )
+
+    if errors:
+        print("ERRORS -- fix before opening PR:")
+        for msg in errors:
+            print(msg)
+        if warnings:
+            print()
+    if warnings:
+        print("WARNINGS -- SVG omissions not documented:")
+        for msg in warnings:
+            print(msg)
+
+    if not errors and not warnings:
+        print(
+            f"OK  {len(pages)} concept pages, {len(cards)} cards, "
+            f"{len(jsonld)} JSON-LD entries, {len(svg)} SVG nodes all consistent."
+        )
+        return 0
+
+    return 1 if errors else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_concepts.py
+++ b/scripts/check_concepts.py
@@ -40,28 +40,25 @@ def extract_card_slugs(html: str) -> set:
 
 
 def extract_jsonld_slugs(html: str) -> set:
-    """Return slugs from every hasPart entry in the CollectionPage JSON-LD block."""
+    """Return slugs from every hasPart entry in any CollectionPage JSON-LD block."""
     slugs = set()
-    ld_m = re.search(
+    for ld_m in re.finditer(
         r'<script\s+type="application/ld\+json">(.*?)</script>',
         html,
         re.DOTALL,
-    )
-    if not ld_m:
-        return slugs
-    try:
-        data = json.loads(ld_m.group(1))
-    except json.JSONDecodeError as exc:
-        print(f"  ERROR  JSON-LD parse failed: {exc}", file=sys.stderr)
-        return slugs
-    graph = data.get("@graph", [data])
-    for node in graph:
-        if node.get("@type") == "CollectionPage":
-            for part in node.get("hasPart", []):
-                url = part.get("url", "")
-                m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
-                if m:
-                    slugs.add(m.group(1))
+    ):
+        try:
+            data = json.loads(ld_m.group(1))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"JSON-LD parse failed: {exc}") from exc
+        graph = data.get("@graph", [data])
+        for node in graph:
+            if node.get("@type") == "CollectionPage":
+                for part in node.get("hasPart", []):
+                    url = part.get("url", "")
+                    m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
+                    if m:
+                        slugs.add(m.group(1))
     return slugs
 
 
@@ -69,7 +66,7 @@ def extract_svg_slugs(html: str) -> set:
     """Return slugs for every concept linked from an SVG cmap-link node."""
     slugs = set()
     fig_m = re.search(
-        r'<figure\s+class="concept-map"[^>]*>(.*?)</figure>',
+        r'<figure\b[^>]*\bclass="[^"]*concept-map[^"]*"[^>]*>(.*?)</figure>',
         html,
         re.DOTALL,
     )
@@ -114,7 +111,11 @@ def main() -> int:
     hub_html = load_html(HUB)
     pages = page_slugs()
     cards = extract_card_slugs(hub_html)
-    jsonld = extract_jsonld_slugs(hub_html)
+    try:
+        jsonld = extract_jsonld_slugs(hub_html)
+    except ValueError as exc:
+        print(f"ERROR  {exc}", file=sys.stderr)
+        return 1
     svg = extract_svg_slugs(hub_html)
     omitted = svg_omitted()
 


### PR DESCRIPTION
## Summary
- Detects ADR drift in three states: `ADR_UNIMPORTED` (active ADR not in memory), `ADR_CHANGED` (file hash differs from import), `ADR_MISSING` (imported decision references a vanished file).
- Adds optional `source: {type, path, sha256}` block to each imported decision JSON entry; `Decision` dataclass and `MemoryStore` are untouched, so legacy memory files load without modification.
- Wires `mneme check --adr-dir` (default `docs/adr`); freshness lines print with a distinct `ADR_<CODE>` prefix and never affect exit code. Skipped silently when the dir is absent.

## Compatibility
- Legacy decisions matching an active ADR by id but lacking `source` are treated as imported (no spurious warnings, no crash).
- "Active" mirrors the existing import contract (`project_decision_graph`): proposed/deprecated/superseded ADRs do not trigger `ADR_UNIMPORTED`.
- Malformed ADR corpora cause the checker to return `[]` (warn-only never raises into the enforcer path).

## Test plan
- [x] 10 unit tests in `tests/test_adr_freshness.py` cover all three codes, proposed-not-flagged, non-ADR decisions, backward-compat without `source`, missing dir, missing decisions key, output shape.
- [x] 4 CLI integration tests in `tests/test_cli_check_freshness.py` cover diagnostic emission, exit-code preservation in strict/warn, clean run, and default-path-absent silence.
- [x] 1 new `tests/test_adr_import.py` test pins the `source` provenance round-trip (hash matches on-disk bytes).
- [x] Full suite: **341 passed**.
- [x] End-to-end demo against a temp ADR: import writes `source`, edit triggers `ADR_CHANGED`, delete triggers `ADR_MISSING`.
- [x] `mneme check` without `--adr-dir` on this repo produces byte-identical output to before.

Follow-up P2 issue queued: normalize this repo's legacy ADRs to the supported frontmatter format so freshness checks dogfood against the real corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)