### PR TITLE
ci: derive IndexNow key from committed key file (stop silent skips)

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -347,7 +347,18 @@ print(f"\n[OK] All {len(sitemap_urls)} sitemap URLs verified - deploy complete")
 def submit_indexnow(urls):
     key = os.environ.get('INDEXNOW_KEY', '')
     if not key:
-        print('[SKIP] IndexNow -- INDEXNOW_KEY not set')
+        # Fall back to the committed, publicly-served key file (site/<32 hex>.txt).
+        # The IndexNow key is public by design (served at keyLocation), so deriving it
+        # from the repo avoids depending on a CI secret that was never set -- which
+        # silently skipped IndexNow on every deploy.
+        import re, glob
+        for path in sorted(glob.glob(os.path.join(BASE_LOCAL, '*.txt'))):
+            stem = os.path.splitext(os.path.basename(path))[0]
+            if re.fullmatch(r'[0-9a-f]{32}', stem):
+                key = stem
+                break
+    if not key:
+        print('[SKIP] IndexNow -- no key (INDEXNOW_KEY unset and no key file found)')
         return
     payload = json.dumps({
         'host': 'mnemehq.com',


### PR DESCRIPTION
## Fix: IndexNow has been silently skipping on every deploy

### Diagnosis
`scripts/deploy_site.py` notifies IndexNow on deploy via `submit_indexnow()`, which reads the key from `INDEXNOW_KEY`. But:

- The deploy workflow (`deploy-site.yml`) `env:` block only passes `CPANEL_API_TOKEN` / `CF_API_TOKEN` / `CF_ZONE_ID` — **not** `INDEXNOW_KEY`.
- There is **no `INDEXNOW_KEY` repo secret** (confirmed via `gh secret list`).

So `os.environ.get('INDEXNOW_KEY')` is always empty and the function takes its `[SKIP]` branch. No page has ever been submitted to IndexNow. The submission code, the key file (`mnemehq.com/43985a40383f4417added3ddee8c8821.txt`, verified live `HTTP 200`), and the sitemap are all otherwise correct.

### Fix
The IndexNow key is **public by design** — it's literally served at the `keyLocation` URL. So when `INDEXNOW_KEY` is unset, derive it from the committed key file `site/<32 hex>.txt`. A repo secret / env var still takes precedence if one is ever added.

- No secret required; works on the next deploy.
- Cannot silently skip again (it logs a clear `[SKIP]` only if *neither* the env var nor a key file is found).

### Verified
- `python -m py_compile scripts/deploy_site.py` → OK
- Key discovery returns exactly `['43985a40383f4417added3ddee8c8821']`, correctly ignoring `robots.txt` / `llms.txt`.

After this merges, the next deploy (including the wave-3 insights from #186) will actually ping IndexNow with the changed URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
