### PR TITLE
feat: surface unparseable ADRs and ignore non-ADR markdown in adr-dir

### DIFF
--- a/mneme-project-memory/mneme/adr_freshness.py
+++ b/mneme-project-memory/mneme/adr_freshness.py
@@ -47,19 +47,23 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from mneme.adr_import import project_decision_graph
-from mneme.adr_parser import parse_adr_directory
+from mneme.adr_parser import parse_adr_file
 
 
 ADR_UNIMPORTED = "ADR_UNIMPORTED"
 ADR_CHANGED = "ADR_CHANGED"
 ADR_MISSING = "ADR_MISSING"
+ADR_UNPARSEABLE = "ADR_UNPARSEABLE"
 
 _SOURCE_TYPE_ADR = "adr"
+_ADR_GLOB = "ADR-*.md"
+_ADR_ID_FROM_NAME = re.compile(r"^(ADR-\d+)")
 
 
 @dataclass(frozen=True)
@@ -132,11 +136,26 @@ def check_freshness(
     raw_decisions = _load_raw_decisions(memory_path)
     decisions_by_id: dict[str, dict] = {d["id"]: d for d in raw_decisions if "id" in d}
 
-    active_adr_ids, adrs_by_id = _active_adrs(adr_dir)
+    active_adr_ids, adrs_by_id, parse_errors = _scan_adr_directory(adr_dir)
 
+    unparseable: list[FreshnessIssue] = []
     unimported: list[FreshnessIssue] = []
     changed: list[FreshnessIssue] = []
     missing: list[FreshnessIssue] = []
+
+    # ADR_UNPARSEABLE: surface per-file parse failures so a single bad
+    # ADR does not silently zero out the rest of the scan.
+    for path, message in parse_errors:
+        unparseable.append(FreshnessIssue(
+            code=ADR_UNPARSEABLE,
+            adr_id=_id_from_filename(path),
+            path=str(path),
+            message=(
+                f"{path.name} could not be parsed as an ADR: {message}. "
+                f"Fix the frontmatter or rename the file out of the "
+                f"ADR-*.md pattern."
+            ),
+        ))
 
     # ADR_UNIMPORTED + ADR_CHANGED: scan the on-disk active corpus.
     for adr_id in sorted(active_adr_ids):
@@ -200,7 +219,7 @@ def check_freshness(
                 ),
             ))
 
-    return unimported + changed + missing
+    return unparseable + unimported + changed + missing
 
 
 # ── internals ─────────────────────────────────────────────────────────────────
@@ -222,26 +241,49 @@ def _load_raw_decisions(memory_path: Path) -> list[dict]:
     return [d for d in raw if isinstance(d, dict)]
 
 
-def _active_adrs(adr_dir: Path):
-    """Parse the ADR directory and return (active_id_set, adr_id_to_ADR_map).
+def _scan_adr_directory(adr_dir: Path):
+    """Scan ADR-*.md files individually, separating parsed from failed.
+
+    Returns ``(active_id_set, adr_id_to_ADR_map, parse_errors)`` where
+    parse_errors is a list of ``(path, message)`` tuples for files whose
+    name matches ``ADR-*.md`` but whose contents could not be parsed.
 
     "Active" mirrors the import contract: ``project_decision_graph`` marks
     accepted-and-not-superseded ADRs as ``status == "active"``. Proposed,
     deprecated, and superseded ADRs are not expected in memory and do not
     trigger UNIMPORTED.
 
-    Parse errors are swallowed -- the freshness checker is warn-only and
-    must not crash an unrelated ``mneme check`` invocation.
-    """
-    try:
-        adrs = parse_adr_directory(adr_dir)
-    except Exception:
-        return set(), {}
+    Non-ADR markdown files (``README.md``, ``notes.md``, ``draft.md``,
+    anything else) are ignored entirely by virtue of the ``ADR-*.md``
+    glob -- they are neither parsed nor reported as errors.
 
-    nodes = project_decision_graph(adrs)
+    Per-file errors are captured rather than raised: one bad ADR must
+    not silently zero out the rest of the scan (the prior behavior),
+    and the checker is warn-only so it must never crash an unrelated
+    ``mneme check`` invocation.
+    """
+    parsed: list = []
+    parse_errors: list[tuple[Path, str]] = []
+    for path in sorted(adr_dir.glob(_ADR_GLOB)):
+        try:
+            parsed.append(parse_adr_file(path))
+        except Exception as exc:
+            parse_errors.append((path, str(exc)))
+
+    nodes = project_decision_graph(parsed)
     active_ids = {n.id for n in nodes if n.status == "active"}
-    by_id = {a.id: a for a in adrs}
-    return active_ids, by_id
+    by_id = {a.id: a for a in parsed}
+    return active_ids, by_id, parse_errors
+
+
+def _id_from_filename(path: Path) -> str:
+    """Extract the ``ADR-NNN`` prefix from a filename, else use the stem.
+
+    Used to label ADR_UNPARSEABLE diagnostics when the file's body cannot
+    be parsed and the declared frontmatter id is therefore unknown.
+    """
+    m = _ADR_ID_FROM_NAME.match(path.name)
+    return m.group(1) if m else path.stem
 
 
 def _coerce_source(value: Any) -> dict | None:
@@ -255,6 +297,7 @@ __all__ = [
     "ADR_UNIMPORTED",
     "ADR_CHANGED",
     "ADR_MISSING",
+    "ADR_UNPARSEABLE",
     "FreshnessIssue",
     "check_freshness",
     "compute_source_hash",

--- a/mneme-project-memory/mneme/adr_parser.py
+++ b/mneme-project-memory/mneme/adr_parser.py
@@ -45,7 +45,12 @@ def parse_adr_file(path: str | Path) -> ADR:
 
 
 def parse_adr_directory(directory: str | Path) -> list[ADR]:
-    """Parse every ``.md`` file in ``directory`` and return a sorted list.
+    """Parse every ``ADR-*.md`` file in ``directory`` and return a sorted list.
+
+    The glob is restricted to ``ADR-*.md`` so that incidental markdown in
+    the ADR directory (a ``README.md`` index, scratch ``notes.md``, work-
+    in-progress ``draft.md``) does not crash the strict ADR parser. Files
+    that do not match the ``ADR-`` filename prefix are ignored entirely.
 
     Files are sorted by ADR id for deterministic output regardless of
     filesystem ordering.
@@ -57,7 +62,7 @@ def parse_adr_directory(directory: str | Path) -> list[ADR]:
         A list of ``ADR`` records, sorted by ``id``.
     """
     directory = Path(directory)
-    adrs = [parse_adr_file(p) for p in sorted(directory.glob("*.md"))]
+    adrs = [parse_adr_file(p) for p in sorted(directory.glob("ADR-*.md"))]
     return sorted(adrs, key=lambda a: a.id)
 
 

--- a/mneme-project-memory/tests/test_adr_freshness.py
+++ b/mneme-project-memory/tests/test_adr_freshness.py
@@ -20,6 +20,7 @@ from mneme.adr_freshness import (
     ADR_CHANGED,
     ADR_MISSING,
     ADR_UNIMPORTED,
+    ADR_UNPARSEABLE,
     FreshnessIssue,
     check_freshness,
 )
@@ -234,3 +235,76 @@ def test_issue_carries_path_and_message(tmp_path):
     assert i.adr_id == "ADR-006"
     assert "ADR-006-shape.md" in i.path
     assert i.message  # non-empty
+
+
+# ── ADR_UNPARSEABLE ───────────────────────────────────────────────────────────
+
+
+def test_unparseable_adr_produces_warning(tmp_path):
+    """An ADR-shaped filename whose contents lack required frontmatter
+    surfaces as ADR_UNPARSEABLE -- silently swallowing it would let real
+    governance content drop out of the active set without explanation.
+    """
+    memory, adr_dir = _layout(tmp_path)
+    bad = adr_dir / "ADR-998-bad.md"
+    bad.write_text("# ADR-998: Legacy heading\n\nNo frontmatter here.\n",
+                   encoding="utf-8")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    unparseable = [i for i in issues if i.code == ADR_UNPARSEABLE]
+    assert len(unparseable) == 1
+    issue = unparseable[0]
+    assert issue.adr_id == "ADR-998"
+    assert "ADR-998-bad.md" in issue.path
+    assert issue.message  # non-empty
+    # An unparseable file must NOT also be reported as UNIMPORTED -- we
+    # don't know its declared status, so we can't claim it should be in
+    # memory.
+    assert [i for i in issues if i.code == ADR_UNIMPORTED] == []
+
+
+def test_unparseable_adr_does_not_block_parseable_neighbors(tmp_path):
+    """One bad ADR must not silence diagnostics for other ADRs in the
+    same directory. Prior to this issue, a single parse error swallowed
+    the entire scan and produced zero diagnostics."""
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-100-good.md", "ADR-100")
+    (adr_dir / "ADR-101-bad.md").write_text("no frontmatter\n", encoding="utf-8")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    codes_by_id = {(i.adr_id, i.code) for i in issues}
+    assert ("ADR-100", ADR_UNIMPORTED) in codes_by_id
+    assert ("ADR-101", ADR_UNPARSEABLE) in codes_by_id
+
+
+# ── non-ADR markdown ignored ──────────────────────────────────────────────────
+
+
+def test_non_adr_markdown_in_adr_dir_is_ignored(tmp_path):
+    """README.md / NOTES.md / draft.md in docs/adr/ are not ADRs.
+    Freshness scanning must ignore them so a stray notes file does not
+    produce noise (and does not produce a false ADR_UNPARSEABLE either).
+    """
+    memory, adr_dir = _layout(tmp_path)
+    (adr_dir / "README.md").write_text("# Index of ADRs\n", encoding="utf-8")
+    (adr_dir / "notes.md").write_text("scratchpad\n", encoding="utf-8")
+    (adr_dir / "draft.md").write_text("---\nfoo: bar\n---\n", encoding="utf-8")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert issues == []
+
+
+def test_non_adr_markdown_ignored_alongside_real_adrs(tmp_path):
+    """Mix of valid ADR-*.md plus stray markdown -> only the ADR matters."""
+    memory, adr_dir = _layout(tmp_path)
+    _write_adr(adr_dir / "ADR-200-real.md", "ADR-200")
+    (adr_dir / "README.md").write_text("not an ADR\n", encoding="utf-8")
+    _write_memory(memory, decisions=[])
+
+    issues = check_freshness(memory_path=memory, adr_dir=adr_dir)
+    assert len(issues) == 1
+    assert issues[0].code == ADR_UNIMPORTED
+    assert issues[0].adr_id == "ADR-200"

--- a/mneme-project-memory/tests/test_adr_parser.py
+++ b/mneme-project-memory/tests/test_adr_parser.py
@@ -52,3 +52,19 @@ def test_malformed_yaml_raises_parse_error():
 def test_parse_adr_file_missing_file_raises():
     with pytest.raises(FileNotFoundError):
         parse_adr_file(VALID_DIR / "does-not-exist.md")
+
+
+def test_parse_directory_ignores_non_adr_markdown(tmp_path):
+    """parse_adr_directory must restrict itself to ADR-*.md files so that
+    incidental markdown (README, scratch notes) in the ADR directory does
+    not crash the strict parser."""
+    (tmp_path / "ADR-001-real.md").write_text(
+        "---\nid: ADR-001\ntitle: real\nstatus: accepted\npriority: normal\n"
+        "date: 2026-01-01\nscope: test\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text("# Index\n", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("scratch\n", encoding="utf-8")
+
+    adrs = parse_adr_directory(tmp_path)
+    assert [a.id for a in adrs] == ["ADR-001"]

--- a/mneme-project-memory/tests/test_cli_check_freshness.py
+++ b/mneme-project-memory/tests/test_cli_check_freshness.py
@@ -156,3 +156,58 @@ def test_check_without_adr_dir_default_missing_is_silent(tmp_path, capsys):
     assert "ADR_UNIMPORTED" not in out
     assert "ADR_CHANGED" not in out
     assert "ADR_MISSING" not in out
+    assert "ADR_UNPARSEABLE" not in out
+
+
+def test_check_emits_unparseable_diagnostic(tmp_path, capsys):
+    """An ADR-shaped file without valid frontmatter surfaces as
+    ADR_UNPARSEABLE in mneme check output (warn-only)."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "ADR-777-broken.md").write_text(
+        "# ADR-777: legacy header only\n\nno yaml here\n",
+        encoding="utf-8",
+    )
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path)
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    assert "ADR_UNPARSEABLE" in out
+    assert "ADR-777" in out
+    # Warn-only: exit code follows enforcer verdict, not freshness.
+    assert code == 0
+
+
+def test_check_ignores_non_adr_markdown_in_adr_dir(tmp_path, capsys):
+    """README.md / notes.md in --adr-dir must not produce any ADR_*
+    warnings (not UNPARSEABLE, not UNIMPORTED, not anything)."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "README.md").write_text("# Index of ADRs\n", encoding="utf-8")
+    (adr_dir / "notes.md").write_text("scratch\n", encoding="utf-8")
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path)
+
+    main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    for code in ("ADR_UNIMPORTED", "ADR_CHANGED", "ADR_MISSING", "ADR_UNPARSEABLE"):
+        assert code not in out


### PR DESCRIPTION
## Summary

- Adds a fourth warn-only freshness code: **`ADR_UNPARSEABLE`** — fires when an `ADR-*.md` file cannot be parsed.
- Narrows `parse_adr_directory` glob from `*.md` to `ADR-*.md` so incidental markdown (`README.md`, `notes.md`, `draft.md`) in the ADR directory is ignored, not crashed on.
- Switches freshness scanning to per-file parse with error capture — one bad ADR no longer silently zeroes out diagnostics for the whole corpus.

## Why

Before this PR, [`adr_freshness._active_adrs`](mneme-project-memory/mneme/adr_freshness.py) called `parse_adr_directory` and swallowed any exception by returning empty sets. A single unparseable ADR file therefore hid the entire scan — `mneme check` would report zero `ADR_*` warnings even when fourteen ADRs failed to parse. [PR #140](https://github.com/TheoV823/mneme/pull/140) only surfaced this because the legacy non-frontmatter ADRs were normalized by hand; a pilot team arriving with messy ADRs would experience the same silent blackout.

This PR addresses both halves of the gap identified in the P3 audit: surface parse failures honestly, and stop pretending every `.md` file in `docs/adr/` is an ADR.

## Scope adherence

- **Warn-only:** `ADR_UNPARSEABLE` never affects the `mneme check` exit code; it follows the same display pattern as the existing three codes.
- **Parser stays strict:** the glob narrows the file selection — it does not loosen what counts as a valid ADR. Files that match `ADR-*.md` still require valid frontmatter; non-matching files are skipped entirely.
- **Untouched:** `DecisionRetriever`, benchmark methodology, `ConflictDetector`, memory-file retrieval, migration tooling.

## Tests added (7)

In `tests/test_adr_freshness.py`:
- `test_unparseable_adr_produces_warning` — bad `ADR-998-*.md` → one `ADR_UNPARSEABLE`, no spurious `ADR_UNIMPORTED`.
- `test_unparseable_adr_does_not_block_parseable_neighbors` — mix of one parseable + one bad → both diagnostics surface.
- `test_non_adr_markdown_in_adr_dir_is_ignored` — `README.md` / `notes.md` / `draft.md` → zero issues.
- `test_non_adr_markdown_ignored_alongside_real_adrs` — stray `README.md` does not produce any ADR_* warning when a real ADR sits next to it.

In `tests/test_adr_parser.py`:
- `test_parse_directory_ignores_non_adr_markdown` — parser-level coverage of the narrowed glob.

In `tests/test_cli_check_freshness.py`:
- `test_check_emits_unparseable_diagnostic` — CLI end-to-end for the new code.
- `test_check_ignores_non_adr_markdown_in_adr_dir` — CLI guarantees no spurious warnings from stray markdown.

Existing `test_check_without_adr_dir_default_missing_is_silent` extended to also assert `ADR_UNPARSEABLE` absent.

## Validation

- Touched test files: **27 passed**.
- Full suite: **348 passed, 52 warnings, 4.69s** (up from 341 baseline; +7 new tests).
- Real-repo `mneme check --memory .mneme/project_memory.json --input README.md --query governance --mode warn --adr-dir docs/adr` → **zero `ADR_*` tokens** on the normalized corpus.
- End-to-end smoke test: dropped `docs/adr/ADR-999-smoke.md` with no frontmatter, ran `mneme check`, observed:
  ```
  WARN  ADR_UNPARSEABLE  [ADR-999] ADR-999-smoke.md could not be parsed as an ADR:
        docs\adr\ADR-999-smoke.md: missing YAML frontmatter (expected file to start with '---').
        Fix the frontmatter or rename the file out of the ADR-*.md pattern.
  ```
  Removed the file; corpus back to clean.

## Compatibility decisions

- **`parse_adr_directory` glob narrows to `ADR-*.md`.** Affects both `mneme adr import` and freshness. For a clean corpus this is a no-op. For a messy corpus, the import path now silently skips stray markdown instead of failing. This is the narrowing the audit recommended — opposite of expanding parser compatibility for legacy ADRs.
- **Issue ordering inside `check_freshness`:** `UNPARSEABLE → UNIMPORTED → CHANGED → MISSING`. Unparseable files are reported first because they block all other freshness reasoning for that file (and operators will want to fix them before anything else).
- **`adr_id` for `ADR_UNPARSEABLE`:** extracted from the filename via `^(ADR-\d+)` since the body's declared id is by definition unknowable. Falls back to the file stem if the regex somehow doesn't match.

## Non-goals

- No ADR parser strictness changes.
- No migration tool.
- No `DecisionRetriever` ranking changes.
- No benchmark methodology changes.
- No `ConflictDetector` contradiction checks.
- No memory-file retrieval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)