### PR TITLE
site: consolidate AI code governance onto concept page + internal links

### DIFF
--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -6,7 +6,7 @@
   <title>AI Governance Infrastructure &mdash; Mneme HQ Concepts</title>
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="AI governance infrastructure is the deterministic enforcement layer that preserves architectural intent across AI-assisted software development. It is the inevitable next category in the AI engineering stack — the same shape every previous infrastructure wave produced once it became autonomous enough to need it." />
+  <meta name="description" content="AI governance infrastructure, also called AI code governance: the deterministic enforcement layer that preserves architectural intent across AI-assisted development." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/concepts/ai-governance-infrastructure/" />
@@ -36,8 +36,8 @@
       {"@type": "ListItem", "position": 2, "name": "Concepts", "item": "https://mnemehq.com/concepts/"},
       {"@type": "ListItem", "position": 3, "name": "AI Governance Infrastructure", "item": "https://mnemehq.com/concepts/ai-governance-infrastructure/"}
     ]},
-    {"@type": "DefinedTerm", "name": "AI Governance Infrastructure", "description": "The deterministic enforcement layer that preserves architectural intent across AI-assisted software development. The category that emerges once AI coding agents reach the velocity and autonomy at which human review can no longer carry the governance load alone.", "url": "https://mnemehq.com/concepts/ai-governance-infrastructure/", "inDefinedTermSet": "https://mnemehq.com/concepts/"},
-    {"@type": "TechArticle", "headline": "AI Governance Infrastructure", "url": "https://mnemehq.com/concepts/ai-governance-infrastructure/", "datePublished": "2026-05-28", "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"}, "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/"}}
+    {"@type": "DefinedTerm", "name": "AI Governance Infrastructure", "alternateName": ["AI code governance", "AI coding governance"], "description": "The deterministic enforcement layer that preserves architectural intent across AI-assisted software development. The category that emerges once AI coding agents reach the velocity and autonomy at which human review can no longer carry the governance load alone.", "url": "https://mnemehq.com/concepts/ai-governance-infrastructure/", "inDefinedTermSet": "https://mnemehq.com/concepts/"},
+    {"@type": "TechArticle", "headline": "AI Governance Infrastructure", "url": "https://mnemehq.com/concepts/ai-governance-infrastructure/", "datePublished": "2026-05-28", "dateModified": "2026-06-03", "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"}, "publisher": {"@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/"}}
   ]}
   </script>
 
@@ -157,8 +157,11 @@
 
     <div class="definition-card">
       <div class="def-label">Definition</div>
-      <p><strong>AI governance infrastructure</strong> is the deterministic enforcement layer that preserves architectural intent across AI-assisted software development. It compiles architectural decisions into machine-evaluable constraints, applies them at every execution surface an AI agent touches, and produces structured verdicts that travel with the codebase regardless of which agent or tool produced the change.</p>
+      <p><strong>AI governance infrastructure</strong> is the deterministic enforcement layer that preserves architectural intent across AI-assisted software development. It compiles architectural decisions into machine-evaluable constraints, applies them at every execution surface an AI agent touches, and produces structured verdicts that travel with the codebase regardless of which agent or tool produced the change. Teams also call this <strong>AI code governance</strong>: the layer that decides whether AI-generated code is allowed to ship, given everything the codebase has already decided.</p>
     </div>
+
+    <h2>AI code governance, named for the surface</h2>
+    <p><strong>AI code governance</strong> is the same layer described here, named for where it bites &mdash; the code an AI agent generates. The question it answers is binary: is this change allowed, given everything the codebase has already decided? That is an enforcement question, not a retrieval one, which is why AI code governance lives in deterministic constraints rather than prompts, memory, or after-the-fact review.</p>
 
     <h2>Why the category emerges</h2>
     <p>Every previous infrastructure wave produced a governance layer once the underlying capability became autonomous enough to outpace manual oversight. Cloud computing produced security and compliance infrastructure. CI/CD produced observability. Data platforms produced lineage and data governance. The pattern is consistent: when the capability layer scales past human-paced review, a specialized governance layer arrives to carry the load.</p>

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -436,6 +436,7 @@
     <li><a href="/insights/autonomous-code-remediation-requires-architectural-governance/">Autonomous Code Remediation Requires Architectural Governance</a></li>
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
     <li><a href="/insights/deployment-quality-will-define-the-ai-era/">Deployment Quality Will Define the AI Era</a></li>
+    <li><a href="/concepts/ai-governance-infrastructure/">AI code governance</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -357,7 +357,7 @@
       </tbody>
     </table>
     </div>
-    <p>The governance and verification layers used to sit downstream of model and runtime, applied at the PR or the deploy. In a persistent-agent world, they have to sit <em>inside</em> the loop &mdash; reachable from every tool call, every orchestration step, every remediation tick.</p>
+    <p>The governance and verification layers used to sit downstream of model and runtime, applied at the PR or the deploy &mdash; the classic posture of <a href="/concepts/ai-governance-infrastructure/">AI code governance</a>. In a persistent-agent world, they have to sit <em>inside</em> the loop &mdash; reachable from every tool call, every orchestration step, every remediation tick.</p>
 
     <h2>Execution environments need verification layers</h2>
     <p>Persistent agents introduce continuity, memory, authority, and compounding execution. Those properties are the source of the capability gains. They are also the source of the new failure mode.</p>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -302,7 +302,7 @@
 
     <p>With most current AI tooling, you cannot answer that question. The constraints the agent was aware of exist somewhere in accumulated prompt history, a cloud memory service, or per-session context that was never persisted. The governance state is opaque. The incident is unreproducible. The audit trail is empty.</p>
 
-    <p>This is not an edge case. It is the default condition for AI coding governance today.</p>
+    <p>This is not an edge case. It is the default condition for <a href="/concepts/ai-governance-infrastructure/">AI code governance</a> today.</p>
 
     <h2>The assumption most teams haven't questioned</h2>
 

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -383,7 +383,7 @@
       <li>Both require distinguishing real issues from already-addressed issues.</li>
       <li>Both become risky when AI outputs are treated as conclusions rather than claims requiring verification.</li>
     </ul>
-    <p>In software teams, this shows up when AI agents review or generate code without preserving the architectural decisions that should constrain the work.</p>
+    <p>In software teams, this shows up when AI agents review or generate code without preserving the architectural decisions that should constrain the work &mdash; the gap that <a href="/concepts/ai-governance-infrastructure/">AI code governance</a> is built to close.</p>
     <p>The same failure mode appears in AI-assisted development. A coding agent can identify a real architectural concern, but apply it to the wrong part of the system. It can flag a missing guardrail that already exists. It can recommend a pattern that violates an ADR because the relevant decision was outside its active context. The model may be capable. The workflow is not governed.</p>
     <div class="callout"><p><strong>High-confidence output without grounded context is not a model problem.</strong> It is an infrastructure problem.</p></div>
 

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -346,7 +346,7 @@
       <div class="layer-row accent"><div class="layer-num">05</div><div class="layer-name">Governance</div><div class="layer-job">Architectural invariants, deterministic constraints, verification contracts, provenance &mdash; the layer the marketplace does not yet name</div></div>
       <div class="layer-row"><div class="layer-num">06</div><div class="layer-name">Verification &amp; review</div><div class="layer-job">CodeRabbit, post-generation checks, observability</div></div>
     </div>
-    <p>The Claude Marketplace announcement names layers 1, 2, 3, 4, and 6. Layer 5 is what sits between them &mdash; the place that says &ldquo;these are the architectural rules; every generation, every tool call, every CI run has to clear them.&rdquo; That layer is not yet productized at the marketplace level. It is the next category.</p>
+    <p>The Claude Marketplace announcement names layers 1, 2, 3, 4, and 6. Layer 5 is what sits between them &mdash; the place that says &ldquo;these are the architectural rules; every generation, every tool call, every CI run has to clear them.&rdquo; That layer is not yet productized at the marketplace level. It is the next category: <a href="/concepts/ai-governance-infrastructure/">AI code governance</a>.</p>
 
     <h2>Conclusion: the industrialization of AI-assisted development</h2>
     <p>The important trend is not better coding models. It is the <strong>industrialization of AI-assisted software development into specialized operational infrastructure</strong>. The first wave was a pair programmer. The second is an engineering organization&rsquo;s worth of infrastructure, decomposed into layers, each with its own vendor category and operational discipline.</p>

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -398,7 +398,7 @@
 
 <p>The report&rsquo;s &ldquo;shift to automation&rdquo; theme is where the governance gap becomes concrete. More AI changes are being accepted automatically: agent-generated changes reaching commits without a separate manual diff acceptance step grew more than 5x in 2026, from 7% on Jan 1 to 36.3% on May 16. Cursor also notes that adoption of its Automations is growing quickly, with security review emerging as a strong use case, and that SDK runs show early demand for turning agent infrastructure into a programmable platform customized to how each company builds software.</p>
 
-<p>Every one of those is a new automated surface. And every automated surface is a place where architectural intent can be honored or quietly broken with no human in the loop. Automation does not remove the need for governance; it multiplies the number of points at which governance has to apply.</p>
+<p>Every one of those is a new automated surface. And every automated surface is a place where architectural intent can be honored or quietly broken with no human in the loop. Automation does not remove the need for <a href="/concepts/ai-governance-infrastructure/">AI code governance</a>; it multiplies the number of points at which governance has to apply.</p>
 
 <p>The implication is that governance can no longer be a single checkpoint. It has to propagate across the lifecycle:</p>
 

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -420,6 +420,7 @@
       <li><a href="/concepts/architectural-governance/"><div class="rel-title">Architectural Governance</div><p class="rel-desc">Architecture made executable: constraints, checks, and release gates that travel with the repo.</p></a></li>
       <li><a href="/concepts/governance-before-generation/"><div class="rel-title">Governance Before Generation</div><p class="rel-desc">Push architectural intent ahead of the model, not after the PR. Block the deviation, do not catch it.</p></a></li>
       <li><a href="/concepts/verification-contracts/"><div class="rel-title">Verification Contracts</div><p class="rel-desc">Predefined checks that prove architectural intent survived the agent run.</p></a></li>
+      <li><a href="/concepts/ai-governance-infrastructure/"><div class="rel-title">AI code governance</div><p class="rel-desc">The infrastructure layer that encodes and enforces architectural decisions across AI coding agents.</p></a></li>
     </ul>
   </aside>
 

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -442,7 +442,7 @@
 
   <div class="cards-wrap">
     <h2 style="font-family:'Inter',sans-serif;font-size:1.1rem;font-weight:600;letter-spacing:-0.01em;text-align:center;margin-bottom:1rem;">Reference architectures</h2>
-    <p class="hub-intro">Mneme HQ enforces architectural, security, design, and workflow decisions wherever AI generates code or structured output. These reference architectures show how teams apply pre-generation governance across different LLM-powered workflows.</p>
+    <p class="hub-intro">Mneme HQ enforces architectural, security, design, and workflow decisions wherever AI generates code or structured output. These reference architectures show how teams apply <a href="/concepts/ai-governance-infrastructure/">AI code governance</a> across different LLM-powered workflows.</p>
     <div class="cards-grid">
 
       <a href="/use-cases/coding-assistant-governance/" class="case-card-link">


### PR DESCRIPTION
## What

Consolidate the **"AI code governance"** head term onto a single canonical page and wire internal links to it.

## Why

GSC (last 28d) shows **47 impressions** for `ai code governance` but no page owns it — the impressions are split across `/use-cases/` (pos ~94) and `/insights/ai-coding-governance-should-be-reviewable/` (pos ~96). Meanwhile `/concepts/ai-governance-infrastructure/` already ranks **page 2 (pos ~12)** for the sibling term "ai governance infrastructure" — making it the natural definitional home. Per review feedback, this strengthens an existing page rather than spawning a new one that would self-compete.

## Changes

**Concept page (`/concepts/ai-governance-infrastructure/`):**
- Synonym added to the definition card ("Teams also call this AI code governance…")
- New H2: "AI code governance, named for the surface"
- `DefinedTerm.alternateName: ["AI code governance", "AI coding governance"]`
- Meta description tightened to ~158 chars, leading with both terms
- Added `dateModified: 2026-06-03`

**Internal links (one contextual link each, anchor "AI code governance" → concept page):**
- `/use-cases/` and the reviewable insight (the two pages catching the impressions)
- The six insights syndicated to dev.to in this sprint

## Validation

`check_encoding`, `check_concepts`, `check_insights`, `check_nav_footer` all pass. SEO check shows only pre-existing site-wide WARNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)