### PR TITLE
site: fix stale pip package name and UX path in coding-assistant FAQ

### DIFF
--- a/docs/site/concept-publication.md
+++ b/docs/site/concept-publication.md
@@ -1,0 +1,146 @@
+# Concept Publication Runbook
+
+Reference checklist for publishing a new concept page to `/concepts/`. Run the
+validator in step 7 before opening the PR.
+
+---
+
+## 1. Create the concept page
+
+Create `site/concepts/{slug}/index.html`.
+
+- Slug is lowercase kebab-case matching the concept's canonical URL segment.
+- Include all required `<head>` metadata: `<title>`, `<meta name="description">`,
+  `<link rel="canonical">`, `og:*` and `twitter:*` tags, `article:published_time`.
+- Include the Schema.org `DefinedTerm` JSON-LD block.
+- Link back to the hub: breadcrumb `Concepts → {Concept Name}`.
+- Add at least one related-concept link in the body (see step 5).
+
+OG image: the publishing script generates `og.png` automatically — do not create
+it by hand.
+
+---
+
+## 2. Add the concept card to site/concepts/index.html
+
+Open `site/concepts/index.html`. Find the correct section grid
+(`Core concepts`, `Systems concepts`, or `Adjacent concepts`).
+
+Append the card inside the grid's `<div class="concepts-grid" role="list">`:
+
+```html
+<a href="/concepts/{slug}/" class="concept-card" role="listitem">
+  <div class="card-top">
+    <span class="card-num">{NN}</span>
+    <div>
+      <div class="card-title">{Concept Name}</div>
+    </div>
+  </div>
+  <p class="card-desc">{One-sentence description matching the page's meta description.}</p>
+  <span class="card-arrow">&rarr;</span>
+</a>
+```
+
+Rules:
+- `card-num` is a sequential two-digit display label within its section. It is
+  decorative — the validator does not check numbering. Keep it consistent with
+  neighbouring cards.
+- `card-desc` must match (or closely paraphrase) the `<meta name="description">`
+  on the concept page. This is the value the validator will eventually use for
+  generation (Phase 2).
+- Do not change the section a concept belongs to without updating the hub intro
+  copy and the SVG diagram caption if relevant.
+
+---
+
+## 3. Add the JSON-LD hasPart entry
+
+In the same file (`site/concepts/index.html`), find the `"hasPart"` array inside
+the `CollectionPage` block (around line 202). Add one entry:
+
+```json
+{"@type": "DefinedTerm", "name": "{Concept Name}", "url": "https://mnemehq.com/concepts/{slug}/"}
+```
+
+- `name` must match the `<title>` on the concept page (before the ` — Mneme HQ` suffix).
+- Maintain alphabetical order within the array, or append — either is acceptable,
+  but be consistent within a session.
+- Do not add a trailing comma to the last entry.
+
+---
+
+## 4. Update the SVG knowledge graph (if applicable)
+
+The SVG diagram in `site/concepts/index.html` (lines ~280–405) is **editorial**.
+Not every concept belongs in it. Before adding a node, decide:
+
+**Add an SVG node if** the concept occupies a structural position in the
+primitives → properties → outcomes architecture, or belongs in the failure rail.
+
+**Omit from SVG if** the concept is contextual, adjacent, or definitional without
+a fixed tier. Instead, add its slug to `docs/site/svg-omitted.txt` (one slug per
+line, no trailing slash) so the validator treats the omission as intentional.
+
+If you add a node:
+- Follow the tier conventions: `cmap-card-primitive` (teal border),
+  `cmap-card` (neutral), `cmap-card-outcome` (accent border), `cmap-card-fail`
+  (red dashed).
+- Add flow lines (`<line class="cmap-flow">`) connecting the new node to its
+  tier neighbors.
+- Update the `<desc>` element to describe the new node.
+- Update the `<figcaption>` if the overall diagram narrative changes.
+- Refer to `docs/contributing/diagram-conventions.md` for color roles and
+  accessibility requirements.
+
+---
+
+## 5. Add related-concept cross-links
+
+On the new concept page, add at least one `<a href="/concepts/{related-slug}/">`
+link to a conceptually adjacent concept. The reciprocal link on the related page
+is strongly encouraged but not required for publication.
+
+On the related concept page(s), add a cross-link back where it reads naturally.
+Prefer linking from the "related concepts" section or an inline reference in
+the body prose.
+
+---
+
+## 6. Update sitemap and internal link audit
+
+Open `site/sitemap.xml`. Add a `<url>` block for the new concept:
+
+```xml
+<url>
+  <loc>https://mnemehq.com/concepts/{slug}/</loc>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+</url>
+```
+
+Then do a quick internal link audit:
+- Search the site for any existing pages that reference the new concept by name
+  but do not link to it. Add links where the prose already calls it out.
+- Check the hub intro copy (`site/concepts/index.html` lines ~273–277). If the
+  new concept warrants a mention there, update it.
+
+---
+
+## 7. Run the validator before opening the PR
+
+```bash
+python scripts/check_concepts.py
+```
+
+Exit code 0 = clean. Any non-zero exit means there is actionable drift:
+
+| Code | Meaning |
+|------|---------|
+| 1 | ERROR — pages missing cards, cards missing JSON-LD, or JSON-LD pointing to absent pages |
+| 2 | WARN only — concepts without SVG nodes not listed in svg-omitted.txt |
+
+Fix all ERRORs before opening the PR. WARNs about SVG omission may be resolved
+by either adding the node or adding the slug to `docs/site/svg-omitted.txt`.
+
+The validator is also a good smoke-check after any bulk edit to the hub — run it
+whenever you touch `site/concepts/index.html`.

--- a/docs/site/concept-publication.md
+++ b/docs/site/concept-publication.md
@@ -11,7 +11,8 @@ Create `site/concepts/{slug}/index.html`.
 
 - Slug is lowercase kebab-case matching the concept's canonical URL segment.
 - Include all required `<head>` metadata: `<title>`, `<meta name="description">`,
-  `<link rel="canonical">`, `og:*` and `twitter:*` tags, `article:published_time`.
+  `<link rel="canonical">`, `og:*` and `twitter:*` tags,
+  `article:published_time` (ISO 8601, e.g. `2026-05-21T00:00:00Z`).
 - Include the Schema.org `DefinedTerm` JSON-LD block.
 - Link back to the hub: breadcrumb `Concepts → {Concept Name}`.
 - Add at least one related-concept link in the body (see step 5).
@@ -63,8 +64,8 @@ the `CollectionPage` block (around line 202). Add one entry:
 ```
 
 - `name` must match the `<title>` on the concept page (before the ` — Mneme HQ` suffix).
-- Maintain alphabetical order within the array, or append — either is acceptable,
-  but be consistent within a session.
+- Append the new entry at the end of the array. The existing array is not
+  alphabetical; do not attempt to re-sort it.
 - Do not add a trailing comma to the last entry.
 
 ---
@@ -87,7 +88,8 @@ If you add a node:
   (red dashed).
 - Add flow lines (`<line class="cmap-flow">`) connecting the new node to its
   tier neighbors.
-- Update the `<desc>` element to describe the new node.
+- Update the diagram-level `<desc id="cmap-desc">` to mention the new node
+  in the overall description.
 - Update the `<figcaption>` if the overall diagram narrative changes.
 - Refer to `docs/contributing/diagram-conventions.md` for color roles and
   accessibility requirements.

--- a/docs/site/svg-omitted.txt
+++ b/docs/site/svg-omitted.txt
@@ -1,0 +1,13 @@
+# Concepts intentionally absent from the SVG knowledge graph.
+# These are contextual or adjacent concepts that do not occupy a structural
+# position in the primitives -> properties -> outcomes architecture.
+# Add a slug here (one per line, no trailing slash) whenever a concept is
+# published without an SVG node.
+agent-verification
+agentic-development
+ai-native-sdlc
+decision-continuity
+execution-surfaces
+governance-provenance
+intent-debt
+reliable-delegation

--- a/scripts/check_concepts.py
+++ b/scripts/check_concepts.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Validates that site/concepts/index.html stays in sync with the concept pages.
+
+Checks:
+  ERROR  -- a concept page has no matching card on the hub
+  ERROR  -- a concept card has no matching JSON-LD hasPart entry
+  ERROR  -- a JSON-LD hasPart entry points to a concept page that does not exist
+  WARN   -- a concept page has no SVG node and is not listed in svg-omitted.txt
+
+Exit codes:  0 = clean   1 = errors found   2 = warnings only
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HUB = REPO_ROOT / "site" / "concepts" / "index.html"
+CONCEPTS_DIR = REPO_ROOT / "site" / "concepts"
+SVG_OMITTED = REPO_ROOT / "docs" / "site" / "svg-omitted.txt"
+
+
+def load_html(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_card_slugs(html: str) -> set:
+    """Return slugs for every <a class="concept-card"> on the hub."""
+    slugs = set()
+    for m in re.finditer(r'<a\s+([^>]+)>', html):
+        attrs = m.group(1)
+        if 'concept-card' not in attrs:
+            continue
+        href_m = re.search(r'href="/concepts/([^/"]+)/"', attrs)
+        if href_m:
+            slugs.add(href_m.group(1))
+    return slugs
+
+
+def extract_jsonld_slugs(html: str) -> set:
+    """Return slugs from every hasPart entry in the CollectionPage JSON-LD block."""
+    slugs = set()
+    ld_m = re.search(
+        r'<script\s+type="application/ld\+json">(.*?)</script>',
+        html,
+        re.DOTALL,
+    )
+    if not ld_m:
+        return slugs
+    try:
+        data = json.loads(ld_m.group(1))
+    except json.JSONDecodeError as exc:
+        print(f"  ERROR  JSON-LD parse failed: {exc}", file=sys.stderr)
+        return slugs
+    graph = data.get("@graph", [data])
+    for node in graph:
+        if node.get("@type") == "CollectionPage":
+            for part in node.get("hasPart", []):
+                url = part.get("url", "")
+                m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
+                if m:
+                    slugs.add(m.group(1))
+    return slugs
+
+
+def extract_svg_slugs(html: str) -> set:
+    """Return slugs for every concept linked from an SVG cmap-link node."""
+    slugs = set()
+    fig_m = re.search(
+        r'<figure\s+class="concept-map"[^>]*>(.*?)</figure>',
+        html,
+        re.DOTALL,
+    )
+    if not fig_m:
+        return slugs
+    fig_html = fig_m.group(1)
+    for m in re.finditer(r'<a\s+([^>]+)>', fig_html):
+        attrs = m.group(1)
+        if 'cmap-link' not in attrs:
+            continue
+        href_m = re.search(r'href="/concepts/([^/"]+)/"', attrs)
+        if href_m:
+            slugs.add(href_m.group(1))
+    return slugs
+
+
+def page_slugs() -> set:
+    """Return slugs for every concept that has a page (index.html exists)."""
+    slugs = set()
+    for child in CONCEPTS_DIR.iterdir():
+        if child.is_dir() and (child / "index.html").exists():
+            slugs.add(child.name)
+    return slugs
+
+
+def svg_omitted() -> set:
+    """Return slugs explicitly listed as SVG-omitted (empty set if file absent)."""
+    if not SVG_OMITTED.exists():
+        return set()
+    return {
+        line.strip().strip("/")
+        for line in SVG_OMITTED.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def main() -> int:
+    if not HUB.exists():
+        print(f"ERROR  Hub not found: {HUB}", file=sys.stderr)
+        return 1
+
+    hub_html = load_html(HUB)
+    pages = page_slugs()
+    cards = extract_card_slugs(hub_html)
+    jsonld = extract_jsonld_slugs(hub_html)
+    svg = extract_svg_slugs(hub_html)
+    omitted = svg_omitted()
+
+    errors = []
+    warnings = []
+
+    # Check 1: every page has a card
+    for slug in sorted(pages - cards):
+        errors.append(f"  page has no card:        /concepts/{slug}/")
+
+    # Check 2: every card has a JSON-LD entry
+    for slug in sorted(cards - jsonld):
+        errors.append(f"  card has no JSON-LD:     /concepts/{slug}/")
+
+    # Check 3: every JSON-LD entry points to an existing page
+    for slug in sorted(jsonld - pages):
+        errors.append(f"  JSON-LD points nowhere:  /concepts/{slug}/")
+
+    # Check 4 (warn): every page has an SVG node or is explicitly omitted
+    svg_gap = pages - svg - omitted
+    for slug in sorted(svg_gap):
+        warnings.append(
+            f"  no SVG node (add node or list in docs/site/svg-omitted.txt):  {slug}"
+        )
+
+    if errors:
+        print("ERRORS -- fix before opening PR:")
+        for msg in errors:
+            print(msg)
+        if warnings:
+            print()
+    if warnings:
+        print("WARNINGS -- SVG omissions not documented:")
+        for msg in warnings:
+            print(msg)
+
+    if not errors and not warnings:
+        print(
+            f"OK  {len(pages)} concept pages, {len(cards)} cards, "
+            f"{len(jsonld)} JSON-LD entries, {len(svg)} SVG nodes all consistent."
+        )
+        return 0
+
+    return 1 if errors else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_concepts.py
+++ b/scripts/check_concepts.py
@@ -40,28 +40,25 @@ def extract_card_slugs(html: str) -> set:
 
 
 def extract_jsonld_slugs(html: str) -> set:
-    """Return slugs from every hasPart entry in the CollectionPage JSON-LD block."""
+    """Return slugs from every hasPart entry in any CollectionPage JSON-LD block."""
     slugs = set()
-    ld_m = re.search(
+    for ld_m in re.finditer(
         r'<script\s+type="application/ld\+json">(.*?)</script>',
         html,
         re.DOTALL,
-    )
-    if not ld_m:
-        return slugs
-    try:
-        data = json.loads(ld_m.group(1))
-    except json.JSONDecodeError as exc:
-        print(f"  ERROR  JSON-LD parse failed: {exc}", file=sys.stderr)
-        return slugs
-    graph = data.get("@graph", [data])
-    for node in graph:
-        if node.get("@type") == "CollectionPage":
-            for part in node.get("hasPart", []):
-                url = part.get("url", "")
-                m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
-                if m:
-                    slugs.add(m.group(1))
+    ):
+        try:
+            data = json.loads(ld_m.group(1))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"JSON-LD parse failed: {exc}") from exc
+        graph = data.get("@graph", [data])
+        for node in graph:
+            if node.get("@type") == "CollectionPage":
+                for part in node.get("hasPart", []):
+                    url = part.get("url", "")
+                    m = re.match(r'https://mnemehq\.com/concepts/([^/]+)/', url)
+                    if m:
+                        slugs.add(m.group(1))
     return slugs
 
 
@@ -69,7 +66,7 @@ def extract_svg_slugs(html: str) -> set:
     """Return slugs for every concept linked from an SVG cmap-link node."""
     slugs = set()
     fig_m = re.search(
-        r'<figure\s+class="concept-map"[^>]*>(.*?)</figure>',
+        r'<figure\b[^>]*\bclass="[^"]*concept-map[^"]*"[^>]*>(.*?)</figure>',
         html,
         re.DOTALL,
     )
@@ -114,7 +111,11 @@ def main() -> int:
     hub_html = load_html(HUB)
     pages = page_slugs()
     cards = extract_card_slugs(hub_html)
-    jsonld = extract_jsonld_slugs(hub_html)
+    try:
+        jsonld = extract_jsonld_slugs(hub_html)
+    except ValueError as exc:
+        print(f"ERROR  {exc}", file=sys.stderr)
+        return 1
     svg = extract_svg_slugs(hub_html)
     omitted = svg_omitted()
 

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -254,7 +254,7 @@
         {
           "@type": "Question",
           "name": "How long does it take to set up?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Under 5 minutes for a project with existing documentation. pip install mneme-project-memory, create a decisions/ directory, add your first YAML decision, and run mneme check. See the README for the quickstart." }
+          "acceptedAnswer": { "@type": "Answer", "text": "Under 5 minutes for a project with existing documentation. pip install mneme-hq, add your first decision to .mneme/project_memory.json, and run mneme check. See the README for the quickstart." }
         },
         {
           "@type": "Question",
@@ -534,7 +534,7 @@
 
     <details>
       <summary>How long does it take to set up?</summary>
-      <div class="faq-body">Under 5 minutes for a project with existing documentation. <code>pip install mneme-project-memory</code>, create a <code>decisions/</code> directory, add your first YAML decision, and run <code>mneme check</code>. See the <a href="https://github.com/TheoV823/mneme" style="color:var(--accent)">README</a> for the quickstart.</div>
+      <div class="faq-body">Under 5 minutes for a project with existing documentation. <code>pip install mneme-hq</code>, add your first decision to <code>.mneme/project_memory.json</code>, and run <code>mneme check</code>. See the <a href="https://github.com/TheoV823/mneme" style="color:var(--accent)">README</a> for the quickstart.</div>
     </details>
 
     <details>


### PR DESCRIPTION
## Summary
- Replace `pip install mneme-project-memory` (never on PyPI) with `pip install mneme-hq` in the JSON-LD structured data (line 257) and visible HTML (line 537) of the coding-assistant-governance use-case page
- Update the setup step description from `create a decisions/ directory` to `add your first decision to .mneme/project_memory.json` to match current Mneme UX

## Test Plan
- [ ] Confirm both FAQ occurrences show `pip install mneme-hq` on the rendered page
- [ ] Confirm JSON-LD structured data passes a schema validator (no stale package name)