### PR TITLE
site: add 16 orphaned indexable pages to sitemap

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -643,4 +643,21 @@
   <url><loc>https://mnemehq.com/works-with/antigravity/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://mnemehq.com/compare/devin-vs-architectural-governance/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://mnemehq.com/compare/google-antigravity-vs-mneme/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <!-- Previously orphaned indexable pages (added to sitemap) -->
+  <url><loc>https://mnemehq.com/concepts/ai-agent-drift/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/concepts/enforcement-provenance/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/concepts/governance-propagation/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/concepts/multi-agent-continuity/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/concepts/precedence-semantics/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/concepts/reliable-delegation/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/docs/benchmark-methodology/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/docs/how-enforcement-works/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/for/cto/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/for/platform/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/for/principal-engineer/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://mnemehq.com/demo/governed-python-agent/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://mnemehq.com/roadmap/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://mnemehq.com/contact/</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://mnemehq.com/founder/</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://mnemehq.com/privacy/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
 </urlset>


### PR DESCRIPTION
## What

A repo + GSC audit found **16 pages that are `index, follow` and self-canonical but missing from `sitemap.xml`**, suppressing their discovery. The recent content batch grew the sitemap to 155 URLs but left these pre-existing orphans untouched.

### Added (priority matched to existing siblings)
- **6 `/concepts/` content pages**: `ai-agent-drift`, `enforcement-provenance`, `governance-propagation`, `multi-agent-continuity`, `precedence-semantics`, `reliable-delegation` @ 0.8
- **2 `/docs/`**: `benchmark-methodology`, `how-enforcement-works` @ 0.8
- **3 `/for/` persona pages**: `cto`, `platform`, `principal-engineer` @ 0.8
- `/demo/governed-python-agent/` and `/roadmap/` @ 0.7
- `/contact/`, `/founder/` @ 0.6; `/privacy/` @ 0.3 (yearly)

## Why it matters
These are indexable content pages — several commercial (`/for/*`) — invisible to the sitemap. `/contact/` alone was pulling **83 impressions** while orphaned (GSC, 5–28 May). All 16 canonicalize to themselves, so they legitimately belong in the sitemap.

## Verification
- Sitemap now **171 URLs**, valid XML, **zero indexable orphans** (re-audited).
- No duplicate `<loc>` entries introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)