### PR TITLE
site: add Related operational essays panel to the 10 insights that lacked one

### DIFF
--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -114,6 +114,18 @@
       .article-wrap { padding: 3rem 1.25rem 5rem; }
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -194,6 +206,16 @@
     <p>That is the difference between a delegated task with rails and a delegated task without them.</p>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/antigravity-solves-coordination-not-governance/"><div class="rel-title">Google Antigravity Solves Agent Coordination. It Does Not Solve Governance.</div><p class="rel-desc">Agent orchestration handles coordination, but the missing infrastructure layer once agents act across surfaces is architectural governance.</p></a></li>
+      <li><a href="/insights/agent-manager-control-plane-governance/"><div class="rel-title">The Agent Manager Is the New Control Plane for Software Development</div><p class="rel-desc">Manager views turn the agent manager into a control plane &mdash; but without policy enforcement, a control plane is only visibility.</p></a></li>
+      <li><a href="/insights/why-context-alone-doesnt-prevent-architectural-drift/"><div class="rel-title">Why Context Alone Doesn&rsquo;t Prevent Architectural Drift</div><p class="rel-desc">Context engineering improves recall but does not enforce constraints. The missing layer between orchestration and verification is governance.</p></a></li>
+      <li><a href="/insights/constraint-decay-coding-agents-architectural-governance/"><div class="rel-title">Constraint Decay: Why Coding Agents Need Architectural Governance</div><p class="rel-desc">Coding agents satisfy loose specs but lose fidelity to architectural patterns as requirements accumulate &mdash; governance must run before PR review.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -114,6 +114,18 @@
       .article-wrap { padding: 3rem 1.25rem 5rem; }
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -183,6 +195,16 @@
     <div class="callout"><p><strong>Manager views without policy are dashboards.</strong> Manager views with policy are control planes. The shift from one to the other is where the next generation of developer tools wins.</p></div>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/google-cloud-agent-registry-agent-fleet-governance/"><div class="rel-title">Google Cloud Agent Registry Governs Which Agents Run, Not Whether Their Output Stays Aligned</div><p class="rel-desc">A registry governs which agents run, not whether their output stays aligned with your architecture &mdash; the gap agent fleet governance still leaves open.</p></a></li>
+      <li><a href="/insights/microsoft-agent-platform-governance-layer/"><div class="rel-title">Microsoft&rsquo;s Agent Platform Reveals the Next AI Infrastructure Layer: Governance</div><p class="rel-desc">GitHub&rsquo;s Agent HQ and Microsoft&rsquo;s Build 2026 stack name governance as a platform layer &mdash; but the architectural layer no platform ships.</p></a></li>
+      <li><a href="/insights/coordination-governance-multi-agent-systems/"><div class="rel-title">The Next AI Infrastructure Layer Is Coordination Governance</div><p class="rel-desc">Subagents parallelize execution and inconsistency alike. Observability explains drift across multi-agent systems; coordination governance prevents it.</p></a></li>
+      <li><a href="/insights/agent-first-ides-need-architectural-invariants/"><div class="rel-title">Why Agent-First IDEs Need Architectural Invariants</div><p class="rel-desc">Agent-first IDEs raise throughput by letting agents act across the repo &mdash; making encoded, enforced architectural invariants more important, not less.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -196,6 +196,19 @@
     .answer-capsule strong { color: var(--accent); }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
   <script type="application/ld+json">
   {
@@ -408,6 +421,16 @@
     <p>Most teams haven't confronted this distinction yet because they're still in the early phase of AI coding adoption, when the volume is low enough that opaque governance is survivable. As agent usage scales, the distinction will become unavoidable. Unreviewed governance state will produce unauditable violations. Opaque constraints will produce irreproducible incidents. Hidden AI memory will produce engineering debt that no one can trace.</p>
 
     <p>The time to establish the right model is before that debt accumulates — not after it.</p>
+
+    <aside class="related-panel" aria-labelledby="related-essays-label">
+      <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+      <ul class="related-list">
+        <li><a href="/insights/memory-is-not-governance/"><div class="rel-title">Memory Is Not Governance</div><p class="rel-desc">Memory, context, retrieval, and governance are four different systems with four different optimization targets &mdash; recall is not constraint enforcement.</p></a></li>
+        <li><a href="/insights/why-rag-fails-for-architectural-governance/"><div class="rel-title">Why RAG Fails for Architectural Governance</div><p class="rel-desc">RAG retrieves similar text; governance requires authoritative, precedence-aware constraint enforcement. They are fundamentally different problems.</p></a></li>
+        <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates can nudge a model toward better output, but they cannot enforce architectural invariants, resolve decision conflicts, or prevent drift.</p></a></li>
+        <li><a href="/insights/machine-readable-pull-requests-agentic-development/"><div class="rel-title">Machine-Readable Pull Requests: The Next Frontier for Agentic Development</div><p class="rel-desc">Pull requests were built for human review; agentic development needs them dual-format, so machines can verify architectural intent, provenance, and policy before review begins.</p></a></li>
+      </ul>
+    </aside>
 
     <div class="article-footer">
       <a href="/insights/" class="back-link">&#8592; Back to Insights</a>

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -122,6 +122,18 @@
       .article-wrap { padding: 3rem 1.25rem 5rem; }
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -234,6 +246,16 @@
     <p>That is the category Mneme is built around. It is also the category the rest of the AI engineering stack is converging toward, whether or not anyone has named it yet.</p>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">AI agent systems are separating into layers &mdash; orchestration, memory, observability, governance, provenance, verification. Production agents need more than runtime.</p></a></li>
+      <li><a href="/insights/ai-agent-governance-two-markets/"><div class="rel-title">AI Agent Governance Is Splitting Into Two Markets</div><p class="rel-desc">Runtime governance protects systems from agent actions; architectural governance protects them from drift &mdash; two distinct markets emerging in parallel.</p></a></li>
+      <li><a href="/insights/generative-ai-software-engineering-stack/"><div class="rel-title">The Generative AI Software Engineering Stack</div><p class="rel-desc">A seven-layer reference frame from foundation models to human oversight. Generation throughput rose; governance and review did not scale at the same rate.</p></a></li>
+      <li><a href="/insights/microsoft-agent-forge-enterprise-ai-infrastructure/"><div class="rel-title">Microsoft Agent Forge Signals the Next Layer of Enterprise AI Infrastructure</div><p class="rel-desc">Once orchestration becomes standardized, differentiation moves upward into governance, verification, and architectural integrity.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -129,6 +129,18 @@
       .article-wrap { padding: 3rem 1.25rem 5rem; }
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -237,6 +249,16 @@
     <p>The infrastructure that closes the gap exists now under a name Liskov would recognize the shape of: architectural governance. Same problem &mdash; modularity protected against implementation leakage. New layer.</p>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/ai-stack-determinism-probabilistic-models/"><div class="rel-title">The AI Stack Is Rebuilding Determinism Around Probabilistic Models</div><p class="rel-desc">Production systems wrap LLMs in deterministic control layers, re-applying classical separation of concerns, explicit contracts, and enforcement gates around probabilistic reasoning.</p></a></li>
+      <li><a href="/insights/models-are-temporary-architectural-intent-is-not/"><div class="rel-title">Models Are Temporary. Architectural Intent Is Not.</div><p class="rel-desc">Models, agents, and IDEs change; architectural intent should not. The case for keeping AI governance outside the model &mdash; and the second lock-in most teams miss.</p></a></li>
+      <li><a href="/insights/why-architectural-governance-needs-precedence-semantics/"><div class="rel-title">Why AI Architectural Governance Needs Precedence Semantics</div><p class="rel-desc">When two architectural decisions overlap, prompts, RAG, and PR review resolve the conflict non-deterministically. Precedence semantics is the layer that makes governance deterministic.</p></a></li>
+      <li><a href="/insights/prompt-engineering-is-not-governance/"><div class="rel-title">Prompt Engineering Is Not Governance</div><p class="rel-desc">Prompt templates can nudge a model toward better output. They cannot enforce architectural invariants, resolve decision conflicts, or prevent drift across a codebase.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -303,6 +303,18 @@
 }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -611,6 +623,15 @@
 
   </div>
 
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/emerging-ai-agent-infrastructure-stack/"><div class="rel-title">The Emerging AI Agent Infrastructure Stack</div><p class="rel-desc">Agent systems are separating into layers &mdash; orchestration, memory, observability, governance, provenance, verification. Production agents need more than a runtime.</p></a></li>
+      <li><a href="/insights/ai-infrastructure-governance-category/"><div class="rel-title">The Next AI Infrastructure Category Is Governance</div><p class="rel-desc">Every infrastructure wave eventually creates a governance layer. Cloud made security, CI/CD made observability, and AI coding agents are now making architectural governance.</p></a></li>
+      <li><a href="/insights/ai-agent-governance-two-markets/"><div class="rel-title">AI Agent Governance Is Splitting Into Two Markets</div><p class="rel-desc">Runtime governance protects systems from what agents do; architectural governance protects them from drift. Two distinct markets forming around the same word.</p></a></li>
+      <li><a href="/insights/mistral-vibe-ai-coding-enterprise-infrastructure/"><div class="rel-title">Mistral Vibe Shows AI Coding Is Becoming Enterprise Infrastructure</div><p class="rel-desc">Spanning terminal agents, IDE extensions, async workflows, and CI/CD, coding agents become a multi-surface execution system &mdash; making governance a platform concern, not a prompt file.</p></a></li>
+    </ul>
+  </aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -152,6 +152,19 @@
     .answer-capsule strong { color: var(--accent); }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
   <script type="application/ld+json">
   {
@@ -365,6 +378,16 @@
     <p>The next step is closing the loop: not just measuring the governance gap, but enforcing decisions before generation happens, so the gap does not accumulate in the first place. The SPACE framework makes the problem legible. Pre-generation governance is how you solve it.</p>
 
     <p>If your Activity numbers look good but your Satisfaction and Communication scores are moving in the wrong direction, the answer is not to slow down AI coding adoption. It is to bring governance upstream — before the code is generated, not after it lands in review.</p>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/dora-metrics-insufficient-for-agentic-development/"><div class="rel-title">DORA Metrics Are Necessary But Insufficient For Agentic Development</div><p class="rel-desc">DORA measures delivery speed, not whether an autonomous engineering system stays architecturally coherent &mdash; governance is the missing layer.</p></a></li>
+      <li><a href="/insights/productivity-paradox-perception-vs-measurement/"><div class="rel-title">METR&rsquo;s AI Productivity Studies: Why AI Coding Feels Fast but Measures Slow</div><p class="rel-desc">Experienced engineers felt faster with AI yet measured 19% slower; closing that perception&ndash;measurement gap is a governance problem.</p></a></li>
+      <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/"><div class="rel-title">Why Code Review Cannot Scale With AI Output</div><p class="rel-desc">AI generates code at 10&ndash;100&times; human pace while review stays linear; the bottleneck needs pre-generation enforcement, not more hiring.</p></a></li>
+      <li><a href="/insights/ai-code-review-does-not-scale-linearly/"><div class="rel-title">AI Code Review Does Not Scale Linearly</div><p class="rel-desc">Generation scales nearly infinitely but reviewer attention does not; the fix is architectural enforcement at generation time, not more reviewers.</p></a></li>
+    </ul>
+  </aside>
 
     <div class="article-footer">
       <a href="/insights/" class="back-link">&#8592; Back to Insights</a>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -259,6 +259,18 @@
 }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -449,6 +461,16 @@
     </aside>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/models-are-temporary-architectural-intent-is-not/"><div class="rel-title">Models Are Temporary. Architectural Intent Is Not.</div><p class="rel-desc">Models, agents, and IDEs change; architectural intent should not. The case for keeping AI governance outside the model &mdash; and the second kind of lock-in most teams miss.</p></a></li>
+      <li><a href="/insights/long-context-windows-governance-infrastructure/"><div class="rel-title">Long Context Does Not Eliminate Governance Infrastructure</div><p class="rel-desc">1M context windows moved filtering into the model and created a new observability gap, making deterministic retrieval, provenance, and governance infrastructure more important, not less.</p></a></li>
+      <li><a href="/insights/ai-stack-determinism-probabilistic-models/"><div class="rel-title">The AI Stack Is Rebuilding Determinism Around Probabilistic Models</div><p class="rel-desc">Production systems still need deterministic control layers around LLMs &mdash; the stack is quietly rebuilding classical patterns like explicit contracts, validation gates, and enforcement.</p></a></li>
+      <li><a href="/insights/ai-infrastructure-governance-category/"><div class="rel-title">The Next AI Infrastructure Category Is Governance</div><p class="rel-desc">Every infrastructure wave eventually grows a governance layer. Cloud got security, CI/CD got observability &mdash; AI coding agents are now creating architectural governance infrastructure.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -267,6 +267,18 @@
 }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -538,6 +550,16 @@
     </div>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/future-of-software-engineering-after-vibe-coding/"><div class="rel-title">The Future of Software Engineering After Vibe Coding</div><p class="rel-desc">Vibe coding changed how software gets built, but production engineering still demands judgment, governance, and accountability in an AI-agent world.</p></a></li>
+      <li><a href="/insights/what-is-harness-engineering/"><div class="rel-title">What Is Harness Engineering? The Execution Layer Between Models and Production</div><p class="rel-desc">The runtime that coordinates an AI model&rsquo;s tool calls, retries, state, and multi-step agent work between the model and production.</p></a></li>
+      <li><a href="/insights/prompt-engineering-vs-harness-engineering/"><div class="rel-title">Prompt Engineering Was About Inputs. Harness Engineering Is About Systems.</div><p class="rel-desc">How AI systems engineering moved from optimizing inputs to designing the agent runtime systems that wrap the model.</p></a></li>
+      <li><a href="/insights/ai-agents-are-not-employees-governance/"><div class="rel-title">Why You Shouldn&rsquo;t Treat AI Agents Like Employees: The Coding-Agent Corollary</div><p class="rel-desc">BCG and HBR find that humanizing AI agents erodes oversight; for coding agents the fix is enforcement, not trust.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -267,6 +267,18 @@
 }
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
+    /* === Related reading === */
+    .related-panel { margin-top: 3.5rem; padding-top: 2.5rem; border-top: 1px solid var(--border); }
+    .related-panel-label { font-family: 'DM Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 1.25rem; }
+    .related-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 10px; overflow: hidden; }
+    .related-list li { margin: 0; }
+    .related-list a { display: block; padding: 1.15rem 1.35rem; background: var(--surface); text-decoration: none; transition: background 0.15s; }
+    .related-list a:hover { background: var(--surface2); }
+    .related-list .rel-title { color: var(--text); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; letter-spacing: -0.005em; transition: color 0.15s; }
+    .related-list .rel-title::after { content: '\2192'; color: var(--accent); opacity: 0.4; transition: opacity 0.15s, transform 0.15s; flex-shrink: 0; }
+    .related-list a:hover .rel-title { color: var(--accent); }
+    .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
+    .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
 </head>
 <body>
@@ -406,6 +418,16 @@
     </div>
 
   </div>
+
+  <aside class="related-panel" aria-labelledby="related-essays-label">
+    <div class="related-panel-label" id="related-essays-label">Related operational essays</div>
+    <ul class="related-list">
+      <li><a href="/insights/goal-driven-agents-architectural-governance/"><div class="rel-title">Goal-Driven Agents Need Architectural Governance</div><p class="rel-desc">As agents shift from prompt-based coding to objective-driven development, governance &mdash; not just tests &mdash; is what keeps the architecture intact.</p></a></li>
+      <li><a href="/insights/prompt-engineering-vs-harness-engineering/"><div class="rel-title">Prompt Engineering Was About Inputs. Harness Engineering Is About Systems.</div><p class="rel-desc">How AI systems engineering moved from optimizing inputs to designing the agent runtime systems that wrap the model.</p></a></li>
+      <li><a href="/insights/constraint-decay-coding-agents-architectural-governance/"><div class="rel-title">Constraint Decay: Why Coding Agents Need Architectural Governance</div><p class="rel-desc">The failure mode where agents satisfy loose functional specs but lose fidelity to architectural patterns as requirements accumulate &mdash; and why governance must run before PR review.</p></a></li>
+      <li><a href="/insights/future-of-software-engineering-after-vibe-coding/"><div class="rel-title">The Future of Software Engineering After Vibe Coding</div><p class="rel-desc">Vibe coding changed how software gets built, but production engineering still demands judgment, governance, and accountability in an AI-agent world.</p></a></li>
+    </ul>
+  </aside>
 
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>


### PR DESCRIPTION
Closes the structural gap surfaced in the related-panel scan: **10 of 100 articles had no related panel at all** (no related-essays panel, no related-reading list).

These pages were missing the related-reading UX surface the other 90 have, and could not reciprocate internal links (which is why `barbara-liskov` and `generative-ai-stack` couldn't be linked-from in the mesh pass).

Each now has a standard 4-link **Related operational essays** panel, curated to topical neighbours, with the `related-list` CSS added (these articles never had it). 10 files, +221 lines, pure insertions (no line-ending churn).

Side effect: under-meshed warnings dropped **13 → 10** as the new outbound links became inbound for neighbours.

Gates: check_insights (exit 0) / nav-footer / sticky-nav / encoding — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)