### PR TITLE
site: remove duplicate compare/claude-code-memory sitemap entry

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -546,11 +546,6 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://mnemehq.com/compare/claude-code-memory/</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://mnemehq.com/qa-glossary/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>


### PR DESCRIPTION
## Summary

- The URL `https://mnemehq.com/compare/claude-code-memory/` appeared twice in `site/sitemap.xml`: once in the canonical `/compare/*` grouping (kept) and once as an orphan further down the file (removed).
- Both entries were byte-identical (`changefreq=monthly`, `priority=0.8`), so this is a pure deduplication — no semantic change to what crawlers see.

## Test plan

- [ ] `<url>` / `</url>` tag counts balanced (verified locally: 116/116)
- [ ] Only one occurrence of `compare/claude-code-memory` in the sitemap (verified locally via grep)
- [ ] Canonical entry preserved in the compare grouping (verified locally)
- [ ] No other sitemap entries touched (5-line deletion, single-purpose diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)