### PR TITLE
site: add P0 security response headers to .htaccess

### DIFF
--- a/site/.htaccess
+++ b/site/.htaccess
@@ -55,6 +55,13 @@ ErrorDocument 404 /404.html
     Header unset Vary
     Header set Vary "Accept-Encoding"
 
+    # Security headers (P0 hardening). Low-risk, instantly reversible.
+    # Intentionally excludes HSTS and CSP for now (separate, higher-care rollouts).
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+
     # HTML
     <FilesMatch "\.(html|htm)$">
         Header set Cache-Control "public, max-age=3600"


### PR DESCRIPTION
## What

Adds four passive security response headers to `site/.htaccess`, inside the existing `<IfModule mod_headers.c>` block:

```apache
Header always set X-Frame-Options "SAMEORIGIN"
Header always set X-Content-Type-Options "nosniff"
Header always set Referrer-Policy "strict-origin-when-cross-origin"
Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
```

This is the **low-risk P0 subset** of a larger security-headers finding. **HSTS and CSP are deliberately excluded** — HSTS is hard to reverse once browser-cached, and a strict CSP can block GA4/inline SVG/fonts. Both warrant separate, higher-care rollouts.

## Scope discipline

- Only `site/.htaccess` changed (+7 lines, 0 deletions).
- No changes to redirects, caching, compression, the deploy workflow, or any HTML.
- Existing structure/formatting preserved; new headers sit between the `Vary` block and the cache `FilesMatch` blocks, still inside the `mod_headers` guard.

## Validation

- **Diff:** +7 lines, single file.
- **Guard placement (programmatic):** all four headers confirmed inside the `mod_headers.c` block (lines 60–63; guard spans 51–79).
- **Apache grammar:** every line matches `Header always set NAME "VALUE"`; `<IfModule>`/`<FilesMatch>` tags balanced 7/7; quotes balanced.
- **`scripts/check_encoding.py`:** OK (380 files scanned).
- **`scripts/seo_check.py`:** runs clean (169 pages, exit 0); checker does not inspect `.htaccess` and no HTML changed, so no regression.
- No Apache binary on the build host, so origin `configtest` was not run; structural + grammar validation used instead. Worth a quick post-deploy header check against the live site.

## Expected production impact

- Merging to `main` triggers `deploy-site.yml` (`paths: site/**`) → cPanel API upload + Cloudflare purge → headers go **live on mnemehq.com** within minutes. This is a real production change.
- All four headers are passive response headers. The only one that can affect legitimate behavior is `X-Frame-Options: SAMEORIGIN`, which blocks third-party sites from embedding mnemehq.com pages in an iframe. No known/intended external embeds exist for the marketing site — **please confirm** before merge if any partner/demo embed relies on framing.
- The other three only harden MIME/referrer/permissions behavior and have no expected user-facing effect.
- No HSTS → nothing is cached browser-side, so there is **no irreversibility risk**.

## Rollback path

- Fully and immediately reversible. Revert this PR (or `git revert <sha>` on `main`); the next deploy removes the headers, and because there's no HSTS nothing persists in browsers — removal is complete on the next request.
- Emergency hotfix alternative: delete the four lines in `site/.htaccess` and redeploy.
- Worst case to watch for: a malformed `.htaccess` returns site-wide HTTP 500. Mitigated here by structural + grammar validation; if it ever happens, revert is the fast fix.

## Post-merge check (suggested)

After deploy, confirm headers on both apex and `www`:

```bash
curl -sI https://mnemehq.com/ | grep -iE 'x-frame|x-content-type|referrer-policy|permissions-policy'
curl -sI https://www.mnemehq.com/ | grep -iE 'x-frame|x-content-type|referrer-policy|permissions-policy'
```

---

**Do not merge yet** — opened for review.
