### PR TITLE
fix: repair syntax error in deploy_site.py blocking all deploys

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -336,7 +336,6 @@ def submit_indexnow(urls):
     except urllib.error.HTTPError as e:
         print(f'[WARN] IndexNow -- HTTP {e.code}: {e.read().decode()[:200]}')
 
-print('
--- IndexNow submission --')
+print('\n-- IndexNow submission --')
 submit_indexnow(purge_urls if not full_deploy else sitemap_urls)
 


### PR DESCRIPTION
## Summary

`scripts/deploy_site.py` has had a SyntaxError at line 339 since commit `c403028` (`feat: submit IndexNow URLs on deploy`). A `print('...')` call was written with the opening `'` and closing `')` on different physical lines:

```python
print('
-- IndexNow submission --')
```

Python rejects this as `SyntaxError: unterminated string literal`. The deploy script never runs, so the deploy workflow has been failing on every push since c403028 — including the deploys for #148, #149, and #151 from this morning. None of the recently merged site changes have actually shipped to mnemehq.com.

## Fix

Collapse to a single line with an escaped newline:

```python
print('\n-- IndexNow submission --')
```

## Test plan

- [x] `python -m py_compile scripts/deploy_site.py` exits 0 (verified locally)
- [ ] CI green on this PR
- [ ] Once merged, the next push to main re-triggers the deploy workflow and mnemehq.com receives the queued changes (rag-coding-memory page, hub SEO pass, sitemap dedup, jetbrains fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)