### PR TITLE
site: insights audit findings - in-body funnel links + orphan mesh

### DIFF
--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -444,6 +444,7 @@
     <div class="cta-block">
       <h3>Move enforcement to the point of authorship</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook, enforcing architectural constraints before code is written. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &#x2192;</a>
     </div>
   </footer>

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -380,6 +380,7 @@
     <div class="cta-block">
       <h3>Keep architecture coherent across every agent</h3>
       <p>Mneme propagates the same architectural decisions to every agent, hook, and CI surface in an orchestrated workflow &mdash; so parallel work does not mean parallel drift. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -444,6 +444,7 @@
     <div class="cta-block">
       <h3>Add governance to your agent stack</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and enforces them at the hook level &mdash; so governance travels with the workflow instead of living only in review. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -499,6 +499,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. The layer that keeps your architecture yours. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -448,6 +448,7 @@
     <div class="cta-block">
       <h3>Governance before generation</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time, via Claude Code&rsquo;s PreToolUse hook. Constraints that hold structurally, not conversationally. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -400,6 +400,7 @@
     <div class="cta-block">
       <h3>Turn maturity-model governance into enforced decisions</h3>
       <p>Mneme enforces your architectural decisions for coding agents &mdash; recorded decisions retrieved at generation time and verified before changes land. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -471,6 +471,7 @@
     <div class="cta-block">
       <h3>Architectural governance for autonomous systems</h3>
       <p>Runtime controls protect the action. Mneme protects the architecture. It is the open-source layer that compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and in CI, so autonomous iteration cannot quietly drift away from engineering intent.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -517,6 +517,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Constrain the agent; keep the accountability. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -456,6 +456,7 @@
     <div class="cta-block">
       <h3>Move governance before generation</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file, not after the PR is opened. Open source, hook-level integration with Claude Code.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/compare/coderabbit/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs CodeRabbit — full comparison &rarr;</a>
     </div>

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -393,6 +393,7 @@
     <div class="cta-block">
       <h3>Stop paying the verification tax by hand.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; before drift reaches the pull request. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -496,6 +496,8 @@
         <li><a href="/insights/goal-driven-agents-architectural-governance/"><div class="rel-title">Goal-Driven Agents Need Architectural Governance</div><p class="rel-desc">Tests verify outcomes. Governance preserves architectural intent while the loop runs.</p></a></li>
         <li><a href="/insights/llm-wiki-library-not-law/"><div class="rel-title">Your LLM Wiki Is a Library, Not a Law</div><p class="rel-desc">Documentation is context. Governance is constraint. The distinction shows up at generation time.</p></a></li>
         <li><a href="/insights/agent-skills-vs-architectural-governance/"><div class="rel-title">Agent Skills vs Architectural Governance</div><p class="rel-desc">Skills teach agents how to act. Governance constrains what those actions can do to the system.</p></a></li>
+        <li><a href="/insights/html-is-not-the-point-structure-is/"><div class="rel-title">HTML Is Not the Point. Structure Is.</div><p class="rel-desc">Software artifacts are becoming machine-operable execution surfaces, expanding the governance surface.</p></a></li>
+        <li><a href="/insights/search-as-code-agent-execution-surface/"><div class="rel-title">Search as Code Is an Execution Surface</div><p class="rel-desc">When agents compose executable workflows, tool governance becomes code-execution governance.</p></a></li>
       </ul>
     </aside>
 

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -505,6 +505,7 @@
     <div class="cta-block">
       <h3>Build the governance layer of your AI operating stack</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints, retrieves them before agents generate, and enforces them deterministically in CI &mdash; the governance, provenance, and verification layers of the AI operating stack. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -496,6 +496,7 @@
     <div class="cta-block">
       <h3>Govern what the AI generates</h3>
       <p>Mneme is an open-source architectural governance layer for AI-assisted development. It turns architectural decisions into enforceable constraints before agents generate code — via Claude Code's PreToolUse hook and other generation-time surfaces.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -455,6 +455,7 @@
     <div class="cta-block">
       <h3>Verify high-confidence AI outputs before they become operational decisions</h3>
       <p>Mneme treats architectural decisions as durable, source-tracked constraints &mdash; so AI-generated criticism and code can be checked against what the repo has already decided. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -412,6 +412,7 @@
     <div class="cta-block">
       <h3>Make verification scale with generation</h3>
       <p>Mneme compiles architectural and operational decisions into deterministic constraints that fire across every surface where work happens. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -415,6 +415,7 @@
       <li><a href="/insights/runtime-verification-is-not-architectural-verification/"><div class="rel-title">Runtime Verification Is Not Architectural Verification</div><p class="rel-desc">Schema-correct and architecturally wrong is a real failure mode.</p></a></li>
       <li><a href="/insights/agent-runtime-governance/"><div class="rel-title">Agent Runtime Governance: The Next AI Infrastructure Layer</div><p class="rel-desc">Where the deterministic boundary sits when agents become long-running.</p></a></li>
       <li><a href="/insights/loop-engineering-is-not-new/"><div class="rel-title">Loop Engineering Is Not New</div><p class="rel-desc">Loops have been computing&rsquo;s core abstraction for seventy years; what is new is governance.</p></a></li>
+      <li><a href="/insights/barbara-liskov-python-encapsulation-ai-governance/"><div class="rel-title">Barbara Liskov&rsquo;s Python Critique Predicts the Governance Problem</div><p class="rel-desc">Advisory encapsulation holds at human pace; it does not survive agent velocity.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -423,6 +423,7 @@
     <div class="cta-block">
       <h3>The deterministic layer your probabilistic stack already needs</h3>
       <p>Mneme compiles ADRs and architectural decisions into machine-evaluable constraints &mdash; the same verdict, every run, across every model and agent. The deterministic layer underneath the probabilistic one. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -421,6 +421,7 @@
     <div class="cta-block">
       <h3>Make agent coordination architecturally stable</h3>
       <p>Mneme provides the deterministic constraint layer that propagates architectural intent across orchestrators, subagents, and CI &mdash; so multi-agent systems can scale without fragmenting. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -724,6 +724,7 @@
     <div class="cta-block">
       <h3>One governance layer. Every agent.</h3>
       <p>Mneme HQ is the tool-agnostic decision store and enforcement hook for codebases that are governed by architecture, not by which assistant happened to write the line. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -212,6 +212,7 @@
     <div class="cta-block">
       <h3>Add deterministic governance to your agent artifact stream</h3>
       <p>Mneme compiles ADRs into machine-evaluable verdicts that travel alongside agent artifacts &mdash; so reviewers see both what happened and whether it was allowed.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -464,6 +464,7 @@
     <div class="cta-block">
       <h3>Stop architectural drift at the generation layer</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook — enforcing architectural constraints before code is written, not after it enters the review queue. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &#x2192;</a>
     </div>
   </footer>

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -388,6 +388,7 @@
     <div class="cta-block">
       <h3>Make risk a first-class constraint in your agent workflow</h3>
       <p>Mneme compiles your team&rsquo;s architectural decisions into enforceable, auditable constraints that reach every stage of the AI development lifecycle &mdash; before commit, in the PR, and in CI. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -403,6 +403,7 @@
     <div class="cta-block">
       <h3>Give autonomous teams enforced architectural boundaries</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -389,6 +389,7 @@
     <div class="cta-block">
       <h3>Design governance in, don't bolt it on</h3>
       <p>Mneme compiles architectural decisions into constraints that are enforced before an agent acts &mdash; governance designed into the workflow, not reviewed after the fact. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -388,6 +388,7 @@
     <div class="cta-block">
       <h3>Your skills encode decisions. Govern the decisions.</h3>
       <p>Mneme records architectural decisions as structured, retrievable constraints and enforces them when agents make changes &mdash; so executable knowledge stays consistent with the decisions it depends on. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -374,6 +374,7 @@
     <div class="cta-block">
       <h3>Durable execution keeps agents running. Keep the architecture intact.</h3>
       <p>Mneme enforces architectural decisions across long-running, multi-repo agent execution &mdash; before changes land, regardless of which environment produced them. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -490,6 +490,7 @@
     <div class="cta-block">
       <h3>Stop letting constraint decay reach the PR queue</h3>
       <p>Mneme compiles ADRs and project constraints into deterministic checks that run before generation and in CI &mdash; the same rules, across every agent and tool. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -402,6 +402,7 @@
       <li><a href="/insights/anthropic-research-system-coordination-infrastructure/"><div class="rel-title">Anthropic&rsquo;s Research System and the Coordination Infrastructure Problem</div><p class="rel-desc">Multi-agent research workflows surface the same shared-state problem.</p></a></li>
       <li><a href="/insights/goal-driven-agents-architectural-governance/"><div class="rel-title">Goal-Driven Agents Need Architectural Governance</div><p class="rel-desc">Autonomy without invariants is how parallel teams produce incompatible systems &mdash; faster.</p></a></li>
       <li><a href="/insights/shared-memory-is-not-shared-intent/"><div class="rel-title">Shared Memory Is Not Shared Intent</div><p class="rel-desc">Shared memory distributes context across AI coding teams; it does not enforce intent.</p></a></li>
+      <li><a href="/insights/latent-space-agent-communication-governance/"><div class="rel-title">Latent-Space Agent Communication</div><p class="rel-desc">When agents stop talking in natural language, we lose the surface we audit them through.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -410,6 +410,7 @@
     <div class="cta-block">
       <h3>Coordination governance for multi-agent workflows</h3>
       <p>Mneme is the open-source layer for governance propagation across autonomous coding systems &mdash; deterministic architectural memory, verification contracts, and provenance that hold across every subagent in the workflow.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -499,6 +499,7 @@
       <li><a href="/insights/pr-review-is-becoming-incident-response/"><div class="rel-title">PR Review Is Becoming Incident Response</div><p class="rel-desc">Under agent velocity, review detects failures rather than preventing them.</p></a></li>
       <li><a href="/insights/datadog-state-of-ai-engineering-governance-crisis/"><div class="rel-title">Datadog State of AI Engineering Report</div><p class="rel-desc">A sibling report-response on the governance crisis at production scale.</p></a></li>
       <li><a href="/insights/deployment-quality-will-define-the-ai-era/"><div class="rel-title">Deployment Quality Will Define the AI Era</div><p class="rel-desc">Throughput is solved; sustained quality under velocity is not.</p></a></li>
+      <li><a href="/insights/snowflake-ai-data-engineering-governance-infrastructure/"><div class="rel-title">Snowflake&rsquo;s AI Data Engineering Report</div><p class="rel-desc">Data engineering is evolving into governance engineering.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -507,6 +507,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme compiles your architectural decisions and ADRs into machine-evaluable constraints and enforces them deterministically at hooks and in CI &mdash; before and around AI code generation, regardless of which model or agent did the work. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -577,6 +577,7 @@
     <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
     <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/">Why Code Review Cannot Scale With AI Output</a></li>
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
+    <li><a href="/insights/snowflake-ai-data-engineering-governance-infrastructure/">Snowflake&rsquo;s AI Data Engineering Report</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -585,6 +585,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -457,6 +457,7 @@
     <div class="cta-block">
       <h3>Build governance infrastructure for AI-assisted engineering</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file. Open source, hook-level integration with Claude Code.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -376,6 +376,7 @@
       <li><a href="/insights/anthropic-claude-marketplace-ai-engineering-control-plane/"><div class="rel-title">The Emerging AI Engineering Control Plane</div><p class="rel-desc">The marketplace-level view of the same stack &mdash; with the governance layer not yet named.</p></a></li>
       <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">When the team uses Devin and Claude Code and Copilot, the rules must still be the same.</p></a></li>
       <li><a href="/insights/coordination-governance-multi-agent-systems/"><div class="rel-title">The Next AI Infrastructure Layer Is Coordination Governance</div><p class="rel-desc">Subagents parallelize execution. They also parallelize inconsistency.</p></a></li>
+      <li><a href="/insights/openclaw-and-the-limits-of-autonomous-coding/"><div class="rel-title">OpenClaw and the Limits of Autonomous Coding</div><p class="rel-desc">100,000 stars in a week, then the wall every autonomous system hits without governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -491,6 +491,7 @@
     <div class="cta-block">
       <h3>Measure whether your system stayed who you decided it would be</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -603,6 +603,7 @@
     <li><a href="/insights/ai-native-engineering-intent-debt/">AI-Native Engineering Has an Intent Debt Problem</a></li>
     <li><a href="/insights/generative-ai-software-engineering-stack/">The Generative AI Software Engineering Stack</a></li>
     <li><a href="/insights/long-running-agents-need-governance/">Long-Running Agents Need More Than Memory</a></li>
+    <li><a href="/insights/mistral-vibe-ai-coding-enterprise-infrastructure/">Mistral Vibe and AI Coding Infrastructure</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -611,6 +611,7 @@
     <div class="cta-block">
       <h3>The governance and verification layer for AI-assisted software development.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent stack. Harnesses keep agents acting. Memory keeps them oriented. Observability records what they did. Mneme keeps them inside their architectural boundaries. Open source, MIT licensed.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -371,6 +371,7 @@
       <li><a href="/insights/rise-of-agentic-engineering-education/"><div class="rel-title">The Rise of Agentic Engineering Education</div><p class="rel-desc">The curriculum companion: what the new discipline has to teach.</p></a></li>
       <li><a href="/insights/github-ai-agent-validation-trust-layer/"><div class="rel-title">GitHub's Trust Layer Validates Behavior, Not Architecture</div><p class="rel-desc">Why tests and evals are necessary and not sufficient for correctness.</p></a></li>
       <li><a href="/insights/agent-manager-control-plane-governance/"><div class="rel-title">The Agent Manager Is the New Control Plane</div><p class="rel-desc">Supervising fleets of agents is not the same as constraining them.</p></a></li>
+      <li><a href="/insights/openclaw-and-the-limits-of-autonomous-coding/"><div class="rel-title">OpenClaw and the Limits of Autonomous Coding</div><p class="rel-desc">100,000 stars in a week, then the wall every autonomous system hits without governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -388,6 +388,7 @@
     <div class="cta-block">
       <h3>Keep your architectural decisions alive after the loop thins out</h3>
       <p>Mneme is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which agent or engineer produced it. It is the governing layer for a world where coding is automated and accountability is not.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -617,6 +617,7 @@
     <div class="cta-block">
       <h3>Mneme HQ is layer 5</h3>
       <p>Open-source decision corpus and pre-generation enforcement for AI-assisted engineering. Tool-agnostic, MIT-licensed, designed to sit above whichever combination of layers 1&ndash;4 your team picks.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -388,6 +388,7 @@
     <div class="cta-block">
       <h3>Enforce architectural invariants before the PR exists.</h3>
       <p>Mneme loads your architectural decisions into the agent&rsquo;s context and verifies every change against them deterministically &mdash; so duplicated utilities and weakened CI thresholds never reach your reviewers. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -427,6 +427,7 @@
       <li><a href="/insights/ai-stack-determinism-probabilistic-models/"><div class="rel-title">The AI Stack Is Rebuilding Determinism Around Probabilistic Models</div><p class="rel-desc">Why probabilistic generation still requires deterministic boundaries.</p></a></li>
       <li><a href="/insights/harness-engineering-verification-layer/"><div class="rel-title">The Missing Layer in Harness Engineering Is Verification</div><p class="rel-desc">Harnesses optimize for successful execution; enterprises need it proven correct.</p></a></li>
       <li><a href="/insights/machine-readable-pull-requests-agentic-development/"><div class="rel-title">The Next Frontier Is Machine-Readable Pull Requests</div><p class="rel-desc">Making the PR a verifiable surface that carries provenance, scope, and policy.</p></a></li>
+      <li><a href="/insights/ai-peer-review-context-loss-governance/"><div class="rel-title">AI Peer Review Study: GPT-5.2 and Context Loss</div><p class="rel-desc">GPT-5.2 beat top human reviewers and still missed context already in the source.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -435,6 +435,7 @@
     <div class="cta-block">
       <h3>Validate the diff, not just the run</h3>
       <p>GitHub grades whether your agent behaved. Mneme decides whether what it changed still conforms to your architecture. It is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which agent produced it.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -606,6 +606,7 @@
     <div class="cta-block">
       <h3>Govern your goal-driven agent loops</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and retrieves them before agents generate &mdash; so the loop optimizes inside your architecture, not around it. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -438,6 +438,7 @@
     <div class="cta-block">
       <h3>Architectural governance for your agent fleet</h3>
       <p>A registry controls which agents run. Mneme controls whether their output stays aligned with your architecture. It is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which registered agent produced it.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -524,6 +524,7 @@
     <div class="cta-block">
       <h3>Govern the agent, not just the artifact</h3>
       <p>A managed runtime decides how an agent runs. Mneme governs what it is allowed to do: it compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -435,6 +435,7 @@
       <li><a href="/insights/long-running-agents-need-governance/"><div class="rel-title">Long-Running Agents Need Governance</div><p class="rel-desc">As agent sessions extend across surfaces, constraints have to propagate with them.</p></a></li>
       <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous Agents</div><p class="rel-desc">Why governance has to be agent-agnostic rather than tied to any single coding tool.</p></a></li>
       <li><a href="/insights/why-context-alone-doesnt-prevent-architectural-drift/"><div class="rel-title">Why Context Alone Doesn&rsquo;t Prevent Architectural Drift</div><p class="rel-desc">Recall is not constraint. The missing layer is governance, not memory.</p></a></li>
+      <li><a href="/insights/when-agents-launch-the-database/"><div class="rel-title">When Agents Launch the Database</div><p class="rel-desc">When AI provisions infrastructure directly, repository-level governance cannot see the change.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -443,6 +443,7 @@
     <div class="cta-block">
       <h3>Governance that survives the endpoint</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints that travel with the repository &mdash; across local agents, IDEs, CI, and runtime surfaces. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -671,6 +671,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
     <div class="cta-block">
       <h3>The governance layer your agent harness is missing.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent workflow. Harnesses keep agents acting. Mneme keeps them inside their architectural boundaries. Open source, MIT licensed.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -429,6 +429,7 @@
       <li><a href="/insights/prompt-engineering-vs-harness-engineering/"><div class="rel-title">Prompt Engineering vs Harness Engineering</div><p class="rel-desc">Why reliability moved out of the prompt and into the system wrapping the model.</p></a></li>
       <li><a href="/insights/runtime-verification-is-not-architectural-verification/"><div class="rel-title">Runtime Verification Is Not Architectural Verification</div><p class="rel-desc">Protecting a single run is not the same as protecting the system it modifies.</p></a></li>
       <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">A reliable harness coordinates execution; it does not enforce the architecture teams committed to.</p></a></li>
+      <li><a href="/insights/runtime-harnesses-for-ai-agents/"><div class="rel-title">Runtime Harnesses for AI Agents</div><p class="rel-desc">Reliability lives in the harness around the model; better models are not enough.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -437,6 +437,7 @@
     <div class="cta-block">
       <h3>Make execution verifiable, not just successful</h3>
       <p>Mneme compiles your architecture decision records into machine-evaluable constraints and enforces them deterministically at agent hooks and in CI. Same input, same verdict, every run &mdash; with each result traceable to the decision behind it. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -448,6 +448,7 @@
     <div class="cta-block">
       <h3>Governance for the machine-operable era</h3>
       <p>Mneme treats architectural decisions as machine-evaluable constraints that follow the artifact across generation, review, and runtime. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -391,6 +391,7 @@
     <div class="cta-block">
       <h3>Turn governance documents into executable controls</h3>
       <p>Mneme converts the architectural decisions buried in wikis and rule files into structured, retrievable constraints that coding agents are verified against before changes land. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -374,6 +374,7 @@
     <div class="cta-block">
       <h3>Govern what agents do, not just what they say</h3>
       <p>Mneme enforces architectural decisions against the changes agents make &mdash; a verification surface that does not depend on agents narrating their reasoning in readable text. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -404,6 +404,7 @@
     <div class="cta-block">
       <h3>Promote your binding decisions out of the wiki</h3>
       <p>Mneme takes the subset of your architectural intent that has to bind agent behavior and makes it explicit, retrievable, enforceable, and auditable &mdash; on top of the docs and ADRs you already have. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -431,6 +431,7 @@
     <div class="cta-block">
       <h3>Bigger context, smaller blind spots</h3>
       <p>Mneme makes architectural decisions deterministically retrievable and machine-enforceable &mdash; so what the agent attended to is no longer the only thing constraining the change. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -747,6 +747,7 @@ mneme check --mode warn</code></pre>
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
     <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
     <li><a href="/insights/loop-engineering-is-not-new/">Loop Engineering Is Not New</a></li>
+    <li><a href="/insights/cloud-agents-need-architectural-governance/">Cloud Agents Need More Than Durable Execution</a></li>
   </ul>
 
   <footer class="article-footer">

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -755,6 +755,7 @@ mneme check --mode warn</code></pre>
     <div class="cta-block">
       <h3>The governance layer your agent harness is missing.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent workflow. Progress logs tell the agent what happened. Mneme tells it what must remain true. Open source, MIT licensed.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -375,6 +375,7 @@
     <div class="cta-block">
       <h3>Build the loop. Then govern what it commits.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that an autonomous loop retrieves at generation time and CI verifies deterministically &mdash; so the probabilistic generator inside the loop cannot quietly drift the system. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -496,6 +496,8 @@
       <li><a href="/insights/ai-code-review-does-not-scale-linearly/"><div class="rel-title">AI Code Review Does Not Scale Linearly</div><p class="rel-desc">Generation throughput rises faster than review throughput. Machine-readable PRs are part of the answer.</p></a></li>
       <li><a href="/insights/ai-coding-governance-should-be-reviewable/"><div class="rel-title">AI Coding Governance Should Be Reviewable</div><p class="rel-desc">If governance happens silently, reviewers cannot see what was actually enforced.</p></a></li>
       <li><a href="/insights/review-is-not-governance/"><div class="rel-title">Review Is Not Governance</div><p class="rel-desc">Why human judgment cannot be the primary enforcement system for architectural invariants.</p></a></li>
+      <li><a href="/insights/latent-space-agent-communication-governance/"><div class="rel-title">Latent-Space Agent Communication</div><p class="rel-desc">When agents stop talking in natural language, we lose the surface we audit them through.</p></a></li>
+      <li><a href="/insights/search-as-code-agent-execution-surface/"><div class="rel-title">Search as Code Is an Execution Surface</div><p class="rel-desc">When agents compose executable workflows, tool governance becomes code-execution governance.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -504,6 +504,7 @@
     <div class="cta-block">
       <h3>Make architectural intent visible to the systems reviewing your code</h3>
       <p>Mneme compiles ADRs and constraints into machine-evaluable verdicts &mdash; the contract behind every change, attachable to every PR. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -394,6 +394,7 @@
     <div class="cta-block">
       <h3>The enforcement layer the rewiring needs</h3>
       <p>Rewire the operating model &mdash; then give your architects&rsquo; decisions a way to reach the agent. Mneme is the open-source layer that compiles your architectural decisions into deterministic, machine-evaluable constraints and enforces them at hooks and in CI, returning the same verdict on every change at the agent&rsquo;s latency, not the org chart&rsquo;s.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -529,6 +529,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. The moat the model can&rsquo;t rent you. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -761,6 +761,7 @@
     <div class="cta-block">
       <h3>Memory feeds it. Governance picks the rule.</h3>
       <p>Mneme HQ is the layer above the memory store: a deterministic precedence engine and enforcement hook for codebases governed by architecture, not by whichever rule ranked highest in this morning's embedding. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -422,6 +422,7 @@
       <li><a href="/insights/governance-perimeter-is-moving-to-the-endpoint/"><div class="rel-title">The Governance Perimeter Is Moving to the Endpoint</div><p class="rel-desc">As autonomous workflows spread, governance must follow the action, not the policy team.</p></a></li>
       <li><a href="/insights/long-running-agents-need-governance/"><div class="rel-title">Long-Running Agents Need Governance</div><p class="rel-desc">Autonomy plus persistence plus memory is exactly where drift compounds.</p></a></li>
       <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
+      <li><a href="/insights/mistral-vibe-ai-coding-enterprise-infrastructure/"><div class="rel-title">Mistral Vibe and AI Coding Infrastructure</div><p class="rel-desc">Coding agents are becoming multi-surface execution systems; governance becomes a platform concern.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -382,6 +382,7 @@
     <div class="cta-block">
       <h3>Your platform governs its agents. Who governs your architecture?</h3>
       <p>Mneme records your architectural decisions once and enforces them across every agent platform your team uses &mdash; GitHub, Cursor, Claude Code, and whatever ships next. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -439,6 +439,7 @@
     <div class="cta-block">
       <h3>Give your coding agents an enforceable operating model</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints and enforces them at the hook and CI layer &mdash; the same rules, across every agent and tool. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -373,6 +373,7 @@
       <li><a href="/insights/agent-runtime-governance/"><div class="rel-title">Agent Runtime Governance</div><p class="rel-desc">What managed agent runtimes signal about the next infrastructure layer.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Seeing the action is not the same as constraining it.</p></a></li>
       <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform and the Governance Layer</div><p class="rel-desc">Agent HQ, ACS, and Agent 365 name governance a layer; architectural governance is the part no platform ships.</p></a></li>
+      <li><a href="/insights/when-agents-launch-the-database/"><div class="rel-title">When Agents Launch the Database</div><p class="rel-desc">When AI provisions infrastructure directly, repository-level governance cannot see the change.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -381,6 +381,7 @@
     <div class="cta-block">
       <h3>Runtime isolation is one layer. Add the architectural one.</h3>
       <p>Mneme enforces the architectural decisions that runtime containment cannot see &mdash; which patterns, invariants, and policies must hold as agents work across environments. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -390,6 +390,7 @@
     <div class="cta-block">
       <h3>The agent moves. Your governance should move with it.</h3>
       <p>Mneme encodes architectural decisions as repo-native, deterministic policy and enforces them across the execution surfaces where agents act &mdash; IDE, CI, cloud, and whatever ships next. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -479,6 +479,7 @@
     <div class="cta-block">
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
       <a href="/compare/cursor-rules/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs Cursor Rules — full comparison →</a>
       <a href="/integrations/cursor/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Cursor — integration guide →</a>

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -387,6 +387,7 @@
         <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/"><div class="rel-title">Architectural Governance Across Heterogeneous AI Coding Agents</div><p class="rel-desc">The multi-agent corollary: governance has to travel across every agent that touches the repo.</p></a></li>
         <li><a href="/insights/agentic-convergence-trap-architectural-governance/"><div class="rel-title">The Agentic Convergence Trap Is an Architecture Problem Too</div><p class="rel-desc">If the model is shared, the architecture is the only thing that keeps your codebase from converging on everyone else&rsquo;s.</p></a></li>
         <li><a href="/insights/mckinsey-ai-table-stakes-to-advantage/"><div class="rel-title">From AI Table Stakes to AI Advantage</div><p class="rel-desc">McKinsey&rsquo;s moat thesis, applied to engineering: the model is rented; the enforced decision layer is owned.</p></a></li>
+        <li><a href="/insights/barbara-liskov-python-encapsulation-ai-governance/"><div class="rel-title">Barbara Liskov&rsquo;s Python Critique Predicts the Governance Problem</div><p class="rel-desc">Advisory encapsulation holds at human pace; it does not survive agent velocity.</p></a></li>
       </ul>
     </aside>
 

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -396,6 +396,7 @@
     <div class="cta-block">
       <h3>Keep your governance outside the model</h3>
       <p>Mneme is the model-independent governance layer for AI-assisted development: a repo-native control surface that returns the same verdict at every enforcement point, regardless of which model or harness produced the change. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -456,6 +456,7 @@
     <div class="cta-block">
       <h3>The layer that survives the model swap</h3>
       <p>Mneme HQ is the open-source decision corpus and pre-generation enforcement layer. Tool-agnostic, model-agnostic, framework-independent &mdash; built for codebases that change models without changing architecture.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -443,6 +443,7 @@
     <div class="cta-block">
       <h3>Governance before generation</h3>
       <p>Mneme HQ enforces architectural constraints at generation time via Claude Code&rsquo;s PreToolUse hook. Execution boundaries, verification contracts, and auditability — built into the workflow, not retrofitted after the fact. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -452,6 +452,7 @@
     <div class="cta-block">
       <h3>Move governance upstream of the PR queue</h3>
       <p>Mneme compiles architecture decisions into deterministic constraints that fire before generation and continue firing across commit, PR, and CI. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -433,6 +433,7 @@
     <div class="cta-block">
       <h3>Move governance before generation</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file, not after the PR is opened. Open source, hook-level integration with Claude Code.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/compare/coderabbit/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs CodeRabbit — full comparison &rarr;</a>
     </div>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -528,6 +528,7 @@
     <div class="cta-block">
       <h3>Stop relying on prompts to enforce architecture</h3>
       <p>Mneme HQ enforces architectural decisions with structured constraints, a precedence engine, and hook-level blocking — not system prompt suggestions. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -475,6 +475,7 @@
     <div class="cta-block">
       <h3>Make the architecture a constraint, not a suggestion</h3>
       <p>A reliable harness runs the agent. It does not hold the agent to your architecture. Mneme compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and in CI &mdash; before drift is ever written. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -478,6 +478,7 @@
       <li><a href="/insights/why-rag-fails-for-architectural-governance/">Why RAG Fails for Architectural Governance</a></li>
       <li><a href="/insights/why-prompt-memory-fails-at-scale/">Why Prompt Memory Fails at Scale</a></li>
       <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/">Why AI Architectural Governance Needs Precedence Semantics</a></li>
+      <li><a href="/insights/long-context-windows-governance-infrastructure/">Long Context Does Not Eliminate Governance Infrastructure</a></li>
       <li><a href="/concepts/decision-continuity/">Concept: Decision Continuity</a></li>
       <li><a href="/architecture/decision-memory-vs-documentation/">What Is Decision Memory? Where Architectural Authority Lives</a></li>
     </ul>

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -393,6 +393,7 @@
     <div class="cta-block">
       <h3>Govern what the AI generates</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time, via Claude Code's PreToolUse hook. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -545,6 +545,7 @@
     <div class="cta-block">
       <h3>The governance layer the curriculum is missing</h3>
       <p>Mneme HQ is the open-source decision corpus and pre-generation enforcement layer that operates above whichever AI coding tool a team picks. Tool-agnostic, MIT-licensed, framework-independent.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -398,6 +398,7 @@
     <div class="cta-block">
       <h3>Stop pasting your architecture into every prompt</h3>
       <p>Mneme retrieves the architectural decisions relevant to the current change and enforces them at the hook level &mdash; not as a static preamble the model can dilute. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -370,6 +370,7 @@
       <li><a href="/insights/prompt-engineering-vs-harness-engineering/"><div class="rel-title">Prompt Engineering vs Harness Engineering</div><p class="rel-desc">From optimizing inputs to designing the system around the model.</p></a></li>
       <li><a href="/insights/harness-engineering-verification-layer/"><div class="rel-title">The Missing Layer in Harness Engineering Is Verification</div><p class="rel-desc">Successful execution is not verified execution.</p></a></li>
       <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">Execution is solved; architectural constraints are not.</p></a></li>
+      <li><a href="/insights/cloud-agents-need-architectural-governance/"><div class="rel-title">Cloud Agents Need More Than Durable Execution</div><p class="rel-desc">Durable execution keeps the agent running; governance keeps the architecture coherent.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -378,6 +378,7 @@
     <div class="cta-block">
       <h3>Make architectural intent part of the harness</h3>
       <p>Mneme adds the governance layer to the agent harness &mdash; enforceable architectural invariants checked before tool execution, before commit, before PR, and in CI. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -415,6 +415,7 @@
     <div class="cta-block">
       <h3>Add architectural verification to your stack</h3>
       <p>Mneme compiles architecture decision records into deterministic constraints that fire across agent harnesses, commits, PRs, and CI. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -366,6 +366,7 @@
       <li><a href="/insights/ai-is-becoming-the-operating-layer-for-software-execution/"><div class="rel-title">AI Is Becoming the Operating Layer for Software Execution</div><p class="rel-desc">Agents run code against real systems, not just answer questions.</p></a></li>
       <li><a href="/insights/agentic-infrastructure-attack-surface/"><div class="rel-title">The Agentic Infrastructure Attack Surface</div><p class="rel-desc">General execution power is also a general risk surface.</p></a></li>
       <li><a href="/insights/why-observability-is-not-governance/"><div class="rel-title">Why Observability Is Not Governance</div><p class="rel-desc">Logging the code is not the same as governing whether it runs.</p></a></li>
+      <li><a href="/insights/html-is-not-the-point-structure-is/"><div class="rel-title">HTML Is Not the Point. Structure Is.</div><p class="rel-desc">Software artifacts are becoming machine-operable execution surfaces, expanding the governance surface.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -374,6 +374,7 @@
     <div class="cta-block">
       <h3>Govern what the agent runs, not just what it calls</h3>
       <p>Mneme enforces architectural and policy decisions against the code agents execute &mdash; not just the tools they were given. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -397,6 +397,7 @@
     <div class="cta-block">
       <h3>Give your AI coding team shared intent, not just shared memory.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so a decision the team agreed to is enforced across all of them, not just remembered. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -412,6 +412,7 @@
     <div class="cta-block">
       <h3>Add governance to your spec-driven workflow</h3>
       <p>Mneme is the open-source architectural governance layer &mdash; deterministic, ADR-derived constraints injected before generation and verified after. It plugs into spec-driven development without replacing it.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -499,6 +499,7 @@
       <li><a href="/insights/harness-engineering-still-needs-governance/"><div class="rel-title">Harness Engineering Still Needs Governance</div><p class="rel-desc">What harnesses solve, where they go silent, and why governance is the missing layer.</p></a></li>
       <li><a href="/insights/ai-infrastructure-governance-category/"><div class="rel-title">The Next AI Infrastructure Category Is Governance</div><p class="rel-desc">Why governance becomes a distinct infrastructure category once agents do most of the writing.</p></a></li>
       <li><a href="/insights/loop-engineering-is-not-new/"><div class="rel-title">Loop Engineering Is Not New</div><p class="rel-desc">Loops have been computing&rsquo;s core abstraction for seventy years; what is new is governance.</p></a></li>
+      <li><a href="/insights/runtime-harnesses-for-ai-agents/"><div class="rel-title">Runtime Harnesses for AI Agents</div><p class="rel-desc">Reliability lives in the harness around the model; better models are not enough.</p></a></li>
     </ul>
   </aside>
 

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -507,6 +507,7 @@
     <div class="cta-block">
       <h3>Build the harness. Then build the layer above it.</h3>
       <p>Mneme compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation &mdash; the governance layer that sits above the harness. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -381,6 +381,7 @@
     <div class="cta-block">
       <h3>Govern the action, not just the commit</h3>
       <p>Mneme enforces architectural decisions at the surfaces where agents act &mdash; before a change reaches the repo, and across the tools agents use beyond it. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -706,6 +706,7 @@
     <div class="cta-block">
       <h3>One precedence engine. Every agent.</h3>
       <p>Mneme HQ is the structured decision store and precedence engine for codebases governed by architecture, not by whichever assistant happened to read the file first. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -652,6 +652,7 @@
     <div class="cta-block">
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -570,6 +570,7 @@
         <li><a href="/insights/deployment-quality-will-define-the-ai-era/">Deployment Quality Will Define the AI Era</a></li>
         <li><a href="/insights/ai-coding-productivity-gains-rework/">Why AI Coding Productivity Gains Lead to More Rework</a></li>
         <li><a href="/insights/github-copilot-usage-based-billing-review-economics/">GitHub Turned AI Code Review Into a Budget Line Item</a></li>
+        <li><a href="/insights/ai-peer-review-context-loss-governance/">AI Peer Review Study: GPT-5.2 and Context Loss</a></li>
     </ul>
 
   <footer class="article-footer">

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -578,6 +578,7 @@
     <div class="cta-block">
       <h3>Enforce architectural decisions before code is written</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook — blocking architectural violations at generation time, not in review. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -493,6 +493,7 @@
     <div class="cta-block">
       <h3>Stop relying on context to enforce architecture</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and enforces them at the hook level &mdash; not in the prompt window. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -511,6 +511,7 @@
     <div class="cta-block">
       <h3>Put governance upstream of your dashboards</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time — pre-tool-use hook in the agent, gate in CI. The drift you can finally stop measuring is the drift you stopped shipping.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -426,6 +426,7 @@
     <div class="cta-block">
       <h3>Structured governance memory for AI coding</h3>
       <p>Mneme HQ replaces context injection with a precedence-aware decision engine that enforces architectural constraints before generation. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -581,6 +581,7 @@
         <li><a href="/insights/review-is-not-governance/">Review Is Not Governance</a></li>
         <li><a href="/insights/why-context-alone-doesnt-prevent-architectural-drift/">Why Context Alone Doesn&rsquo;t Prevent Architectural Drift</a></li>
         <li><a href="/architecture/decision-memory-vs-documentation/">Decision Memory: Where Architectural Authority Lives</a></li>
+        <li><a href="/insights/long-context-windows-governance-infrastructure/">Long Context Does Not Eliminate Governance Infrastructure</a></li>
     </ul>
 
   <footer class="article-footer">

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -589,6 +589,7 @@
     <div class="cta-block">
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -392,6 +392,7 @@
     <div class="cta-block">
       <h3>Verify the diff, not just the agent</h3>
       <p>Secure what your agents are allowed to do &mdash; then verify that what they build preserves your architecture. Mneme is the open-source layer that compiles your architectural decisions into deterministic, machine-evaluable constraints and enforces them at hooks and in CI, returning the same verdict on every change no matter which agent produced it. It is the part of zero trust that inspects the code.</p>
+      <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>


### PR DESCRIPTION
Addresses the non-blocking quality warnings `check_insights` now surfaces.

## Funnel (this commit)
94/100 articles had no contextual bottom-funnel link in the body. Added a `See the live demo →` link to each article's CTA (before the GitHub button, inside `<article>`). **82 articles updated; funnel warnings 94 → 12** (the 12 left have non-standard CTAs). Deterministic; skips the 6 that already had an in-article funnel link.

## Mesh (follow-up commit)
Reciprocal related-essays links for the remaining hub-only/orphan pages, to lift them to ≥3 inbound.

Gates: check_insights (exit 0) / nav-footer / sticky-nav / encoding — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)