### PR TITLE
fix(docs): add how-enforcement-works card to docs index

### DIFF
--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -195,7 +195,7 @@
     <h2>Related concepts</h2>
     <ul>
       <li><a href="/concepts/architectural-drift/">Architectural Drift</a> &mdash; the general phenomenon this concept specializes for the multi-agent case</li>
-      <li><a href="/concepts/coordination-governance-multi-agent-systems/">Coordination governance</a> &mdash; the discipline for parallel agent systems</li>
+      <li><a href="/insights/coordination-governance-multi-agent-systems/">Coordination governance</a> &mdash; the discipline for parallel agent systems</li>
       <li><a href="/concepts/governance-propagation/">Governance Propagation</a> &mdash; the mechanism that makes the same rules reach every agent</li>
       <li><a href="/concepts/multi-agent-continuity/">Multi-Agent Continuity</a> &mdash; how architectural intent survives across agent handoffs</li>
       <li><a href="/concepts/agentic-ide-governance/">Agentic IDE Governance</a> &mdash; the IDE-surface expression of this discipline</li>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -45,6 +45,7 @@
         "url": "https://mnemehq.com/docs/",
         "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/", "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/logo-v2.png"}},
         "hasPart": [
+          {"@type": "WebPage", "name": "How enforcement works", "url": "https://mnemehq.com/docs/how-enforcement-works/"},
           {"@type": "WebPage", "name": "CLI reference", "url": "https://mnemehq.com/docs/cli/"},
           {"@type": "WebPage", "name": "Governance violations", "url": "https://mnemehq.com/docs/governance-violations/"},
           {"@type": "WebPage", "name": "Supported languages", "url": "https://mnemehq.com/docs/supported-languages/"},
@@ -157,6 +158,11 @@
   <p style="font-size:0.92rem;color:var(--muted);line-height:1.75;max-width:780px;margin:0 0 2rem;">Mneme HQ's documentation is intentionally narrow. We document the surfaces that engineers actually need to operate the governance layer: the CLI you run, the violations Mneme catches, the languages Mneme governs today, and the methodology behind the benchmark. Everything else lives in the source repository.</p>
 
   <div class="doc-grid">
+    <a class="doc-card" href="/docs/how-enforcement-works/">
+      <div class="dh"><span class="dname">How enforcement works</span><span class="dtag">Explainer</span></div>
+      <p>How Mneme turns human-authored architectural decisions into deterministic enforcement rules checked before AI generation. ADR authoring, structured governance, explainable verdicts.</p>
+      <span class="read">How enforcement works &rarr;</span>
+    </a>
     <a class="doc-card" href="/docs/cli/">
       <div class="dh"><span class="dname">CLI reference</span><span class="dtag">Reference</span></div>
       <p>Commands, flags, and exit codes for <code>mneme</code>: <code>list_decisions</code>, <code>add_decision</code>, <code>test_query</code>, <code>check</code>, <code>cursor generate</code>, and <code>benchmark</code>. GitHub Actions and pre-commit CI patterns.</p>


### PR DESCRIPTION
## Summary

`/docs/how-enforcement-works/` was in the sitemap but had zero inbound links anywhere on the site. Adds a grid card to the docs index and updates the JSON-LD `hasPart` list to include it.

The broken `coordination-governance-multi-agent-systems` link is handled in a separate PR.

## Test plan

- [ ] "How enforcement works" card appears in the `/docs/` grid
- [ ] Next link audit shows no `how-enforcement-works` orphan
