### PR TITLE
fix(schema): resolve GSC VideoObject errors -- truncated names + undersized thumbnails

### DIFF
--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -275,7 +275,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "Managing Architectural Drift in AI-Assisted Development | Architectural Governance for AI Coding ...",
+  "name": "Managing Architectural Drift in AI-Assisted Development | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=architectural_drift\n\nDrift is what happens when implementation slowly stops matching intent. AI coding agents do not in",
   "thumbnailUrl": "https://i.ytimg.com/vi/hP8jMyVA6D4/maxresdefault.jpg",
   "uploadDate": "2026-05-12T10:38:36Z",

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -224,7 +224,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "Precedence Semantics: When Org Rules and Team Exceptions Coexist | Architectural Governance for A...",
+  "name": "Precedence Semantics: When Org Rules and Team Exceptions Coexist | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=precedence_semantics\n\nReal architectural governance is not flat. Org-level rules exist. Team-level exceptions exist. Se",
   "thumbnailUrl": "https://i.ytimg.com/vi/tktp6ik0Gxk/maxresdefault.jpg",
   "uploadDate": "2026-05-27T22:38:13Z",

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -56,7 +56,7 @@
         "@type": "VideoObject",
         "name": "ADRs Don't Govern AI Agents. Compilers Do.",
         "description": "Full ADR compiler walkthrough. ADRs with Constraints sections are compiled into executable, precedence-aware decisions and enforced end-to-end against Mneme's own architectural records.",
-        "thumbnailUrl": "https://i.ytimg.com/vi/lMkq-RoKeD4/hqdefault.jpg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/lMkq-RoKeD4/maxresdefault.jpg",
         "uploadDate": "2026-05-15",
         "contentUrl": "https://www.youtube.com/watch?v=lMkq-RoKeD4",
         "embedUrl": "https://www.youtube-nocookie.com/embed/lMkq-RoKeD4",

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -63,7 +63,7 @@
         "@type": "VideoObject",
         "name": "Project Memory Is Not Just Context. It Is Enforcement.",
         "description": "Project memory as enforcement policy. The approved dependency list lives in project_memory.json as a structured, version-controlled rule, and Mneme returns a WARN verdict when an AI agent introduces an unapproved package during a refactor.",
-        "thumbnailUrl": "https://i.ytimg.com/vi/pBJSpN8d9FU/hqdefault.jpg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/pBJSpN8d9FU/maxresdefault.jpg",
         "uploadDate": "2026-05-09",
         "contentUrl": "https://www.youtube.com/watch?v=pBJSpN8d9FU",
         "embedUrl": "https://www.youtube-nocookie.com/embed/pBJSpN8d9FU",

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -83,7 +83,7 @@
         "@type": "VideoObject",
         "name": "Mneme HQ — Governed Python Agent Demo",
         "description": "Hero walkthrough of the Mneme HQ governed Python agent demo. A Python agent proposes a violating import, Mneme blocks it at the pre-generation stage, and the agent retries with a compliant implementation. End-to-end product loop across three flagship demos.",
-        "thumbnailUrl": "https://i.ytimg.com/vi/4Yg43V9amao/hqdefault.jpg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4Yg43V9amao/maxresdefault.jpg",
         "uploadDate": "2026-05-15",
         "contentUrl": "https://www.youtube.com/watch?v=4Yg43V9amao",
         "embedUrl": "https://www.youtube-nocookie.com/embed/4Yg43V9amao",

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -56,7 +56,7 @@
         "@type": "VideoObject",
         "name": "From ADR to CI: Enforcing Architecture in GitHub Actions",
         "description": "Walkthrough of governance continuity across multiple actors. Three agents act on the same codebase against a shared invariant set, and architectural decisions hold from ADR through CI enforcement.",
-        "thumbnailUrl": "https://i.ytimg.com/vi/LaJqeJrKkgg/hqdefault.jpg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/LaJqeJrKkgg/maxresdefault.jpg",
         "uploadDate": "2026-05-13",
         "contentUrl": "https://www.youtube.com/watch?v=LaJqeJrKkgg",
         "embedUrl": "https://www.youtube-nocookie.com/embed/LaJqeJrKkgg",

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -255,7 +255,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "AI-Native Engineering Has an Intent Debt Problem | Architectural Governance for AI Coding Teams \u2014...",
+  "name": "AI-Native Engineering Has an Intent Debt Problem | Architectural Governance for AI Coding Teams \u2014 Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=intent_debt\n\nTechnical debt is code you regret. Intent debt is architecture you forgot you decided. AI coding agents ge",
   "thumbnailUrl": "https://i.ytimg.com/vi/nwSBZXolBhA/maxresdefault.jpg",
   "uploadDate": "2026-05-20T12:57:15Z",

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -301,7 +301,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "One Codebase, Five AI Coding Tools: Who Enforces the Architecture? | Architectural Governance for...",
+  "name": "One Codebase, Five AI Coding Tools: Who Enforces the Architecture? | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=one_codebase_five_tools\n\nCursor, Claude Code, Copilot, Windsurf, internal agents \u2014 most teams now ship code from four o",
   "thumbnailUrl": "https://i.ytimg.com/vi/xtTDcb2JB2c/maxresdefault.jpg",
   "uploadDate": "2026-05-20T13:10:27Z",

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -216,7 +216,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "Autonomous Code Remediation Needs Architectural Governance | Architectural Governance for AI Codi...",
+  "name": "Autonomous Code Remediation Needs Architectural Governance | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=autonomous_remediation_governance\n\nAutonomous code remediation agents \u2014 Devin, OpenHands, internal auto-fixers \u2014 genera",
   "thumbnailUrl": "https://i.ytimg.com/vi/DDo0x1lkBNI/maxresdefault.jpg",
   "uploadDate": "2026-05-27T22:56:25Z",

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -182,7 +182,7 @@
         "@type": "VideoObject",
         "name": "The SPACE Framework: Measuring GitHub Copilot's Real Productivity Impact",
         "description": "Companion video walking through what the SPACE framework reveals when applied to GitHub Copilot adoption data. Accepted suggestions measure activity, not outcomes, and the dimensions that improve fastest with AI coding tools are the ones traditional governance handles least well.",
-        "thumbnailUrl": "https://i.ytimg.com/vi/Rjlzm0psfB4/hqdefault.jpg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/Rjlzm0psfB4/maxresdefault.jpg",
         "uploadDate": "2026-05-12",
         "contentUrl": "https://www.youtube.com/watch?v=Rjlzm0psfB4",
         "embedUrl": "https://www.youtube-nocookie.com/embed/Rjlzm0psfB4",

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -286,7 +286,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "Beyond Prompts: The Architecture of AI Governance | Architectural Governance for AI Coding Teams ...",
+  "name": "Beyond Prompts: The Architecture of AI Governance | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=beyond_prompts\n\nPrompts shape what the model says. Architecture decides what the model is allowed to build. The interes",
   "thumbnailUrl": "https://i.ytimg.com/vi/kIswxPe7bGc/maxresdefault.jpg",
   "uploadDate": "2026-05-12T10:50:39Z",

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -323,7 +323,7 @@
 {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  "name": "Why CLAUDE.md Stops Scaling for AI Coding Governance | Architectural Governance for AI Coding Tea...",
+  "name": "Why CLAUDE.md Stops Scaling for AI Coding Governance | Architectural Governance for AI Coding Teams — Mneme HQ",
   "description": "Mneme HQ \u2014 architectural governance for AI-assisted development.\nhttps://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=claude_md_stops_scaling\n\nCLAUDE.md and .cursorrules are useful as guidance. They stop scaling the moment you treat them",
   "thumbnailUrl": "https://i.ytimg.com/vi/5QxAbdLg0nw/maxresdefault.jpg",
   "uploadDate": "2026-05-20T12:49:09Z",


### PR DESCRIPTION
## Summary

Fixes two classes of GSC VideoObject structured data errors flagged across 20 pages:

**Truncated `name` fields (7 pages)**
YouTube enforces a 100-character title limit, so long titles were stored with a trailing `...` in the VideoObject `name` field. Google flags these as invalid. Reconstructed the full intended title (`... | Architectural Governance for AI Coding Teams — Mneme HQ`) on all affected pages.

Pages fixed: `architectural-drift`, `precedence-semantics`, `ai-native-engineering-intent-debt`, `architectural-governance-across-heterogeneous-ai-coding-agents`, `autonomous-code-remediation-requires-architectural-governance`, `prompt-engineering-is-not-governance`, `why-claude-md-stops-scaling`

**`hqdefault` thumbnails (5 pages)**
GSC Video rich results require thumbnails at least 696px wide. `hqdefault.jpg` is 480×360 — too small. Upgraded all instances to `maxresdefault.jpg` (1280×720).

Pages fixed: `demo/index`, `demo/adr-compiler`, `demo/dependency-policy`, `demo/multi-agent-governance`, `insights/github-copilot-space-framework`

## Test plan

- [ ] Validate affected pages in Google Rich Results Test — no VideoObject errors
- [ ] Confirm all `thumbnailUrl` values resolve to 1280×720 images
- [ ] GSC Video enhancements report should clear over next crawl cycle
