### PR TITLE
site: accessible inline links + reciprocal mesh across insights, enforced in check_insights

### DIFF
--- a/mneme-project-memory/integrations/claude-code/skills/publish-insight/SKILL.md
+++ b/mneme-project-memory/integrations/claude-code/skills/publish-insight/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: publish-insight
+description: |
+  Author and publish a Mneme HQ insight article end to end. Use when asked to
+  "write an insight", "publish an article", "scope an article", turn a ChatGPT
+  "Post-*" scope thread into a page, or react to a report / launch / paper with
+  a governance-angle article. Encodes the SEO patterns, the publishing contract,
+  internal-link mesh, funnel, and accessibility so a new insight is born compliant.
+---
+
+# publish-insight — author + register a Mneme insight, correctly, first time
+
+The canonical contract is `docs/site/insight-publishing-contract.md` and
+`scripts/check_insights.py` (the gate). This skill is the *generation* procedure;
+the validator is the *enforcement*. Follow both.
+
+## 1. Scope + SEO intent
+
+- Lead the `<title>`, `<h1>`, and meta with a **recognizable entity** (report
+  name + year, vendor, paper, launch, OSS project), then pivot to the governance
+  interpretation. Avoid abstract category-only titles (good for LinkedIn, weak
+  for SEO).
+- **Report response?** Lead title/H1/meta with `[Report Name] [Year]`, add an
+  early `What [Report] Shows` H2, plant the report's own vocabulary in the body
+  and FAQ, and nest the source as `isBasedOn` → `Report` in the TechArticle
+  JSON-LD. Otherwise use the entity-anchor pattern.
+- Read the source(s) in full and use **verified** facts/stats only; do not
+  attribute anecdotes to unverifiable named people — generalize them.
+- One authoritative **outbound reference** (`target="_blank" rel="noopener"`),
+  cited once.
+
+## 2. Overlap check (do this before writing)
+
+Grep `site/insights/*/index.html` for the theme. If a close article exists
+(especially same source/report), either pick a genuinely differentiated angle
+or **update the existing page** instead of shipping a near-duplicate. Shipping a
+near-duplicate is a failure.
+
+## 3. Write — clone the scaffold
+
+Copy a recent exemplar (`site/insights/ai-coding-agent-verification-tax/`
+standard, or `bcg-ai-era-operating-models-governance/` for report-response).
+Keep the `<style>`, global `<nav>`, site `<footer>`, and trailing `<script>`
+blocks **byte-identical** (nav-footer-check + sticky-nav-check are strict).
+Efficient method for a batch: write one golden file, `Copy-Item` to the other
+slug dirs, then Edit only the per-article regions (title, meta, JSON-LD,
+breadcrumb label, `<article>` body). A 5-line Read of a copy satisfies Edit's
+read-precondition for whole-file edits.
+
+Body structure: eyebrow + `<h1>` + `.article-lede` + byline; `<h2>` sections;
+`.callout`; `.gov-table`; an `<ol>` Record/Retrieve/Check/Reject/Return loop
+where it fits; 4-item FAQ (`<details>`); two `.related-panel` asides (concepts +
+essays); `.article-footer` with `.cta-block`.
+
+## 4. The three quality rules check_insights now enforces
+
+- **Accessible links (HARD):** include `.article-body a { color: #8be0c8;
+  text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4);
+  transition: border-color 0.15s; } .article-body a:hover { border-bottom-color:
+  #8be0c8; }`. Teal (not the lime `--accent`/CTA colour), underlined (WCAG 1.4.1
+  — never colour alone), ~12.6:1 on `#0c0c0d`.
+- **Mesh (WARN, aim ≥3 inbound):** cross-link 3–4 existing insights + 3–4
+  concepts in the body/related panels, AND add a reciprocal `related-essays`
+  `<li>` *into* each neighbour article pointing back, matching that file's own
+  related-list format. A page reachable only from the hub is under-meshed.
+- **Funnel (WARN):** include at least one contextual bottom-funnel link
+  (`/demo/`, `/pilot/`, or `/use-cases/...`) in the body/CTA, beyond the GitHub
+  CTA and global nav — especially on buyer-intent (report/cost) pieces.
+
+## 5. Register (every item; check_insights gates them)
+
+1. `site/sitemap.xml` — add `<url><loc>https://mnemehq.com/insights/<slug>/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>`.
+2. `site/insights/index.html` — add the `<a class="insight-card-link">` card in the right `cards-grid` **and** a matching `{"@type":"Article",...}` entry in the CollectionPage `hasPart` (both checked independently).
+3. OG image — add a tuple to `TEMPLATES` + `NEW_MAP_ENTRIES` in `scripts/ensure_og_coverage.py`, run it, then render **only the new slug(s)** (a temp Playwright loop or a narrowed `TEMPLATE_MAP`) — never the full `generate_og_images.py`. Confirm `site/insights/<slug>/og.png` exists.
+4. Head: canonical, `og:image` + `twitter:image` → the article-local `og.png`; `<nav class="breadcrumb-nav">` (3 items); BreadcrumbList JSON-LD (positions 1/2/3, exact item URLs); TechArticle JSON-LD (url == canonical, non-empty headline; `isBasedOn` Report for report responses).
+
+## 6. Validate, then PR
+
+Run `python scripts/check_insights.py` (must exit 0; read its WARN lines and
+close the mesh/funnel gaps), plus `check_nav_footer.py`, `check_sticky_nav.py`,
+`check_encoding.py` (save UTF-8, no BOM, preserve CRLF). Branch `site/...`,
+squash-merge with a taxonomy-compliant title. Merge order matters if a deploy
+tooling fix is in flight (see the deploy notes); the live deploy submits changed
+URLs to IndexNow on success.
+
+## Anti-slop
+
+Match the house voice: concrete, declarative, short sentences, specific worked
+examples (the BillingService ADR). No "in today's fast-paced world", no
+furthermore-chains, no em-dash-as-connective-tissue overuse. Two-quotes-max from
+any copyrighted source; paraphrase practitioner quotes.

--- a/scripts/check_insights.py
+++ b/scripts/check_insights.py
@@ -365,7 +365,58 @@ def check_slug(
             f"in site/insights/index.html"
         )
 
+    # 9. inline body links must be styled (accessibility): an unstyled <a> in the
+    #    article body falls back to the browser-default blue (~2:1 contrast on the
+    #    #0c0c0d background — a WCAG fail). Require a `.article-body a` color rule.
+    if not re.search(r"\.article-body a\s*\{[^}]*color\s*:", html):
+        errors.append(
+            f"Inline body links not styled in {slug}: add a "
+            f"`.article-body a {{ color: #8be0c8; ... }}` rule. Unstyled links render "
+            f"the inaccessible browser-default blue on the dark background."
+        )
+
     return errors
+
+
+FUNNEL_RE = re.compile(r'href="/(?:pilot|demo|use-cases)/')
+
+
+def inbound_counts(slugs: list[str]) -> dict[str, int]:
+    """One pass over site/**.html: count distinct pages linking to each
+    /insights/<slug>/ (excluding the article's own index.html). Mesh warning."""
+    slug_set = set(slugs)
+    refs: dict[str, set[str]] = {s: set() for s in slugs}
+    for path in SITE_DIR.rglob("*.html"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        is_article_index = path.name == "index.html" and path.parent.name in slug_set
+        for s in set(re.findall(r'/insights/([^/"]+)/', text)):
+            if s in slug_set and not (is_article_index and path.parent.name == s):
+                refs[s].add(str(path))
+    return {s: len(v) for s, v in refs.items()}
+
+
+def article_region(html: str) -> str:
+    m = re.search(r"<article\b.*?</article>", html, re.DOTALL)
+    return m.group(0) if m else ""
+
+
+def slug_warnings(slug: str, html: str, inbound: int) -> list[str]:
+    """Non-blocking quality warnings: mesh depth and in-body funnel link."""
+    warns: list[str] = []
+    if inbound < 3:
+        warns.append(
+            f"under-meshed: only {inbound} inbound internal link(s) "
+            f"(aim for >= 3 reciprocal related-essays links)"
+        )
+    if not FUNNEL_RE.search(article_region(html)):
+        warns.append(
+            "no in-body funnel link (/pilot, /demo, or /use-cases) beyond the "
+            "global nav and GitHub CTA"
+        )
+    return warns
 
 
 def main() -> int:
@@ -388,6 +439,30 @@ def main() -> int:
             all_errors[slug] = errs
 
     total_errors = sum(len(v) for v in all_errors.values())
+
+    # Non-blocking quality warnings: mesh depth + in-body funnel link.
+    inbound = inbound_counts(slugs)
+    warnings: dict[str, list[str]] = {}
+    for slug in slugs:
+        try:
+            html = (INSIGHTS_DIR / slug / "index.html").read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        w = slug_warnings(slug, html, inbound.get(slug, 0))
+        if w:
+            warnings[slug] = w
+
+    if warnings:
+        nwarn = sum(len(v) for v in warnings.values())
+        print(
+            f"WARN  {len(warnings)}/{len(slugs)} insight articles have quality "
+            f"warnings ({nwarn}); non-blocking (mesh / funnel guidance)."
+        )
+        for slug in sorted(warnings):
+            print(f"  {slug}/")
+            for msg in warnings[slug]:
+                print(f"    - {msg}")
+        print()
 
     if total_errors:
         print(

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; }
-    .article-body a:hover { color: var(--accent-dim); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
@@ -436,6 +436,7 @@
     <li><a href="/insights/autonomous-code-remediation-requires-architectural-governance/">Autonomous Code Remediation Requires Architectural Governance</a></li>
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
     <li><a href="/insights/deployment-quality-will-define-the-ai-era/">Deployment Quality Will Define the AI Era</a></li>
+    <li><a href="/insights/ai-coding-productivity-gains-rework/">Why AI Coding Productivity Gains Lead to More Rework</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -64,12 +64,12 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -64,12 +64,12 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -132,12 +132,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -63,6 +63,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -64,9 +64,9 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--teal); text-decoration: underline; text-underline-offset: 3px; }
-    .article-body a:hover { color: var(--text); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -389,6 +391,7 @@
       <li><a href="/insights/mckinsey-ai-table-stakes-to-advantage/"><div class="rel-title">From AI Table Stakes to AI Advantage</div><p class="rel-desc">McKinsey&rsquo;s argument that deployment is table stakes and the operating model is the edge.</p></a></li>
       <li><a href="/insights/rule-files-vs-retrieval-memory/"><div class="rel-title">Rule Files vs Retrieval Memory</div><p class="rel-desc">Why static rule files plateau and retrieval-backed memory scales with agents.</p></a></li>
       <li><a href="/insights/dora-metrics-insufficient-for-agentic-development/"><div class="rel-title">DORA Metrics Are Necessary But Insufficient</div><p class="rel-desc">Delivery metrics see speed; they do not see governance.</p></a></li>
+      <li><a href="/insights/bcg-ai-era-operating-models-governance/"><div class="rel-title">BCG&rsquo;s AI-Era Operating Models Create a Governance Problem</div><p class="rel-desc">Flatter, more autonomous org models remove the layers that were doing governance work.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -120,6 +120,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
@@ -505,6 +507,7 @@
     <li><a href="/insights/artifacts-are-not-governance/">Artifacts Are Not Governance</a></li>
     <li><a href="/insights/zero-trust-for-ai-agents-architectural-governance/">Zero Trust for AI Agents</a></li>
     <li><a href="/insights/agentic-convergence-trap-architectural-governance/">The Agentic Convergence Trap Is an Architecture Problem Too</a></li>
+    <li><a href="/insights/bcg-ai-era-operating-models-governance/">BCG&rsquo;s AI-Era Operating Models Create a Governance Problem</a></li>
     <li><a href="/concepts/enforcement-provenance/">Enforcement Provenance</a></li>
   </ul>
 

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -445,6 +447,7 @@
         <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/">Why Code Review Cannot Scale With AI Output</a></li>
         <li><a href="/insights/review-is-not-governance/">Review Is Not Governance</a></li>
         <li><a href="/insights/deployment-quality-will-define-the-ai-era/">Deployment Quality Will Define the AI Era</a></li>
+        <li><a href="/insights/github-copilot-usage-based-billing-review-economics/">GitHub Turned AI Code Review Into a Budget Line Item</a></li>
     </ul>
 
   <footer class="article-footer">

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -381,6 +383,8 @@
       <li><a href="/insights/pr-review-is-becoming-incident-response/"><div class="rel-title">PR Review Is Becoming an Incident Response Layer</div><p class="rel-desc">The merge queue as the place governance failures get detected, not prevented.</p></a></li>
       <li><a href="/insights/rule-files-vs-retrieval-memory/"><div class="rel-title">Rule Files vs Retrieval Memory</div><p class="rel-desc">Token budget, precedence, and scope &mdash; the three ceilings of static instructions.</p></a></li>
       <li><a href="/insights/github-agent-pull-requests-review-wrong-layer/"><div class="rel-title">Agent Pull Requests Are Everywhere: GitHub&rsquo;s Review Fix Targets the Wrong Layer</div><p class="rel-desc">GitHub&rsquo;s data shows reviewers trust agent PRs more while debt rises.</p></a></li>
+      <li><a href="/insights/ai-coding-productivity-gains-rework/"><div class="rel-title">Why AI Coding Productivity Gains Lead to More Rework</div><p class="rel-desc">Faros 2026 telemetry: throughput rises, but so do bugs, churn, and rework.</p></a></li>
+      <li><a href="/insights/github-copilot-usage-based-billing-review-economics/"><div class="rel-title">GitHub Turned AI Code Review Into a Budget Line Item</div><p class="rel-desc">Usage-based billing makes ungoverned AI output a finance problem.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -385,7 +385,7 @@
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">
       <h3>Turn AI throughput back into progress.</h3>
-      <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; catching the violations that drive rework and churn before they merge. Open source.</p>
+      <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; catching the violations that drive rework and churn before they merge. Open source, or <a href="/demo/">see it enforce a decision in the live demo</a>.</p>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); transition: border-color 0.15s; }
-    .article-body a:hover { border-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -62,6 +62,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body a.ext { color: var(--accent); text-decoration: none; border-bottom: 1px dotted rgba(200,240,96,0.4); }
     .article-body a.ext:hover { color: var(--accent-dim); border-bottom-color: rgba(200,240,96,0.7); }

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -136,12 +136,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -401,6 +403,7 @@
       <li><a href="/insights/deployment-quality-will-define-the-ai-era/"><div class="rel-title">Deployment Quality Will Define the AI Era</div><p class="rel-desc">The bottleneck is not generation speed; it is what survives integration.</p></a></li>
       <li><a href="/insights/dora-metrics-insufficient-for-agentic-development/"><div class="rel-title">DORA Metrics Are Necessary But Insufficient For Agentic Development</div><p class="rel-desc">Delivery metrics can stay green while the architecture degrades; governance is the missing measurement layer.</p></a></li>
       <li><a href="/insights/mckinsey-ai-table-stakes-to-advantage/"><div class="rel-title">From AI Table Stakes to AI Advantage</div><p class="rel-desc">McKinsey&rsquo;s answer to the same ROI question: the return is in the moat above the model, not the model itself.</p></a></li>
+      <li><a href="/insights/github-copilot-usage-based-billing-review-economics/"><div class="rel-title">GitHub Turned AI Code Review Into a Budget Line Item</div><p class="rel-desc">Usage-based billing makes ungoverned AI output a finance problem.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -130,12 +130,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
@@ -414,6 +414,7 @@
       <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">Deterministic verdicts require deterministic ordering &mdash; the missing primitive in most stacks.</p></a></li>
       <li><a href="/insights/runtime-verification-is-not-architectural-verification/"><div class="rel-title">Runtime Verification Is Not Architectural Verification</div><p class="rel-desc">Schema-correct and architecturally wrong is a real failure mode.</p></a></li>
       <li><a href="/insights/agent-runtime-governance/"><div class="rel-title">Agent Runtime Governance: The Next AI Infrastructure Layer</div><p class="rel-desc">Where the deterministic boundary sits when agents become long-running.</p></a></li>
+      <li><a href="/insights/loop-engineering-is-not-new/"><div class="rel-title">Loop Engineering Is Not New</div><p class="rel-desc">Loops have been computing&rsquo;s core abstraction for seventy years; what is new is governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -130,12 +130,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -72,12 +72,12 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -64,12 +64,12 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -377,6 +379,7 @@
       <li><a href="/insights/dora-metrics-insufficient-for-agentic-development/"><div class="rel-title">DORA Metrics Are Necessary But Insufficient for Agentic Development</div><p class="rel-desc">Delivery metrics built for human-written code miss the governance layer.</p></a></li>
       <li><a href="/insights/agent-governance-in-the-sdlc/"><div class="rel-title">Agent Governance in the SDLC</div><p class="rel-desc">Where enforcement has to sit inside each stage of the lifecycle.</p></a></li>
       <li><a href="/insights/mckinsey-agentic-software-delivery-governance/"><div class="rel-title">McKinsey on Agentic Software Delivery</div><p class="rel-desc">A second major consultancy maps agentic delivery and lands on the same governance gap.</p></a></li>
+      <li><a href="/insights/ai-adoption-maturity-model-engineering-analysis/"><div class="rel-title">AI Adoption Maturity Model: A Technical Analysis</div><p class="rel-desc">CMU SEI and Accenture&rsquo;s five-level model, and the governance execution gap it leaves open.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -66,12 +66,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .article-body p code { font-family: 'DM Mono', monospace; font-size: 0.85em; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.4rem; color: var(--accent); }
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -392,6 +394,7 @@
       <li><a href="/insights/ai-roi-problem-is-about-systems-not-models/"><div class="rel-title">The AI ROI Problem Is About Systems, Not Models</div><p class="rel-desc">Why measurable AI value depends on the system around the model.</p></a></li>
       <li><a href="/insights/ibm-2026-tech-leader-study-agent-governance/"><div class="rel-title">IBM 2026 Tech Leader Study: 77% Say AI Adoption Is Outpacing Governance</div><p class="rel-desc">IBM&rsquo;s survey numbers on the widening adoption-governance gap.</p></a></li>
       <li><a href="/insights/ai-agents-are-not-employees-governance/"><div class="rel-title">Why You Shouldn&rsquo;t Treat AI Agents Like Employees</div><p class="rel-desc">Agents need engineered constraints; management techniques don&rsquo;t transfer.</p></a></li>
+      <li><a href="/insights/ai-adoption-maturity-model-engineering-analysis/"><div class="rel-title">AI Adoption Maturity Model: A Technical Analysis</div><p class="rel-desc">CMU SEI and Accenture&rsquo;s five-level model, and the governance execution gap it leaves open.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -134,12 +134,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
     .article-body .tight { margin-bottom: 0.5rem; }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
@@ -481,6 +481,7 @@
       <li><a href="/insights/pr-review-is-becoming-incident-response/"><div class="rel-title">PR Review Is Becoming Incident Response</div><p class="rel-desc">As agent output grows, the review queue turns into a constraint-recovery system.</p></a></li>
       <li><a href="/insights/ai-code-review-does-not-scale-linearly/"><div class="rel-title">AI Code Review Does Not Scale Linearly</div><p class="rel-desc">Generation throughput rises faster than review throughput. The math forces governance earlier.</p></a></li>
       <li><a href="/insights/datadog-state-of-ai-engineering-governance-crisis/"><div class="rel-title">Datadog State of AI Engineering: The Governance Crisis</div><p class="rel-desc">Industry data shows the same pattern: more agent code, fewer enforced architectural invariants.</p></a></li>
+      <li><a href="/insights/ai-coding-productivity-gains-rework/"><div class="rel-title">Why AI Coding Productivity Gains Lead to More Rework</div><p class="rel-desc">Faros 2026 telemetry: throughput rises, but so do bugs, churn, and rework.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -131,12 +131,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
@@ -401,6 +401,7 @@
       <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">When the agents in the swarm come from different vendors, the constraints must still be the same.</p></a></li>
       <li><a href="/insights/anthropic-research-system-coordination-infrastructure/"><div class="rel-title">Anthropic&rsquo;s Research System and the Coordination Infrastructure Problem</div><p class="rel-desc">Multi-agent research workflows surface the same shared-state problem.</p></a></li>
       <li><a href="/insights/goal-driven-agents-architectural-governance/"><div class="rel-title">Goal-Driven Agents Need Architectural Governance</div><p class="rel-desc">Autonomy without invariants is how parallel teams produce incompatible systems &mdash; faster.</p></a></li>
+      <li><a href="/insights/shared-memory-is-not-shared-intent/"><div class="rel-title">Shared Memory Is Not Shared Intent</div><p class="rel-desc">Shared memory distributes context across AI coding teams; it does not enforce intent.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -128,6 +128,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -125,12 +125,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -124,6 +124,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -480,6 +482,7 @@
       <li><a href="/insights/ai-roi-problem-is-about-systems-not-models/"><div class="rel-title">The AI ROI Problem Is About Systems, Not Models</div><p class="rel-desc">Generation is commoditizing while verification is not, and the asymmetry eats the gains.</p></a></li>
       <li><a href="/insights/ai-code-review-does-not-scale-linearly/"><div class="rel-title">AI Code Review Does Not Scale Linearly</div><p class="rel-desc">Generation scales with compute; the human verification behind it does not.</p></a></li>
       <li><a href="/insights/deployment-quality-will-define-the-ai-era/"><div class="rel-title">Deployment Quality Will Define the AI Era</div><p class="rel-desc">Throughput is largely solved; sustained quality under velocity is the open problem.</p></a></li>
+      <li><a href="/insights/ai-adoption-maturity-model-engineering-analysis/"><div class="rel-title">AI Adoption Maturity Model: A Technical Analysis</div><p class="rel-desc">CMU SEI and Accenture&rsquo;s five-level model, and the governance execution gap it leaves open.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -61,6 +61,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -120,6 +120,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -105,6 +105,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.6rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.55rem; line-height: 1.8; }

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -121,6 +121,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -69,9 +69,9 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-color: var(--accent); }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -361,7 +361,7 @@
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">
       <h3>Stop paying to review code that should never have been generated.</h3>
-      <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; rejecting non-compliant changes before they reach a metered review. Open source.</p>
+      <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; rejecting non-compliant changes before they reach a metered review. Open source, or <a href="/demo/">see it enforce a decision in the live demo</a>.</p>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); transition: border-color 0.15s; }
-    .article-body a:hover { border-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -121,6 +121,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -135,6 +135,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -61,6 +61,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -120,6 +120,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -379,6 +381,8 @@
       <li><a href="/insights/rule-files-vs-retrieval-memory/"><div class="rel-title">Rule Files vs Retrieval Memory</div><p class="rel-desc">Why static instruction files lose to retrieval once agents scale.</p></a></li>
       <li><a href="/insights/datadog-state-of-ai-engineering-governance-crisis/"><div class="rel-title">Datadog&rsquo;s State of AI Engineering Report Quietly Confirms the Governance Crisis</div><p class="rel-desc">Independent telemetry pointing at the same enforcement gap.</p></a></li>
       <li><a href="/insights/cursor-developer-habits-report-governance-infrastructure/"><div class="rel-title">Cursor Developer Habits Report 2026</div><p class="rel-desc">What developer behavior data says about governance infrastructure.</p></a></li>
+      <li><a href="/insights/ai-adoption-maturity-model-engineering-analysis/"><div class="rel-title">AI Adoption Maturity Model: A Technical Analysis</div><p class="rel-desc">CMU SEI and Accenture&rsquo;s five-level model, and the governance execution gap it leaves open.</p></a></li>
+      <li><a href="/insights/bcg-ai-era-operating-models-governance/"><div class="rel-title">BCG&rsquo;s AI-Era Operating Models Create a Governance Problem</div><p class="rel-desc">Flatter, more autonomous org models remove the layers that were doing governance work.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); transition: border-color 0.15s; }
-    .article-body a:hover { border-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -131,12 +131,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -63,6 +63,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
@@ -744,6 +746,7 @@ mneme check --mode warn</code></pre>
     <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/">Why AI Architectural Governance Needs Precedence Semantics</a></li>
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
     <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
+    <li><a href="/insights/loop-engineering-is-not-new/">Loop Engineering Is Not New</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -130,12 +130,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .article-body pre { background: #0a0a0d; border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem 1.4rem; margin: 1.75rem 0; overflow-x: auto; font-family: 'DM Mono', monospace; font-size: 0.82rem; line-height: 1.65; color: var(--text); }
     .article-body pre code { font-family: inherit; color: inherit; background: none; padding: 0; }

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -121,6 +121,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -374,6 +376,7 @@
       <li><a href="/insights/future-of-software-engineering-after-vibe-coding/"><div class="rel-title">The Future of Software Engineering After Vibe Coding</div><p class="rel-desc">The engineering-side version of the role shift McKinsey describes.</p></a></li>
       <li><a href="/insights/what-is-the-ai-sdlc/"><div class="rel-title">What Is the AI SDLC?</div><p class="rel-desc">The lifecycle redefined by AI, and where enforcement has to sit inside it.</p></a></li>
       <li><a href="/insights/coordination-governance-multi-agent-systems/"><div class="rel-title">The Next Layer Is Coordination Governance</div><p class="rel-desc">Orchestrating agents is not the same as constraining what they build.</p></a></li>
+      <li><a href="/insights/bcg-ai-era-operating-models-governance/"><div class="rel-title">BCG&rsquo;s AI-Era Operating Models Create a Governance Problem</div><p class="rel-desc">Flatter, more autonomous org models remove the layers that were doing governance work.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
@@ -749,6 +751,7 @@
       <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Harnesses keep agents acting across sessions. Memory keeps them informed. Neither layer enforces architectural boundaries.</p></a></li>
       <li><a href="/insights/long-running-agents-need-governance/"><div class="rel-title">Long-Running Agents Need More Than Memory</div><p class="rel-desc">Continuity infrastructure preserves what happened. Governance preserves what must remain true.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Visibility explains drift after it occurs. Governance constrains drift before generation.</p></a></li>
+      <li><a href="/insights/shared-memory-is-not-shared-intent/"><div class="rel-title">Shared Memory Is Not Shared Intent</div><p class="rel-desc">Shared memory distributes context across AI coding teams; it does not enforce intent.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -129,12 +129,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
@@ -421,6 +421,7 @@
       <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">A layered view of where governance, orchestration, memory, and verification sit in the agent stack.</p></a></li>
       <li><a href="/insights/governance-perimeter-is-moving-to-the-endpoint/"><div class="rel-title">The Governance Perimeter Is Moving to the Endpoint</div><p class="rel-desc">As autonomous workflows spread, governance must follow the action, not the policy team.</p></a></li>
       <li><a href="/insights/long-running-agents-need-governance/"><div class="rel-title">Long-Running Agents Need Governance</div><p class="rel-desc">Autonomy plus persistence plus memory is exactly where drift compounds.</p></a></li>
+      <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -133,12 +133,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
@@ -430,6 +430,7 @@
       <li><a href="/insights/ai-is-becoming-the-operating-layer-for-software-execution/"><div class="rel-title">AI Is Becoming the Operating Layer for Software Execution</div><p class="rel-desc">Once AI moves from suggesting to executing, the surrounding operating model determines whether it scales.</p></a></li>
       <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">Where governance, orchestration, memory, and verification sit in the agent stack &mdash; and which layer is still missing.</p></a></li>
       <li><a href="/compare/rag-vs-governance/"><div class="rel-title">RAG vs Governance</div><p class="rel-desc">Side-by-side: what retrieval can answer, what only enforcement can answer.</p></a></li>
+      <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -370,6 +372,7 @@
       <li><a href="/insights/governance-perimeter-is-moving-to-the-endpoint/"><div class="rel-title">The Governance Perimeter Is Moving to the Endpoint</div><p class="rel-desc">As execution moves on-device, governance has to travel with it.</p></a></li>
       <li><a href="/insights/agent-runtime-governance/"><div class="rel-title">Agent Runtime Governance</div><p class="rel-desc">What managed agent runtimes signal about the next infrastructure layer.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Seeing the action is not the same as constraining it.</p></a></li>
+      <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -379,6 +381,7 @@
       <li><a href="/insights/microsoft-execution-containers-ai-agent-runtime-governance/"><div class="rel-title">Microsoft Execution Containers Show Why AI Agent Governance Is Moving to the Runtime</div><p class="rel-desc">OS-enforced isolation is one layer. Architectural governance is the layer above it.</p></a></li>
       <li><a href="/insights/agent-runtime-governance/"><div class="rel-title">Agent Runtime Governance</div><p class="rel-desc">What managed agent runtimes signal about the next infrastructure layer.</p></a></li>
       <li><a href="/insights/ai-is-becoming-the-operating-layer-for-software-execution/"><div class="rel-title">AI Is Becoming the Operating Layer for Software Execution</div><p class="rel-desc">When AI mediates execution, governance becomes part of the operating layer.</p></a></li>
+      <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -130,12 +130,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -65,12 +65,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); transition: border-color 0.15s; }
-    .article-body a:hover { border-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -104,6 +104,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.55rem; line-height: 1.8; }

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -64,9 +64,9 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--teal); text-decoration: underline; text-underline-offset: 3px; }
-    .article-body a:hover { color: var(--text); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -120,6 +120,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -464,6 +466,7 @@
       <li><a href="/insights/harness-engineering-verification-layer/"><div class="rel-title">The Missing Layer in Harness Engineering Is Verification</div><p class="rel-desc">A reliable run still needs an independent check that its output is correct.</p></a></li>
       <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompts shape model behavior; they cannot enforce architectural decisions deterministically.</p></a></li>
       <li><a href="/insights/why-claude-md-stops-scaling/"><div class="rel-title">Why CLAUDE.md Stops Scaling</div><p class="rel-desc">Why static instruction files cannot hold architectural intent as systems grow.</p></a></li>
+      <li><a href="/insights/loop-engineering-is-not-new/"><div class="rel-title">Loop Engineering Is Not New</div><p class="rel-desc">Loops have been computing&rsquo;s core abstraction for seventy years; what is new is governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -63,6 +63,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
 
     .contrast-block { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; margin: 2.5rem 0; }

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -105,6 +105,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.6rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.55rem; line-height: 1.8; }

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -92,6 +92,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -143,12 +143,12 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
     .article-body li strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; border-bottom: 1px solid rgba(200,240,96,0.3); }
-    .article-body a:hover { border-bottom-color: var(--accent); }
 
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -105,6 +105,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.6rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.55rem; line-height: 1.8; }

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -120,6 +120,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -496,6 +498,7 @@
       <li><a href="/insights/harness-engineering-verification-layer/"><div class="rel-title">The Missing Layer in Harness Engineering Is Verification</div><p class="rel-desc">Coordinating execution is not verifying that the execution was correct against durable intent.</p></a></li>
       <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">What harnesses solve, where they go silent, and why governance is the missing layer.</p></a></li>
       <li><a href="/insights/ai-infrastructure-governance-category/"><div class="rel-title">The Next AI Infrastructure Category Is Governance</div><p class="rel-desc">Why governance becomes a distinct infrastructure category once agents do most of the writing.</p></a></li>
+      <li><a href="/insights/loop-engineering-is-not-new/"><div class="rel-title">Loop Engineering Is Not New</div><p class="rel-desc">Loops have been computing&rsquo;s core abstraction for seventy years; what is new is governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -69,9 +69,9 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
-    .article-body a { color: var(--accent); text-decoration: none; }
-    .article-body a:hover { text-decoration: underline; }
 
     .phase-list { display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; margin: 2rem 0; }
     .phase-row { background: var(--surface); padding: 1rem 1.25rem; display: flex; gap: 1.25rem; align-items: flex-start; }

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -95,6 +95,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -65,6 +65,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -566,6 +568,8 @@
         <li><a href="/insights/ai-code-review-does-not-scale-linearly/">AI Code Review Does Not Scale Linearly</a></li>
         <li><a href="/insights/review-is-not-governance/">Review Is Not Governance</a></li>
         <li><a href="/insights/deployment-quality-will-define-the-ai-era/">Deployment Quality Will Define the AI Era</a></li>
+        <li><a href="/insights/ai-coding-productivity-gains-rework/">Why AI Coding Productivity Gains Lead to More Rework</a></li>
+        <li><a href="/insights/github-copilot-usage-based-billing-review-economics/">GitHub Turned AI Code Review Into a Budget Line Item</a></li>
     </ul>
 
   <footer class="article-footer">

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -91,6 +91,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }
@@ -482,6 +484,7 @@
       <li><a href="/insights/why-rag-fails-for-architectural-governance/"><div class="rel-title">Why RAG Fails for Architectural Governance</div><p class="rel-desc">Retrieval surfaces information. It does not enforce constraints. The failure modes are different.</p></a></li>
       <li><a href="/insights/why-prompt-memory-fails-at-scale/"><div class="rel-title">Why Prompt Memory Fails at Scale</div><p class="rel-desc">As sessions grow, prompt-based context cannot maintain deterministic architectural constraint priority.</p></a></li>
       <li><a href="/insights/agent-skills-vs-architectural-governance/"><div class="rel-title">Agent Skills vs Architectural Governance</div><p class="rel-desc">Skills package reusable capability. Governance encodes enforceable constraints. These are different layers of the same stack.</p></a></li>
+      <li><a href="/insights/shared-memory-is-not-shared-intent/"><div class="rel-title">Shared Memory Is Not Shared Intent</div><p class="rel-desc">Shared memory distributes context across AI coding teams; it does not enforce intent.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -63,6 +63,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -64,6 +64,8 @@
     .article-body { font-size: 0.92rem; line-height: 1.9; color: var(--text); }
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body ul li { margin-bottom: 0.5rem; line-height: 1.8; }
@@ -415,6 +417,7 @@
         <li><a href="/insights/mneme-vs-cursor-rules/">Mneme vs Cursor Rules</a></li>
         <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/">Architectural Governance Across Heterogeneous AI Coding Agents</a></li>
         <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
+        <li><a href="/insights/shared-memory-is-not-shared-intent/">Shared Memory Is Not Shared Intent</a></li>
     </ul>
 
   <footer class="article-footer">

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -65,6 +65,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -121,6 +121,8 @@
     .article-body h2 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 600; letter-spacing: -0.015em; margin: 3rem 0 1rem; color: var(--text); }
     .article-body h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text); }
     .article-body p { margin-bottom: 1.25rem; color: var(--muted); }
+    .article-body a { color: #8be0c8; text-decoration: none; border-bottom: 1px solid rgba(139,224,200,0.4); transition: border-color 0.15s; }
+    .article-body a:hover { border-bottom-color: #8be0c8; }
     .article-body p strong { color: var(--text); font-weight: 500; }
     .article-body ul, .article-body ol { margin: 0 0 1.25rem 1.5rem; color: var(--muted); }
     .article-body li { margin-bottom: 0.5rem; }


### PR DESCRIPTION
Corpus-wide insights quality pass (100 articles).

## What
1. **Accessible links** — every article's inline body links now use teal `#8be0c8` + underline (`.article-body a`). ~12.6:1 contrast on `#0c0c0d` (AAA), distinct from the lime CTA accent, with a non-colour underline cue (WCAG 1.4.1). Fixes **59** unstyled default-blue articles + standardizes **41** inconsistent lime/colour-only ones.
2. **Reciprocal mesh** — related-essays links from ~25 neighbour articles into the **7 previously hub-only pages** (4 wave-3 + ai-adoption-maturity, bcg-operating-models, microsoft-agent-platform), each lifted **1 → 5 inbound**.
3. **Enforcement in `check_insights.py`** — HARD check that body links are styled (no broken default); non-blocking WARN for under-meshed (<3 inbound) and missing in-body funnel link.

## Audit that motivated it
59/100 broken-blue links · 28 under-meshed · 96 no in-body funnel link.

## Checks
check_insights (exit 0, link-style hard check passes for all 100; WARN flags 97 for mesh/funnel follow-ups) · nav-footer · sticky-nav · encoding — all green.

Follow-ups (separate): in-body funnel links on high-intent pages, and a `publish-insight` skill encoding this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)