### PR TITLE
ci: advance deploy marker only after verification passes

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -297,8 +297,6 @@ print(f"\n[OK] {len(files_to_upload)} files uploaded")
 if not full_deploy:
     purge_urls = [u for u in (label_to_url(label) for _, _, label in files_to_upload) if u]
 
-tag_deployed()
-
 # ── Purge Cloudflare cache BEFORE verification ────────────────────────────────
 # Purge first so verification hits fresh server responses, not stale CF cache.
 # A cached 404 for a newly uploaded URL would otherwise cause verification to
@@ -341,6 +339,16 @@ if verify_failures:
     raise SystemExit(1)
 
 print(f"\n[OK] All {len(sitemap_urls)} sitemap URLs verified - deploy complete")
+
+# Advance the deploy marker ONLY after every sitemap URL has verified 200.
+# Previously tag_deployed() ran right after upload, before this verification --
+# so a deploy whose pages never actually served (silent upload miss, or an
+# "optimistic" flaky upload) still moved the marker, and the next delta deploy
+# skipped re-uploading them. That left 9 pages 404 on the origin for ~3 days
+# while the marker claimed they were deployed. Tagging here means a failed
+# verification leaves the marker behind, so the next deploy retries the same
+# delta and re-uploads the missing pages.
+tag_deployed()
 
 
 # -- IndexNow: notify search engines of updated pages --


### PR DESCRIPTION
## Root cause of the 3-day wave-2 outage

`tag_deployed()` (which moves the `site-deployed` delta marker to HEAD) ran **right after upload, before** the post-upload verification step. So a deploy whose pages never actually served (silent upload miss, or an optimistic flaky upload) still advanced the marker, then failed verification. The run failed — but the marker had moved, so every later delta deploy skipped re-uploading the never-live pages.

Result: 9 wave-2 insight pages stayed **404 on the origin for ~3 days** while the marker claimed they were deployed, and the all-sitemap verification failed every deploy (which also blocked IndexNow).

Log proof: `[OK] Tagged site-deployed at HEAD` printed at 18:44:25, **before** `All 215 sitemap URLs verified` at 18:44:34.

## Fix
Move `tag_deployed()` to **after** verification succeeds. A failed verification now leaves the marker behind, so the next deploy retries the same delta and re-uploads the missing pages. No behaviour change on a clean deploy.

Verified: `py_compile` OK; `tag_deployed()` is called exactly once, after the verification `SystemExit(1)` and the `All sitemap URLs verified` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)