### PR TITLE
site: recategorize two concept pages on the concepts hub

### DIFF
--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -502,9 +502,20 @@
       <span class="card-arrow">→</span>
     </a>
 
-    <a href="/concepts/governance-before-generation/" class="concept-card" role="listitem">
+    <a href="/concepts/multi-agent-architectural-drift/" class="concept-card" role="listitem">
       <div class="card-top">
         <span class="card-num">05</span>
+        <div>
+          <div class="card-title">Multi-Agent Architectural Drift</div>
+        </div>
+      </div>
+      <p class="card-desc">What happens when multiple autonomous agents each make locally reasonable changes that compound into system-wide architectural deviation.</p>
+      <span class="card-arrow">→</span>
+    </a>
+
+    <a href="/concepts/governance-before-generation/" class="concept-card" role="listitem">
+      <div class="card-top">
+        <span class="card-num">06</span>
         <div>
           <div class="card-title">Governance Before Generation</div>
         </div>
@@ -515,7 +526,7 @@
 
     <a href="/concepts/architectural-compiler/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">06</span>
+        <span class="card-num">07</span>
         <div>
           <div class="card-title">Architectural Compiler</div>
         </div>
@@ -526,7 +537,7 @@
 
     <a href="/concepts/executable-architectural-intent/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">07</span>
+        <span class="card-num">08</span>
         <div>
           <div class="card-title">Executable Architectural Intent</div>
         </div>
@@ -537,7 +548,7 @@
 
     <a href="/concepts/verification-contracts/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">08</span>
+        <span class="card-num">09</span>
         <div>
           <div class="card-title">Verification Contracts</div>
         </div>
@@ -554,7 +565,7 @@
 
     <a href="/concepts/governance-propagation/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">09</span>
+        <span class="card-num">10</span>
         <div>
           <div class="card-title">Governance Propagation</div>
         </div>
@@ -565,7 +576,7 @@
 
     <a href="/concepts/deterministic-enforcement/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">10</span>
+        <span class="card-num">11</span>
         <div>
           <div class="card-title">Deterministic Enforcement</div>
         </div>
@@ -576,7 +587,7 @@
 
     <a href="/concepts/precedence-semantics/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">11</span>
+        <span class="card-num">12</span>
         <div>
           <div class="card-title">Precedence Semantics</div>
         </div>
@@ -587,7 +598,7 @@
 
     <a href="/concepts/multi-agent-continuity/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">12</span>
+        <span class="card-num">13</span>
         <div>
           <div class="card-title">Multi-Agent Continuity</div>
         </div>
@@ -598,7 +609,7 @@
 
     <a href="/concepts/decision-continuity/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">13</span>
+        <span class="card-num">14</span>
         <div>
           <div class="card-title">Decision Continuity</div>
         </div>
@@ -609,7 +620,7 @@
 
     <a href="/concepts/enforcement-provenance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">14</span>
+        <span class="card-num">15</span>
         <div>
           <div class="card-title">Enforcement Provenance</div>
         </div>
@@ -620,7 +631,7 @@
 
     <a href="/concepts/governance-provenance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">15</span>
+        <span class="card-num">16</span>
         <div>
           <div class="card-title">Governance Provenance</div>
         </div>
@@ -629,9 +640,20 @@
       <span class="card-arrow">→</span>
     </a>
 
+    <a href="/concepts/artifact-provenance/" class="concept-card" role="listitem">
+      <div class="card-top">
+        <span class="card-num">17</span>
+        <div>
+          <div class="card-title">Artifact Provenance</div>
+        </div>
+      </div>
+      <p class="card-desc">The record of plans, diffs, screenshots, browser recordings, and verification evidence produced by autonomous agents. Provenance explains; governance constrains.</p>
+      <span class="card-arrow">→</span>
+    </a>
+
     <a href="/concepts/model-independent-governance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">16</span>
+        <span class="card-num">18</span>
         <div>
           <div class="card-title">Model-Independent Governance</div>
         </div>
@@ -642,7 +664,7 @@
 
     <a href="/concepts/agent-verification/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">17</span>
+        <span class="card-num">19</span>
         <div>
           <div class="card-title">Agent Verification</div>
         </div>
@@ -653,7 +675,7 @@
 
     <a href="/concepts/execution-surfaces/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">18</span>
+        <span class="card-num">20</span>
         <div>
           <div class="card-title">Execution Surfaces</div>
         </div>
@@ -670,7 +692,7 @@
 
     <a href="/concepts/ai-native-sdlc/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">19</span>
+        <span class="card-num">21</span>
         <div>
           <div class="card-title">AI-Native SDLC</div>
         </div>
@@ -681,7 +703,7 @@
 
     <a href="/concepts/agentic-development/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">20</span>
+        <span class="card-num">22</span>
         <div>
           <div class="card-title">Agentic Development</div>
         </div>
@@ -692,7 +714,7 @@
 
     <a href="/concepts/objective-driven-development/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">21</span>
+        <span class="card-num">23</span>
         <div>
           <div class="card-title">Objective-Driven Development</div>
         </div>
@@ -703,7 +725,7 @@
 
     <a href="/concepts/ai-operating-layer/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">22</span>
+        <span class="card-num">24</span>
         <div>
           <div class="card-title">AI Operating Layer</div>
         </div>
@@ -714,7 +736,7 @@
 
     <a href="/concepts/reliable-delegation/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">23</span>
+        <span class="card-num">25</span>
         <div>
           <div class="card-title">Reliable Delegation</div>
         </div>
@@ -725,7 +747,7 @@
 
     <a href="/concepts/intent-debt/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">24</span>
+        <span class="card-num">26</span>
         <div>
           <div class="card-title">Intent Debt</div>
         </div>
@@ -736,7 +758,7 @@
 
     <a href="/concepts/spec-driven-development/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">25</span>
+        <span class="card-num">27</span>
         <div>
           <div class="card-title">Spec-Driven Development</div>
         </div>
@@ -753,7 +775,7 @@
 
     <a href="/concepts/ai-governance-infrastructure/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">26</span>
+        <span class="card-num">28</span>
         <div>
           <div class="card-title">AI Governance Infrastructure</div>
         </div>
@@ -764,7 +786,7 @@
 
     <a href="/concepts/autonomous-software-engineering-governance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">27</span>
+        <span class="card-num">29</span>
         <div>
           <div class="card-title">Autonomous Software Engineering Governance</div>
         </div>
@@ -775,7 +797,7 @@
 
     <a href="/concepts/runtime-governance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">28</span>
+        <span class="card-num">30</span>
         <div>
           <div class="card-title">Runtime Governance</div>
         </div>
@@ -786,7 +808,7 @@
 
     <a href="/concepts/agentic-ide-governance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">29</span>
+        <span class="card-num">31</span>
         <div>
           <div class="card-title">Agentic IDE Governance</div>
         </div>
@@ -797,34 +819,12 @@
 
     <a href="/concepts/antigravity-governance/" class="concept-card" role="listitem">
       <div class="card-top">
-        <span class="card-num">30</span>
+        <span class="card-num">32</span>
         <div>
           <div class="card-title">Antigravity Governance</div>
         </div>
       </div>
       <p class="card-desc">The practice of applying architectural constraints, decision provenance, and verification checks to agent-first workflows running across editor, terminal, and browser.</p>
-      <span class="card-arrow">→</span>
-    </a>
-
-    <a href="/concepts/multi-agent-architectural-drift/" class="concept-card" role="listitem">
-      <div class="card-top">
-        <span class="card-num">31</span>
-        <div>
-          <div class="card-title">Multi-Agent Architectural Drift</div>
-        </div>
-      </div>
-      <p class="card-desc">What happens when multiple autonomous agents each make locally reasonable changes that compound into system-wide architectural deviation.</p>
-      <span class="card-arrow">→</span>
-    </a>
-
-    <a href="/concepts/artifact-provenance/" class="concept-card" role="listitem">
-      <div class="card-top">
-        <span class="card-num">32</span>
-        <div>
-          <div class="card-title">Artifact Provenance</div>
-        </div>
-      </div>
-      <p class="card-desc">The record of plans, diffs, screenshots, browser recordings, and verification evidence produced by autonomous agents. Provenance explains; governance constrains.</p>
       <span class="card-arrow">→</span>
     </a>
 


### PR DESCRIPTION
## Summary

Editorial recategorization of two concept pages on `/concepts/` so each sits in the section that matches its semantic type. Follow-up to #171 (kept separate to keep that PR's review surface clean).

## Moves

| Page | From → To | Why |
|---|---|---|
| `multi-agent-architectural-drift` | Applied governance surfaces → **Core concepts** | It's a drift *problem definition*, a sibling of `ai-agent-drift` and `architectural-drift`. The three now sit contiguously as the drift trio. |
| `artifact-provenance` | Applied governance surfaces → **System properties** | It's a provenance/evidence *property*, now beside `enforcement-provenance` and `governance-provenance`. |

**Result:** *Applied governance surfaces* becomes a clean set of the five named enforcement surfaces (`ai-governance-infrastructure`, `autonomous-software-engineering-governance`, `runtime-governance`, `agentic-ide-governance`, `antigravity-governance`). Section sizes: Core 8→9, System properties 10→11, Applied surfaces 7→5. Cards renumbered 01–32 in document order.

## Invariants

- **JSON-LD unchanged:** cards only move *within* the page, so the concept set is identical — the hub ↔ page ↔ `hasPart` invariants hold.
- `check_concepts.py`: passes (warnings only — pre-existing SVG omissions, unchanged by this PR).
- `check_nav_footer.py` (the guard from #171): **OK**, the global nav/footer on this page is untouched.

## Scope

One file (`site/concepts/index.html`), 48/48 lines — the two card blocks plus renumbering. No content, copy, or URL changes; pages keep their slugs, so no redirects needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
