### PR TITLE
site: add RAG coding memory comparison + SEO/GEO pass on compare hub

### DIFF
--- a/scripts/generate_og_images.py
+++ b/scripts/generate_og_images.py
@@ -56,6 +56,7 @@ TEMPLATE_MAP = {
     "og-compare-cursor-rules.html": "compare/cursor-rules/og.png",
     "og-compare-claude-code-memory.html": "compare/claude-code-memory/og.png",
     "og-compare-rag-vs-governance.html": "compare/rag-vs-governance/og.png",
+    "og-compare-rag-coding-memory.html": "compare/rag-coding-memory/og.png",
     "og-integration-index.html": "integrations/og.png",
     "og-integration-claude-code.html": "integrations/claude-code/og.png",
     "og-integration-cursor.html": "integrations/cursor/og.png",

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Compare — Mneme HQ vs Alternatives</title>
+  <title>Compare Mneme HQ to AI Coding Governance Alternatives</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="See how Mneme HQ compares to CodeRabbit, Cursor Rules, Claude Code memory, and RAG-based governance. Structured comparisons for engineering teams evaluating AI governance tools." />
+  <meta name="description" content="Compare Mneme HQ to AI code review, rules files, agent memory, and RAG approaches. Structured comparisons for engineering teams evaluating architectural governance for AI coding agents." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/compare/" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Mneme HQ" />
-  <meta property="og:title" content="Compare — Mneme HQ vs Alternatives" />
-  <meta property="og:description" content="See how Mneme HQ compares to CodeRabbit, Cursor Rules, Claude Code memory, and RAG-based governance." />
+  <meta property="og:title" content="Compare Mneme HQ to AI Coding Governance Alternatives" />
+  <meta property="og:description" content="Compare Mneme HQ to AI code review, rules files, agent memory, and RAG approaches. Structured comparisons for evaluating architectural governance for AI coding agents." />
   <meta property="og:url" content="https://mnemehq.com/compare/" />
   <meta property="og:image" content="https://mnemehq.com/compare/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Compare — Mneme HQ vs Alternatives" />
-  <meta name="twitter:description" content="See how Mneme HQ compares to CodeRabbit, Cursor Rules, Claude Code memory, and RAG-based governance." />
+  <meta name="twitter:title" content="Compare Mneme HQ to AI Coding Governance Alternatives" />
+  <meta name="twitter:description" content="Compare Mneme HQ to AI code review, rules files, agent memory, and RAG approaches. Structured comparisons for evaluating architectural governance for AI coding agents." />
   <meta name="twitter:image" content="https://mnemehq.com/compare/og.png" />
 
     <!-- Consent defaults -->
@@ -43,15 +43,63 @@
       },
       {
         "@type": "CollectionPage",
-        "name": "Compare — Mneme HQ vs Alternatives",
-        "description": "Structured comparisons between Mneme HQ and alternative approaches to AI coding governance.",
+        "name": "Compare Mneme HQ to AI Coding Governance Alternatives",
+        "description": "Structured comparisons between Mneme HQ and alternative approaches to AI coding governance: code review, rules files, agent memory, and retrieval-augmented context.",
         "url": "https://mnemehq.com/compare/",
+        "inLanguage": "en",
+        "dateModified": "2026-05-27",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
         "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
         "hasPart": [
           {"@type": "WebPage", "name": "Mneme HQ vs CodeRabbit", "url": "https://mnemehq.com/compare/coderabbit/"},
           {"@type": "WebPage", "name": "Mneme HQ vs Cursor Rules", "url": "https://mnemehq.com/compare/cursor-rules/"},
           {"@type": "WebPage", "name": "Mneme HQ vs Claude Code Memory", "url": "https://mnemehq.com/compare/claude-code-memory/"},
+          {"@type": "WebPage", "name": "RAG Coding Memory vs Mneme", "url": "https://mnemehq.com/compare/rag-coding-memory/"},
           {"@type": "WebPage", "name": "Mneme HQ vs RAG-based Governance", "url": "https://mnemehq.com/compare/rag-vs-governance/"}
+        ]
+      },
+      {
+        "@type": "ItemList",
+        "name": "Mneme HQ alternatives comparisons",
+        "description": "Structured comparisons of Mneme HQ against adjacent categories in AI coding governance.",
+        "numberOfItems": 5,
+        "itemListOrder": "https://schema.org/ItemListOrderAscending",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Mneme HQ vs CodeRabbit", "url": "https://mnemehq.com/compare/coderabbit/"},
+          {"@type": "ListItem", "position": 2, "name": "Mneme HQ vs Cursor Rules", "url": "https://mnemehq.com/compare/cursor-rules/"},
+          {"@type": "ListItem", "position": 3, "name": "Mneme HQ vs Claude Code Memory", "url": "https://mnemehq.com/compare/claude-code-memory/"},
+          {"@type": "ListItem", "position": 4, "name": "RAG Coding Memory vs Mneme", "url": "https://mnemehq.com/compare/rag-coding-memory/"},
+          {"@type": "ListItem", "position": 5, "name": "Mneme HQ vs RAG-based Governance", "url": "https://mnemehq.com/compare/rag-vs-governance/"}
+        ]
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What does Mneme HQ compete with?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Mneme HQ competes with adjacent categories rather than direct replacements: AI code review (CodeRabbit), per-repo rules files (Cursor Rules), built-in agent memory (Claude Code), and retrieval-augmented context (RAG). Most teams use Mneme alongside one of these rather than instead of them, because Mneme operates at a different layer — pre-generation enforcement of architectural decisions."}
+          },
+          {
+            "@type": "Question",
+            "name": "Which Mneme HQ comparison should I read first?",
+            "acceptedAnswer": {"@type": "Answer", "text": "If your team uses Cursor or any rules-file system, start with the Cursor Rules comparison. If you use Claude Code or a similar agent, start with Claude Code Memory. If your stack relies on a vector store of architectural decisions, start with RAG Coding Memory. The CodeRabbit comparison covers the dual-stack pattern — pre-generation enforcement plus post-generation review — that most teams settle on."}
+          },
+          {
+            "@type": "Question",
+            "name": "Is Mneme HQ an alternative to GitHub Copilot or Cursor?",
+            "acceptedAnswer": {"@type": "Answer", "text": "No. Mneme HQ is not a coding assistant. It is the governance layer that runs alongside any AI coding agent — Copilot, Cursor, Claude Code, Aider, Continue, and others — to enforce architectural decisions at edit time. The comparisons here are about adjacent categories that solve nearby problems, not direct replacements for an AI coding tool."}
+          },
+          {
+            "@type": "Question",
+            "name": "Why do most Mneme HQ comparisons resolve to 'use both'?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Mneme operates pre-generation; most alternatives operate either at a different stage (PR review, retrieval) or on a different surface (per-repo files, in-session memory). The two layers are complementary. The dual-stack pattern — pre-generation enforcement plus a complementary tool — is the typical outcome, not a replacement decision."}
+          },
+          {
+            "@type": "Question",
+            "name": "Are these comparison pages biased toward Mneme HQ?",
+            "acceptedAnswer": {"@type": "Answer", "text": "We describe each alternative in its own framing first, name the dimensions where the two approaches differ, and give an explicit decision matrix for when each tool is the right fit. The goal is to be useful to a buyer who has not yet decided, not to win every comparison. Many pages conclude that a hybrid or dual-stack architecture is the right answer."}
+          }
         ]
       }
     ]
@@ -193,6 +241,41 @@
 }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+
+    /* Hub byline + last-updated */
+    .hub-byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; text-align: center; }
+    .hub-byline a { color: var(--muted); text-decoration: none; }
+    .hub-byline a:hover { color: var(--text); }
+    .hub-byline .sep { color: var(--border2); margin: 0 0.5rem; }
+
+    /* At-a-glance summary table */
+    .glance-wrap { max-width: 900px; margin: 0 auto 3rem; padding: 0 0.25rem; }
+    .glance-eyebrow { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.85rem; padding-left: 0.25rem; }
+    .glance-table-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+    .glance-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; min-width: 640px; }
+    .glance-table th { text-align: left; padding: 0.85rem 1.1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; font-size: 0.74rem; letter-spacing: 0.04em; text-transform: uppercase; font-family: 'DM Mono', monospace; background: rgba(255,255,255,0.015); }
+    .glance-table td { padding: 0.9rem 1.1rem; border-bottom: 1px solid var(--border); vertical-align: top; line-height: 1.6; }
+    .glance-table tr:last-child td { border-bottom: none; }
+    .glance-table td:first-child { color: var(--text); font-weight: 500; white-space: nowrap; }
+    .glance-table td:first-child a { color: var(--text); text-decoration: none; border-bottom: 1px dotted var(--border2); }
+    .glance-table td:first-child a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+    .glance-table td:nth-child(2) { color: var(--teal); font-family: 'DM Mono', monospace; font-size: 0.78rem; }
+    .glance-table td:nth-child(3) { color: var(--muted); }
+    .glance-table td:nth-child(4) { color: var(--muted); }
+
+    /* FAQ block */
+    .faq-wrap { max-width: 720px; margin: 4rem auto 0; padding: 0 0.25rem; }
+    .faq-wrap h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin-bottom: 1.25rem; color: var(--text); }
+    .faq-list { margin: 0; }
+    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
+    .faq-item[open] summary::after { content: '\2212'; }
+    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
+    .faq-body a { color: var(--accent); text-decoration: none; }
+    .faq-body a:hover { color: var(--accent-dim); }
   </style>
 </head>
 <body>
@@ -225,7 +308,14 @@
 <div class="hero">
   <div class="section-eyebrow">Compare</div>
   <h1>Mneme HQ vs the alternatives</h1>
-  <p class="hero-sub">Structured comparisons for engineering teams evaluating AI governance tools. How each approach works, when each is the right fit, and where they diverge.</p>
+  <p class="hero-sub">Structured comparisons for engineering teams evaluating AI coding governance tools. How each approach works, when each is the right fit, and where they diverge.</p>
+  <p class="hub-byline">
+    By <a href="/founder/">Theo Valmis</a>
+    <span class="sep">&middot;</span>
+    <time datetime="2026-05-27">Last updated May 2026</time>
+    <span class="sep">&middot;</span>
+    <span>5 comparisons</span>
+  </p>
 </div>
 
 <div class="cards-wrap">
@@ -274,6 +364,19 @@
 
     <div class="compare-card">
       <div class="card-meta">
+        <span class="card-tag">Coding Memory</span>
+        <span class="card-dot"></span>
+        <span class="card-tag">6 min read</span>
+      </div>
+      <h3>RAG Coding Memory vs Mneme</h3>
+      <p>RAG is useful for contextual memory. It is weak as decision memory. When an AI coding agent has to recall architectural decisions across sessions, retrieval ranking, embedding decay, and scope collisions all surface.</p>
+      <div class="card-footer">
+        <a href="/compare/rag-coding-memory/" class="read-link">Compare &rarr;</a>
+      </div>
+    </div>
+
+    <div class="compare-card">
+      <div class="card-meta">
         <span class="card-tag">Architecture</span>
         <span class="card-dot"></span>
         <span class="card-tag">5 min read</span>
@@ -287,7 +390,81 @@
 
   </div>
 
-  <h2 style="font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; color: var(--text); letter-spacing: -0.01em; margin: 4rem auto 1rem; max-width: 660px;">How to read these comparisons</h2>
+  <section class="glance-wrap" aria-labelledby="glance-heading" style="margin-top: 4rem;">
+    <h2 id="glance-heading" class="glance-eyebrow">At a glance &middot; how Mneme HQ compares</h2>
+    <div class="glance-table-scroll">
+      <table class="glance-table">
+        <thead>
+          <tr>
+            <th scope="col">Comparison</th>
+            <th scope="col">Category</th>
+            <th scope="col">Operates at</th>
+            <th scope="col">When to choose Mneme</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/compare/coderabbit/">vs CodeRabbit</a></td>
+            <td>AI code review</td>
+            <td>Post-generation, PR stage</td>
+            <td>Need pre-generation blocking, not post-hoc review</td>
+          </tr>
+          <tr>
+            <td><a href="/compare/cursor-rules/">vs Cursor Rules</a></td>
+            <td>Per-repo rules file</td>
+            <td>Editor-local, Cursor-only</td>
+            <td>Need cross-IDE enforcement with precedence semantics</td>
+          </tr>
+          <tr>
+            <td><a href="/compare/claude-code-memory/">vs Claude Code Memory</a></td>
+            <td>Built-in agent memory</td>
+            <td>Session-scoped instructions</td>
+            <td>Need deterministic recall across sessions and agents</td>
+          </tr>
+          <tr>
+            <td><a href="/compare/rag-coding-memory/">vs RAG Coding Memory</a></td>
+            <td>Retrieval for coding context</td>
+            <td>Generation-time context injection</td>
+            <td>Need exact recall of architectural decisions, not approximate</td>
+          </tr>
+          <tr>
+            <td><a href="/compare/rag-vs-governance/">vs RAG-based Governance</a></td>
+            <td>Retrieval as governance</td>
+            <td>Pre-generation context hint</td>
+            <td>Need enforcement that blocks, not retrieval that suggests</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="faq-wrap" aria-labelledby="faq-heading">
+    <h2 id="faq-heading">Frequently asked questions</h2>
+    <div class="faq-list">
+      <details class="faq-item">
+        <summary>What does Mneme HQ compete with?</summary>
+        <div class="faq-body">Mneme HQ competes with adjacent categories rather than direct replacements: AI code review (CodeRabbit), per-repo rules files (Cursor Rules), built-in agent memory (Claude Code), and retrieval-augmented context (RAG). Most teams use Mneme alongside one of these rather than instead of them, because Mneme operates at a different layer &mdash; pre-generation enforcement of architectural decisions.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Which Mneme HQ comparison should I read first?</summary>
+        <div class="faq-body">If your team uses Cursor or any rules-file system, start with the <a href="/compare/cursor-rules/">Cursor Rules comparison</a>. If you use Claude Code or a similar agent, start with <a href="/compare/claude-code-memory/">Claude Code Memory</a>. If your stack relies on a vector store of architectural decisions, start with <a href="/compare/rag-coding-memory/">RAG Coding Memory</a>. The <a href="/compare/coderabbit/">CodeRabbit comparison</a> covers the dual-stack pattern &mdash; pre-generation enforcement plus post-generation review &mdash; that most teams settle on.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Is Mneme HQ an alternative to GitHub Copilot or Cursor?</summary>
+        <div class="faq-body">No. Mneme HQ is not a coding assistant. It is the governance layer that runs alongside any AI coding agent &mdash; Copilot, Cursor, Claude Code, Aider, Continue, and others &mdash; to enforce architectural decisions at edit time. The comparisons here are about adjacent categories that solve nearby problems, not direct replacements for an AI coding tool.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Why do most Mneme HQ comparisons resolve to &ldquo;use both&rdquo;?</summary>
+        <div class="faq-body">Mneme operates pre-generation; most alternatives operate either at a different stage (PR review, retrieval) or on a different surface (per-repo files, in-session memory). The two layers are complementary. The dual-stack pattern &mdash; pre-generation enforcement plus a complementary tool &mdash; is the typical outcome, not a replacement decision.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Are these comparison pages biased toward Mneme HQ?</summary>
+        <div class="faq-body">We describe each alternative in its own framing first, name the dimensions where the two approaches differ, and give an explicit decision matrix for when each tool is the right fit. The goal is to be useful to a buyer who has not yet decided, not to win every comparison. Many pages conclude that a hybrid or dual-stack architecture is the right answer.</div>
+      </details>
+    </div>
+  </section>
+
+  <h2 style="font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; color: var(--text); letter-spacing: -0.01em; margin: 4rem auto 1rem; max-width: 660px;">How each comparison is structured</h2>
 
   <p style="font-size: 0.88rem; color: var(--muted); line-height: 1.85; max-width: 660px; margin: 0 auto 1.1rem;">Each comparison page follows the same template. We describe what the alternative tool does (in the alternative tool's own words, not ours), name the dimensions where the two approaches differ, and give an explicit decision matrix for when each tool is the right fit. The goal is to be useful to a buyer who has not yet decided &mdash; not to win every comparison.</p>
 

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -148,7 +148,7 @@
     @media (max-width: 900px) {
       html, body { overflow-x: hidden; }
       body.menu-open { overflow: hidden; }
-      nav { position: relative; padding: 1rem 1.25rem; }
+      nav { padding: 1rem 1.25rem; }
       .nav-hamburger { display: flex; }
       .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
       .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -1,0 +1,550 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RAG Coding Memory vs Mneme | AI Coding Agent Memory</title>
+  <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="/assets/css/fonts.css">
+  <meta name="description" content="RAG can help coding agents retrieve project context, but architectural decisions need deterministic recall, scope handling, precedence, and auditability. Compare RAG coding memory with Mneme." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0c0c0d" />
+  <link rel="canonical" href="https://mnemehq.com/compare/rag-coding-memory/" />
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Mneme HQ" />
+  <meta property="og:title" content="RAG Coding Memory vs Mneme" />
+  <meta property="og:description" content="RAG can help coding agents retrieve project context, but architectural decisions need deterministic recall, scope handling, precedence, and auditability." />
+  <meta property="og:url" content="https://mnemehq.com/compare/rag-coding-memory/" />
+  <meta property="og:image" content="https://mnemehq.com/compare/rag-coding-memory/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="RAG Coding Memory vs Mneme" />
+  <meta name="twitter:description" content="RAG is useful for contextual memory. It is weak as decision memory. The distinction matters when AI coding agents have to recall architectural decisions across sessions." />
+  <meta name="twitter:image" content="https://mnemehq.com/compare/rag-coding-memory/og.png" />
+  <meta name="author" content="Theo Valmis" />
+  <meta property="article:published_time" content="2026-05-27T00:00:00Z" />
+  <meta property="article:author" content="https://mnemehq.com/founder/" />
+  <meta property="article:section" content="Engineering" />
+
+    <!-- Consent defaults -->
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'granted','ad_storage':'denied','ad_user_data':'denied','ad_personalization':'denied'});</script>
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
+  <!-- End Google Tag Manager -->
+  <link rel="icon" href="/favicon.png" type="image/png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0c0c0d; --surface: #141416; --surface2: #1a1a1d;
+      --border: #222226; --border2: #2e2e34;
+      --text: #e8e8ec; --muted: #a8a8b8;
+      --accent: #c8f060; --accent-dim: #a8d040; --teal: #8be0c8;
+    }
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; min-height: 100vh; }
+    nav { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 2.5rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(12,12,13,0.95); backdrop-filter: blur(12px); z-index: 100; }
+    .logo { display: flex; align-items: center; text-decoration: none; }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.82rem; transition: color 0.15s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .btn-nav-cta { background: var(--accent); color: #0c0c0d; padding: 0.45rem 1.1rem; border-radius: 6px; font-size: 0.82rem; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+    .btn-nav-cta:hover { background: var(--accent-dim); color: #0c0c0d; }
+
+    .article-wrap { max-width: 720px; margin: 0 auto; padding: 5rem 2rem 7rem; }
+    .article-header { margin-bottom: 3.5rem; }
+    .article-eyebrow { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; }
+    .eyebrow-tag { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); font-family: 'DM Mono', monospace; }
+    .eyebrow-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--border2); }
+    .eyebrow-meta { font-size: 0.7rem; color: var(--muted); font-family: 'DM Mono', monospace; }
+    .article-header h1 { font-family: 'Instrument Serif', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
+    .article-lede { font-size: 1.1rem; color: var(--muted); line-height: 1.75; border-left: 2px solid var(--accent); padding-left: 1.25rem; }
+    .byline { font-family: 'DM Mono', monospace; font-size: 0.7rem; color: var(--muted); letter-spacing: 0.04em; margin-top: 1.25rem; }
+    .byline a { color: var(--muted); text-decoration: none; }
+    .byline a:hover { color: var(--text); }
+    .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+
+    .faq-list { margin-top: 1.5rem; }
+    .faq-item { border-top: 1px solid var(--border); padding: 1.05rem 0; }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item summary { cursor: pointer; font-size: 0.92rem; color: var(--text); font-weight: 500; list-style: none; position: relative; padding-right: 2rem; }
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after { content: '+'; font-family: 'DM Mono', monospace; color: var(--muted); font-size: 1.1rem; position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
+    .faq-item[open] summary::after { content: '\2212'; }
+    .faq-body { padding-top: 0.85rem; font-size: 0.85rem; color: var(--muted); line-height: 1.8; }
+    .faq-body a { color: var(--accent); text-decoration: none; }
+    .faq-body a:hover { color: var(--accent-dim); }
+
+    .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
+    .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
+    .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
+    .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body p strong { color: var(--text); font-weight: 500; }
+    .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
+    .article-body li { margin-bottom: 0.5rem; }
+    .article-body li strong { color: var(--text); font-weight: 500; }
+
+    .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
+    .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
+    .callout p strong { color: var(--accent); }
+
+    .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
+    .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
+    .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    .comparison-table td:first-child { color: var(--muted); white-space: nowrap; }
+    .comparison-table td:nth-child(2) { color: var(--text); opacity: 0.55; }
+    .comparison-table td:nth-child(3) { color: var(--teal); }
+
+    .memory-split { margin: 2.5rem 0; display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    .memory-card { padding: 1.25rem 1.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; }
+    .memory-card--contextual { border-left: 3px solid var(--teal); }
+    .memory-card--decision { border-left: 3px solid var(--accent); }
+    .memory-card-label { font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.5rem; }
+    .memory-card--contextual .memory-card-label { color: var(--teal); }
+    .memory-card--decision .memory-card-label { color: var(--accent); }
+    .memory-card-title { font-size: 0.95rem; font-weight: 600; color: var(--text); margin-bottom: 0.55rem; letter-spacing: -0.005em; }
+    .memory-card p { font-size: 0.82rem; color: var(--muted); line-height: 1.75; margin: 0; }
+    @media (max-width: 640px) { .memory-split { grid-template-columns: 1fr; } }
+
+    .article-footer { margin-top: 4rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .back-link { color: var(--muted); font-size: 0.82rem; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; }
+    .back-link:hover { color: var(--text); }
+    .cta-block { margin-top: 2.5rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; }
+    .cta-block h3 { font-family: 'Inter', sans-serif; font-size: 1.1rem; font-weight: 600; margin-bottom: 0.6rem; }
+    .cta-block p { font-size: 0.85rem; color: var(--muted); margin-bottom: 1.25rem; }
+    .btn-primary { display: inline-block; background: var(--accent); color: #0c0c0d; padding: 0.65rem 1.5rem; border-radius: 8px; font-size: 0.85rem; font-weight: 600; font-family: 'DM Mono', monospace; text-decoration: none; transition: background 0.15s; }
+    .btn-primary:hover { background: var(--accent-dim); }
+    .cta-secondary { display: block; margin-top: 0.75rem; font-size: 0.82rem; color: var(--muted); text-decoration: none; }
+    .cta-secondary:hover { color: var(--text); }
+
+    footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+
+    .breadcrumb-nav { max-width: 720px; margin: 0 auto; padding: 1.75rem 2rem 0.85rem; }
+    .breadcrumb { display: flex; align-items: center; gap: 0.5rem; list-style: none; font-size: 0.82rem; flex-wrap: wrap; }
+    .breadcrumb li + li::before { content: '/'; color: var(--border2); margin-right: 0.5rem; }
+    .breadcrumb a { color: var(--muted); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--text); }
+    .breadcrumb [aria-current="page"] { color: var(--text); }
+
+    h2#related-reading { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 400; margin-top: 3.5rem; margin-bottom: 0.75rem; }
+    h2#related-reading + ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    h2#related-reading + ul li { margin: 0; }
+    h2#related-reading + ul li a { display: flex; justify-content: space-between; align-items: center; padding: 0.9rem 1.1rem; background: var(--surface); color: var(--text); text-decoration: none; font-size: 0.85rem; font-weight: 500; transition: background 0.15s, color 0.15s; }
+    h2#related-reading + ul li a::after { content: '\2192'; opacity: 0.35; transition: opacity 0.15s, transform 0.15s; display: inline-block; margin-left: 0.5rem; }
+    h2#related-reading + ul li a:hover { background: var(--surface2); color: var(--accent); }
+    h2#related-reading + ul li a:hover::after { opacity: 1; transform: translateX(3px); }
+
+    .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
+    .nav-hamburger:hover { border-color: var(--accent); }
+    .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .nav-hamburger span { display: block; width: 18px; height: 2px; background: currentColor; border-radius: 1px; transition: transform 0.25s ease, opacity 0.18s ease; transform-origin: center; }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+    @media (max-width: 900px) {
+      html, body { overflow-x: hidden; }
+      body.menu-open { overflow: hidden; }
+      nav { position: relative; padding: 1rem 1.25rem; }
+      .nav-hamburger { display: flex; }
+      .nav-links { display: flex !important; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; gap: 0; background: rgba(12,12,13,0.98); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 1.25rem; z-index: 99; max-height: 0; overflow: hidden; opacity: 0; visibility: hidden; transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease, visibility 0s linear 0.28s; }
+      .nav-links.open { max-height: 80vh; opacity: 1; visibility: visible; padding: 0.5rem 1.25rem 1.25rem; transition: max-height 0.32s ease, opacity 0.25s ease, padding 0.32s ease, visibility 0s; overflow-y: auto; }
+      .nav-links a:not(.btn-nav-cta) { display: block; color: var(--text); font-size: 0.92rem; padding: 0.85rem 0; border-bottom: 1px solid var(--border); }
+      .nav-links a:not(.btn-nav-cta):last-of-type { border-bottom: none; }
+      .nav-links .btn-nav-cta { margin-top: 1rem; text-align: center; display: block; }
+    }
+    @media (max-width: 640px) { .article-wrap { padding: 3rem 1.25rem 5rem; } }
+
+    @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* Cross-reference panel (Related governance concepts) */
+    .related-panel { margin-top: 3rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/"},
+          {"@type": "ListItem", "position": 2, "name": "Compare", "item": "https://mnemehq.com/compare/"},
+          {"@type": "ListItem", "position": 3, "name": "RAG Coding Memory vs Mneme", "item": "https://mnemehq.com/compare/rag-coding-memory/"}
+        ]
+      },
+      {
+        "@type": "Article",
+        "headline": "RAG Coding Memory vs Mneme",
+        "description": "RAG can help coding agents retrieve project context, but architectural decisions need deterministic recall, scope handling, precedence, and auditability. Compare RAG coding memory with Mneme.",
+        "url": "https://mnemehq.com/compare/rag-coding-memory/",
+        "datePublished": "2026-05-27",
+        "dateModified": "2026-05-27",
+        "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
+        "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
+        "image": "https://mnemehq.com/compare/rag-coding-memory/og.png",
+        "mainEntityOfPage": "https://mnemehq.com/compare/rag-coding-memory/"
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is RAG a good memory layer for AI coding agents?",
+            "acceptedAnswer": {"@type": "Answer", "text": "RAG works well as contextual memory: surfacing relevant code snippets, documentation, prior commits, and historical examples to improve generation quality. It is weaker as decision memory: when an architectural decision must apply every time a certain file or pattern is touched, top-k retrieval can miss the rule, rank it below noisier neighbors, or surface a superseded version. Contextual memory is approximate by nature; decision memory has to be exact."}
+          },
+          {
+            "@type": "Question",
+            "name": "Why does RAG miss architectural decisions for coding agents?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Three structural reasons. First, embedding similarity is keyword-shaped: a decision phrased differently from the current task is not retrieved. Second, scope is not native to vector search: a decision that applies only to one directory may surface for unrelated files. Third, precedence is invisible to retrieval: when two decisions overlap, the model picks based on context order, not authority. Each of these is solvable in indexing, but the cumulative reliability is still probabilistic."}
+          },
+          {
+            "@type": "Question",
+            "name": "Can I plug my existing ADR RAG into Mneme HQ?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Yes. Mneme imports ADRs and architectural decision records into a typed decision corpus with scope rules and precedence semantics. Your existing ADR collection remains the human-readable source. Mneme adds the machine-evaluable layer on top: each decision becomes a constraint with explicit scope, supersession history, and an enforcement contract. You keep RAG for narrative retrieval; Mneme handles the per-edit recall."}
+          },
+          {
+            "@type": "Question",
+            "name": "Should we use both RAG and Mneme for coding memory?",
+            "acceptedAnswer": {"@type": "Answer", "text": "Yes, at different layers. RAG is the right tool for contextual recall: documentation, design discussions, prior implementations. Mneme is the right tool for decision recall: which architectural decisions apply to this file, in what order, with what scope. Most teams settle on a layered architecture where RAG informs generation and Mneme enforces decisions. The two operate on different memory problems."}
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<nav>
+  <a href="/" class="logo"><img src="/logo-v2.png" alt="Mneme HQ" height="36" style="display:block;"></a>
+  <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
+  <div class="nav-links">
+    <a href="/#how-it-works">How it works</a>
+    <a href="/use-cases/">Use cases</a>
+    <a href="/insights/">Insights</a>
+    <a href="/roadmap/">Roadmap</a>
+    <a href="/demo/">Demo</a>
+    <a href="/benchmark/">Benchmark</a>
+    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/TheoV823/mneme" class="btn-nav-cta">Get started</a>
+  </div>
+</nav>
+
+<main>
+<nav aria-label="Breadcrumb" class="breadcrumb-nav">
+  <ol class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/compare/">Compare</a></li>
+    <li aria-current="page">RAG Coding Memory vs Mneme</li>
+  </ol>
+</nav>
+<article class="article-wrap">
+  <header class="article-header">
+    <div class="article-eyebrow">
+      <span class="eyebrow-tag">Comparative</span>
+      <span class="eyebrow-dot"></span>
+      <span class="eyebrow-meta">6 min read &nbsp;&middot;&nbsp; May 2026</span>
+    </div>
+    <h1>RAG Coding Memory vs Mneme</h1>
+    <p class="article-lede">RAG is useful for contextual memory. It is weak as decision memory. Coding agents need both &mdash; and the difference between them decides whether your architectural decisions survive across sessions.</p>
+    <p class="byline">
+      By <a href="/founder/">Theo Valmis</a>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-27">Published May 2026</time>
+      <span class="sep">&middot;</span>
+      <time datetime="2026-05-27">Updated May 2026</time>
+    </p>
+  </header>
+
+  <div class="article-body">
+
+    <h2>What teams mean by &ldquo;RAG for coding memory&rdquo;</h2>
+
+    <p>The pattern is now familiar: index a repository&rsquo;s ADRs, design docs, code snippets, prior commits, and engineering wiki pages into a vector store. At each coding agent turn, retrieve the top-k most relevant chunks and inject them into the model&rsquo;s context. The goal is persistent project memory &mdash; the agent &ldquo;remembers&rdquo; what your team has decided, even across new sessions.</p>
+
+    <p>It is a genuine upgrade over a single CLAUDE.md or a flat rules file. The vector store scales beyond a context window. The retrieval is task-relevant, not blanket. And for a wide class of coding work &mdash; understanding unfamiliar code, surfacing examples, finding related implementations &mdash; it does what it claims.</p>
+
+    <ul>
+      <li>Scales to large knowledge bases without saturating the context window</li>
+      <li>Surfaces task-relevant context instead of injecting every rule into every session</li>
+      <li>Works with the infrastructure teams already have: pgvector, Pinecone, Chroma, LanceDB</li>
+      <li>Improves average-case code quality by giving the model concrete examples and prior art</li>
+      <li>Captures tacit knowledge that lives in design docs and Slack threads</li>
+    </ul>
+
+    <p>Where RAG-as-coding-memory breaks is at the seam between two different memory problems. <strong>Contextual memory</strong> is what the agent should know to do good work. <strong>Decision memory</strong> is what the agent must obey every time, even when the topic isn&rsquo;t the focus of the current task.</p>
+
+    <div class="memory-split">
+      <div class="memory-card memory-card--contextual">
+        <div class="memory-card-label">Contextual memory</div>
+        <div class="memory-card-title">RAG&rsquo;s home turf</div>
+        <p>Approximate. Recall-quality scales with embedding quality. Best for examples, prior implementations, design discussions, narrative documentation. The model decides how to apply what is surfaced.</p>
+      </div>
+      <div class="memory-card memory-card--decision">
+        <div class="memory-card-label">Decision memory</div>
+        <div class="memory-card-title">Where typed corpus wins</div>
+        <p>Exact. Recall must be deterministic regardless of phrasing. Best for architectural decisions, scope rules, supersessions. The system &mdash; not the model &mdash; resolves which decision applies and how.</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <p><strong>The framing that resolves the debate:</strong> RAG is good memory for things the agent can use. It is poor memory for things the agent must obey. Architectural decisions are the second category.</p>
+    </div>
+
+    <h2>Where they differ as memory layers</h2>
+
+    <div style="overflow-x:auto;margin:2rem 0;">
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>Dimension</th>
+          <th>RAG coding memory</th>
+          <th>Mneme HQ</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Recall guarantee</td>
+          <td>Probabilistic top-k</td>
+          <td>Deterministic scope lookup</td>
+        </tr>
+        <tr>
+          <td>Scope handling</td>
+          <td>Implicit in embeddings</td>
+          <td>Explicit per decision (file, dir, repo)</td>
+        </tr>
+        <tr>
+          <td>Precedence resolution</td>
+          <td>Model interprets context order</td>
+          <td>Precedence engine resolves</td>
+        </tr>
+        <tr>
+          <td>Cross-session continuity</td>
+          <td>Re-retrieved per session, embedding-dependent</td>
+          <td>Same verdict every session, every agent</td>
+        </tr>
+        <tr>
+          <td>Supersession history</td>
+          <td>Old and new versions may both surface</td>
+          <td>Superseded decisions explicitly tracked</td>
+        </tr>
+        <tr>
+          <td>Override semantics</td>
+          <td>None &mdash; model silently overrides</td>
+          <td>Override is a decision record with rationale</td>
+        </tr>
+        <tr>
+          <td>Audit trail</td>
+          <td>Which chunks retrieved, not which applied</td>
+          <td>Every enforcement event is traceable</td>
+        </tr>
+        <tr>
+          <td>Multi-agent recall</td>
+          <td>Different models retrieve and apply differently</td>
+          <td>Same enforcement contract for every agent</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+
+    <h2>Three coding-memory failure modes</h2>
+
+    <p>The reliability gap shows up in concrete ways once a team scales an AI coding agent past a handful of sessions. These are the patterns that drive teams from pure-RAG memory to a typed decision layer.</p>
+
+    <h3>1. Silent forgetting</h3>
+
+    <p>An architectural decision is indexed. It exists in the vector store. The agent edits a file the decision applies to &mdash; but the current task description doesn&rsquo;t embed close to the decision&rsquo;s text. The decision is not in the top-k. The agent generates code that violates it, and nothing notices.</p>
+
+    <p>This is the most common failure: not that the rule is missing, but that retrieval ranking demoted it. The fix is not better embeddings. It is recall that doesn&rsquo;t depend on phrasing similarity.</p>
+
+    <h3>2. Embedding decay</h3>
+
+    <p>A decision is rephrased over time as ADRs are edited, summarized, or rewritten. Each rephrasing shifts its embedding. Tasks that used to retrieve it cleanly now miss. Worse: an older, superseded version with stronger keyword overlap re-enters the top-k while the current version doesn&rsquo;t. The agent obeys the wrong version of a decision the team thought it had updated.</p>
+
+    <h3>3. Scope collision</h3>
+
+    <p>Two decisions overlap. One is repo-wide; the other applies only to a specific service. Both retrieve. The model picks based on context order, recency in the window, or token similarity &mdash; not authority. The narrower, more specific decision loses to the broader one because it embedded slightly worse. Vector search has no native concept of scope precedence.</p>
+
+    <p>Each of these is structural. They are not solvable by upgrading the embedding model, the chunking strategy, or the reranker. They are the cost of using probabilistic retrieval as a substitute for typed lookup.</p>
+
+    <h2>Why typed decision memory works for code</h2>
+
+    <p>Code is structured. Files have paths. Modules have boundaries. Architectural decisions have explicit scope &mdash; this applies to <code style="font-family:'DM Mono',monospace;font-size:0.88em;color:var(--text);">services/auth/**</code>, that applies to the whole repo. Vector search flattens all of this into similarity space and asks the model to reconstruct it from context.</p>
+
+    <p>Mneme treats decisions as typed records, not text. Each decision has explicit scope (file glob, directory, repo), a precedence position (override, supersedes), and a machine-evaluable predicate. When an AI coding agent attempts an Edit or Write, Mneme looks up which decisions apply by scope match, resolves any precedence conflicts deterministically, and either lets the edit through or blocks it with the specific decision that fired.</p>
+
+    <p>The retrieval is exact. Same file, same edit, same verdict &mdash; every time, every agent, every session. There is no embedding drift because there is no embedding. There is no top-k miss because there is no ranking step. The decision either applies (by scope) or it doesn&rsquo;t.</p>
+
+    <p>This is not a richer RAG. It is a different memory primitive: structured lookup against a typed corpus, designed for the property RAG cannot offer &mdash; deterministic recall of decisions that must hold every time.</p>
+
+    <h2>Using RAG and Mneme together</h2>
+
+    <p>The right architecture treats RAG and Mneme as complementary memory layers rather than competing approaches. Each handles the memory problem it is suited to.</p>
+
+    <ol>
+      <li><strong>Index narrative context with RAG.</strong> Design docs, prior implementations, related code, engineering discussions. These are the things the agent should be able to find when relevant &mdash; and they tolerate approximate recall.</li>
+      <li><strong>Encode decisions in Mneme.</strong> Architectural decisions, scope rules, supersessions, language and dependency policies. These need to apply every time, regardless of whether the current task description happens to mention them.</li>
+      <li><strong>Use RAG output to improve generation quality.</strong> Surface examples, document excerpts, prior art into the model&rsquo;s context window at task time.</li>
+      <li><strong>Use Mneme to enforce decision recall at edit time.</strong> Hook into Edit and Write operations. When the model produces an edit that violates an architectural decision, Mneme blocks it before it reaches the codebase.</li>
+      <li><strong>Track overrides as first-class decision records.</strong> When a team intentionally diverges from a decision, the override is itself recorded with rationale and scope. RAG can surface the override discussion; Mneme governs the new boundary.</li>
+    </ol>
+
+    <p>In this architecture, RAG is the memory of <em>what we have written</em>. Mneme is the memory of <em>what we have decided</em>. A coding agent that uses both has stronger context and harder compliance guarantees than either provides alone &mdash; and the failure modes of RAG-as-decision-memory disappear, because RAG is no longer being asked to do the work it was never built for.</p>
+
+    <section class="faq-list" aria-labelledby="faq-heading">
+      <h2 id="faq-heading" style="font-family:'Inter',sans-serif;font-size:1.25rem;font-weight:600;letter-spacing:-0.015em;margin-bottom:1.25rem;">Frequently asked questions</h2>
+      <details class="faq-item">
+        <summary>Is RAG a good memory layer for AI coding agents?</summary>
+        <div class="faq-body">RAG works well as contextual memory: surfacing relevant code snippets, documentation, prior commits, and historical examples to improve generation quality. It is weaker as decision memory: when an architectural decision must apply every time a certain file or pattern is touched, top-k retrieval can miss the rule, rank it below noisier neighbors, or surface a superseded version. Contextual memory is approximate by nature; decision memory has to be exact.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Why does RAG miss architectural decisions for coding agents?</summary>
+        <div class="faq-body">Three structural reasons. First, embedding similarity is keyword-shaped: a decision phrased differently from the current task is not retrieved. Second, scope is not native to vector search: a decision that applies only to one directory may surface for unrelated files. Third, precedence is invisible to retrieval: when two decisions overlap, the model picks based on context order, not authority. Each of these is solvable in indexing, but the cumulative reliability is still probabilistic.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Can I plug my existing ADR RAG into Mneme HQ?</summary>
+        <div class="faq-body">Yes. Mneme imports ADRs and architectural decision records into a typed decision corpus with scope rules and precedence semantics. Your existing ADR collection remains the human-readable source. Mneme adds the machine-evaluable layer on top: each decision becomes a constraint with explicit scope, supersession history, and an enforcement contract. You keep RAG for narrative retrieval; Mneme handles the per-edit recall.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Should we use both RAG and Mneme for coding memory?</summary>
+        <div class="faq-body">Yes, at different layers. RAG is the right tool for contextual recall: documentation, design discussions, prior implementations. Mneme is the right tool for decision recall: which architectural decisions apply to this file, in what order, with what scope. Most teams settle on a layered architecture where RAG informs generation and Mneme enforces decisions. The two operate on different memory problems.</div>
+      </details>
+    </section>
+
+  <aside class="related-panel" aria-labelledby="related-panel-label">
+    <div class="related-panel-label" id="related-panel-label">Related governance concepts</div>
+    <ul class="related-list">
+      <li><a href="/concepts/decision-continuity/"><div class="rel-title">Decision continuity</div><p class="rel-desc">Architectural decisions that hold across sessions, agents, and refactors &mdash; the property RAG retrieval cannot guarantee.</p></a></li>
+      <li><a href="/concepts/multi-agent-continuity/"><div class="rel-title">Multi-agent continuity</div><p class="rel-desc">Why coding memory has to be model-independent: different agents retrieve and apply context differently.</p></a></li>
+      <li><a href="/concepts/precedence-semantics/"><div class="rel-title">Precedence semantics</div><p class="rel-desc">Ordered rules that resolve overlapping decisions deterministically &mdash; supersession, scope, recency.</p></a></li>
+      <li><a href="/concepts/deterministic-enforcement/"><div class="rel-title">Deterministic enforcement</div><p class="rel-desc">Same input, same verdict &mdash; every run, every agent, every consumer. The precondition for auditability.</p></a></li>
+    </ul>
+  </aside>
+
+  </div>
+
+  <footer class="article-footer">
+    <a href="/compare/" class="back-link">&larr; Back to Compare</a>
+    <div class="cta-block">
+      <h3>Decision memory that recalls every time</h3>
+      <p>Mneme HQ hooks into your AI coding agent&rsquo;s Edit and Write operations, looks up architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/insights/why-prompt-memory-fails-at-scale/" class="cta-secondary">Read: Why prompt memory fails at scale &rarr;</a>
+    </div>
+  </footer>
+</article>
+</main>
+
+<footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">
+  <div style="max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 2.5rem 2rem;">
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Product</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/use-cases/">Use cases</a></li>
+        <li><a href="/works-with/">Works with</a></li>
+        <li><a href="/platforms/">Platforms</a></li>
+        <li><a href="/integrations/">Integrations</a></li>
+        <li><a href="/compare/">Compare</a></li>
+        <li><a href="/demo/">Demo</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Learn</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/concepts/">Concepts</a></li>
+        <li><a href="/architecture/">Architecture</a></li>
+        <li><a href="/insights/">Insights</a></li>
+        <li><a href="/standards/">Standards</a></li>
+        <li><a href="/benchmark/">Benchmark</a></li>
+        <li><a href="/docs/">Docs</a></li>
+        <li><a href="/docs/cli/">CLI reference</a></li>
+        <li><a href="/docs/governance-violations/">Governance violations</a></li>
+        <li><a href="/supported-languages/">Supported languages</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Company</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="/pilot/" style="color:var(--accent);">Request pilot</a></li>
+        <li><a href="/for/">For teams</a></li>
+        <li><a href="/founder/">Founder</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/roadmap/">Roadmap</a></li>
+        <li><a href="/contact/">Contact</a></li>
+      </ul>
+    </div>
+    <div>
+      <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Code</div>
+      <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
+        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
+        <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
+      </ul>
+    </div>
+  </div>
+  <div style="max-width: 1080px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
+    <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
+    <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
+      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+      </a>
+      <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 .06.77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"/></svg>
+      </a>
+      <a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener" aria-label="YouTube" style="color: var(--muted); display: inline-flex;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.12C19.55 3.5 12 3.5 12 3.5s-7.55 0-9.4.58A3 3 0 0 0 .5 6.2 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.12c1.85.58 9.4.58 9.4.58s7.55 0 9.4-.58a3 3 0 0 0 2.1-2.12A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.8zM9.6 15.57V8.43L15.82 12 9.6 15.57z"/></svg>
+      </a>
+      <a href="https://dev.to/mnemehq" target="_blank" rel="noopener" aria-label="DEV.to" style="color: var(--muted); display: inline-flex;">
+        <svg width="16" height="16" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true"><path d="M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35 3.88-2.9 5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.36 47.28l.02 70.93zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19l-.01 29.52zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58l-38.46 144.8z"/></svg>
+      </a>
+    </nav>
+    <span>&copy; 2026</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<script>
+(function(){
+  var btn = document.querySelector('.nav-hamburger');
+  var links = document.querySelector('.nav-links');
+  if (!btn || !links) return;
+  function setOpen(open){
+    links.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', String(open));
+    document.body.classList.toggle('menu-open', open);
+  }
+  btn.addEventListener('click', function(e){ e.stopPropagation(); setOpen(!links.classList.contains('open')); });
+  document.addEventListener('click', function(e){ if (!links.classList.contains('open')) return; if (links.contains(e.target) || btn.contains(e.target)) return; setOpen(false); });
+  document.addEventListener('keydown', function(e){ if (e.key === 'Escape' && links.classList.contains('open')) setOpen(false); });
+  links.addEventListener('click', function(e){ if (e.target.tagName === 'A') setOpen(false); });
+  window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
+})();
+</script>
+</body>
+</html>

--- a/site/og-compare-rag-coding-memory.html
+++ b/site/og-compare-rag-coding-memory.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 1200px;
+    height: 630px;
+    background: #0c0c0d;
+    font-family: 'DM Mono', monospace;
+    overflow: hidden;
+    position: relative;
+  }
+  .grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(200,240,96,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(200,240,96,0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    pointer-events: none;
+  }
+  .glow {
+    position: absolute;
+    top: -120px;
+    left: -120px;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle at top left, rgba(200,240,96,0.08), transparent 70%);
+    pointer-events: none;
+  }
+  .container {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 44px 52px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  .top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .logo {
+    font-family: 'Instrument Serif', serif;
+    font-size: 26px;
+    color: #e8e8ec;
+    letter-spacing: -0.3px;
+  }
+  .tag {
+    font-family: 'DM Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    color: #c8f060;
+    background: rgba(200,240,96,0.08);
+    border: 1px solid rgba(200,240,96,0.25);
+    border-radius: 100px;
+    padding: 5px 14px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .middle {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 880px;
+    padding-top: 8px;
+  }
+  .heading {
+    font-family: 'Instrument Serif', serif;
+    font-size: 60px;
+    line-height: 1.08;
+    color: #e8e8ec;
+    letter-spacing: -1px;
+    margin-bottom: 20px;
+  }
+  .heading em {
+    font-style: italic;
+    color: #c8f060;
+  }
+  .subtitle {
+    font-family: 'DM Mono', monospace;
+    font-size: 15px;
+    line-height: 1.65;
+    color: #88889a;
+    font-weight: 300;
+    max-width: 720px;
+  }
+  .bottom {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
+  .url {
+    font-family: 'DM Mono', monospace;
+    font-size: 12px;
+    color: #55555f;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+  <div class="grid"></div>
+  <div class="glow"></div>
+  <div class="container">
+    <div class="top">
+      <span class="logo">Mneme HQ</span>
+      <span class="tag">Compare</span>
+    </div>
+    <div class="middle">
+      <div class="heading">RAG Coding Memory <em>vs</em> Mneme</div>
+      <div class="subtitle">RAG is useful for contextual memory.<br>It is weak as decision memory.</div>
+    </div>
+    <div class="bottom">
+      <div class="url">mnemehq.com/compare/rag-coding-memory</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -5,6 +5,9 @@ Allow: /
 User-agent: GPTBot
 Allow: /
 
+User-agent: ChatGPT-User
+Allow: /
+
 User-agent: ClaudeBot
 Allow: /
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -291,6 +291,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://mnemehq.com/compare/rag-coding-memory/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://mnemehq.com/integrations/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>


### PR DESCRIPTION
## Summary

**New comparison page** at `/compare/rag-coding-memory/` framed as *contextual memory (RAG) vs decision memory (Mneme HQ)*. Targets BOFU traffic searching for "RAG for coding memory", "AI coding agent memory", "long-term memory for AI engineering".

**SEO/GEO pass on `/compare/`** based on a structured audit covering ChatGPT/Perplexity/Google AI Overviews citation patterns. Comparison content is the #1 most-cited format in AI search (~33% of ChatGPT citations); the hub now ships every extractable surface that drives citations.

### What changed on the hub

| Change | Why |
|---|---|
| Keyword-led `<title>` ("Compare Mneme HQ to AI Coding Governance Alternatives") | Adds high-intent keyword surface |
| Category-led meta/og/twitter descriptions | No longer goes stale when new comparisons ship |
| CollectionPage gains `dateModified` / `inLanguage` / `author` | Freshness + E-E-A-T signals |
| New `ItemList` JSON-LD (positions 1-5) | Schema.org-preferred type for ordered comparison sets |
| New `FAQPage` JSON-LD (5 Q&A) + visible FAQ | Highly extractable Q&A format for AI citations |
| Visible byline + "Last updated May 2026" near hero | Freshness + author attribution |
| New "At a glance" comparison table | Single most-citable block format per Princeton GEO study |
| "How to read these comparisons" → "How each comparison is structured" | Better query-pattern match |
| `ChatGPT-User` added to `robots.txt` | Allows live-retrieval citations (GPTBot is training-only) |

### Files

- `site/compare/rag-coding-memory/index.html` (new)
- `site/og-compare-rag-coding-memory.html` (new OG template)
- `site/compare/index.html` (hub: card + table + FAQ + JSON-LD)
- `site/sitemap.xml` (new entry)
- `site/robots.txt` (ChatGPT-User allowlist)
- `scripts/generate_og_images.py` (TEMPLATE_MAP entry)

## Test plan

- [ ] Run `python scripts/generate_og_images.py` to produce `/compare/rag-coding-memory/og.png`
- [ ] Visual diff `/compare/` to confirm summary table + FAQ render correctly
- [ ] Validate JSON-LD: paste hub source into [Schema Markup Validator](https://validator.schema.org/) - expect BreadcrumbList + CollectionPage + ItemList + FAQPage all valid
- [ ] Click through all 5 cards from `/compare/` to confirm no broken links
- [ ] Verify the rag-coding-memory page itself: internal links (decision-continuity, multi-agent-continuity, precedence-semantics, deterministic-enforcement, why-prompt-memory-fails-at-scale, founder) all resolve
- [ ] Confirm mobile rendering of the new summary table (overflow-x scroll on narrow screens)

## Out of scope

- Tier 1 missing compare pages (Copilot, Aider, Continue.dev, Windsurf, Sourcegraph Cody) - queued as separate work
- `scripts/check_compare.py` validator (analogous to `check_insights.py`) to enforce hub/sitemap/OG sync going forward - queued as separate cleanup
- Consolidating inline `style=""` attributes on the lower hub sections - cosmetic, deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)