### PR TITLE
site: add Substack newsletter CTA across insights

### DIFF
--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -439,6 +439,12 @@
     <li><a href="/insights/ai-coding-productivity-gains-rework/">Why AI Coding Productivity Gains Lead to More Rework</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&#x2190; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -217,6 +217,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-formation-engineering-performance-metrics/index.html
+++ b/site/insights/agent-formation-engineering-performance-metrics/index.html
@@ -412,6 +412,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -375,6 +375,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -206,6 +206,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -416,6 +416,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -439,6 +439,12 @@
     </aside>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -493,6 +493,12 @@
     <li><a href="/concepts/model-independent-governance/">Model-Independent Governance</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -586,6 +586,12 @@
     </div>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </article>
 </main>
 

--- a/site/insights/agentic-resource-discovery-agent-governance/index.html
+++ b/site/insights/agentic-resource-discovery-agent-governance/index.html
@@ -424,6 +424,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agentic-workforce-visibility-crisis/index.html
+++ b/site/insights/agentic-workforce-visibility-crisis/index.html
@@ -382,6 +382,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -442,6 +442,12 @@
     <li><a href="/insights/what-is-the-ai-sdlc/">What Is the AI SDLC?</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -395,6 +395,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -466,6 +466,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -511,6 +511,12 @@
     <li><a href="/concepts/enforcement-provenance/">Enforcement Provenance</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -450,6 +450,12 @@
         <li><a href="/insights/github-copilot-usage-based-billing-review-economics/">GitHub Turned AI Code Review Into a Budget Line Item</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -388,6 +388,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
+++ b/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
@@ -369,6 +369,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-coding-agents-life-sciences-governance/index.html
+++ b/site/insights/ai-coding-agents-life-sciences-governance/index.html
@@ -365,6 +365,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -472,6 +472,12 @@
     </div>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </article>
 </main>
 

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -381,6 +381,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-governance-for-regulated-industries/index.html
+++ b/site/insights/ai-governance-for-regulated-industries/index.html
@@ -387,6 +387,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -257,6 +257,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -502,6 +502,12 @@
     </aside>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -490,6 +490,12 @@
       <li><a href="/insights/generative-ai-software-engineering-stack/">The Generative AI Software Engineering Stack</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -450,6 +450,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
+++ b/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
@@ -379,6 +379,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -407,6 +407,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -419,6 +419,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/all/index.html
+++ b/site/insights/all/index.html
@@ -1836,6 +1836,12 @@
   </div>
 
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -400,6 +400,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -416,6 +416,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -227,6 +227,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -718,6 +718,12 @@
         <li><a href="/insights/openai-compatible-apis-are-commoditizing-models/">OpenAI-Compatible APIs Are Commoditizing Models</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -207,6 +207,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -458,6 +458,12 @@
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&#x2190; Back to Insights</a>
 

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -383,6 +383,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -260,6 +260,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -398,6 +398,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -384,6 +384,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/block-builderbot-coordination-governance/index.html
+++ b/site/insights/block-builderbot-coordination-governance/index.html
@@ -367,6 +367,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -383,6 +383,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -369,6 +369,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -485,6 +485,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -406,6 +406,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -503,6 +503,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -580,6 +580,12 @@
     <li><a href="/insights/snowflake-ai-data-engineering-governance-infrastructure/">Snowflake&rsquo;s AI Data Engineering Report</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -451,6 +451,12 @@
         <li><a href="/insights/review-is-not-governance/">Review Is Not Governance</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -380,6 +380,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -486,6 +486,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -606,6 +606,12 @@
     <li><a href="/insights/mistral-vibe-ai-coding-enterprise-infrastructure/">Mistral Vibe and AI Coding Infrastructure</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
+++ b/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
@@ -406,6 +406,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -384,6 +384,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -632,6 +632,12 @@
       <li><a href="/insights/mistral-vibe-ai-coding-enterprise-infrastructure/"><div class="rel-title">Mistral Vibe Shows AI Coding Is Becoming Enterprise Infrastructure</div><p class="rel-desc">Spanning terminal agents, IDE extensions, async workflows, and CI/CD, coding agents become a multi-surface execution system &mdash; making governance a platform concern, not a prompt file.</p></a></li>
     </ul>
   </aside>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -383,6 +383,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -431,6 +431,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -424,6 +424,12 @@
     </div>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </article>
 </main>
 

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -357,6 +357,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -601,6 +601,12 @@
     </aside>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -433,6 +433,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -519,6 +519,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/governance-control-plane-after-agent-frameworks/index.html
+++ b/site/insights/governance-control-plane-after-agent-frameworks/index.html
@@ -397,6 +397,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/governance-layers-for-ai-coding-assistants/index.html
+++ b/site/insights/governance-layers-for-ai-coding-assistants/index.html
@@ -382,6 +382,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -439,6 +439,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -665,6 +665,12 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
     <li><a href="/insights/why-context-alone-doesnt-prevent-architectural-drift/">Why Context Alone Doesn&rsquo;t Prevent Architectural Drift</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -433,6 +433,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -443,6 +443,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -386,6 +386,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -562,6 +562,12 @@
     <a href="/insights/all/" class="read-pill" style="display: inline-block; padding: 0.7rem 1.6rem; font-size: 0.9rem;">View all insights &rarr;</a>
   </div>
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -369,6 +369,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -399,6 +399,12 @@
     </aside>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -426,6 +426,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -750,6 +750,12 @@ mneme check --mode warn</code></pre>
     <li><a href="/insights/cloud-agents-need-architectural-governance/">Cloud Agents Need More Than Durable Execution</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -370,6 +370,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -501,6 +501,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -389,6 +389,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -523,6 +523,12 @@
     <li><a href="/insights/ai-infrastructure-governance-category/">The Next AI Infrastructure Category Is Governance</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -755,6 +755,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -426,6 +426,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -377,6 +377,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -434,6 +434,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -377,6 +377,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -385,6 +385,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -352,6 +352,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -473,6 +473,12 @@
         <li><a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/">Architectural Governance Across Heterogeneous AI Coding Agents</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">← Back to Insights</a>
 

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -392,6 +392,12 @@
     </aside>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/open-knowledge-format-vs-governance/index.html
+++ b/site/insights/open-knowledge-format-vs-governance/index.html
@@ -396,6 +396,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -472,6 +472,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -437,6 +437,12 @@
     <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/">Why Code Review Cannot Scale With AI Output</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -447,6 +447,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -427,6 +427,12 @@
         <li><a href="/insights/why-code-review-cannot-scale-with-ai-output/">Why Code Review Cannot Scale With AI Output</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -522,6 +522,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">← Back to Insights</a>
 

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -470,6 +470,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -494,6 +494,12 @@
     </div>
 
   </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </article>
 </main>
 

--- a/site/insights/recursive-self-improvement-orchestration-problem/index.html
+++ b/site/insights/recursive-self-improvement-orchestration-problem/index.html
@@ -397,6 +397,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -387,6 +387,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -561,6 +561,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -393,6 +393,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -374,6 +374,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -410,6 +410,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -370,6 +370,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -395,6 +395,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -422,6 +422,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -429,6 +429,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/stanford-ai-index-2026-engineering-governance/index.html
+++ b/site/insights/stanford-ai-index-2026-engineering-governance/index.html
@@ -383,6 +383,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/topics/agent-infrastructure/index.html
+++ b/site/insights/topics/agent-infrastructure/index.html
@@ -656,6 +656,12 @@
     </div>
   </div>
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/topics/ai-coding-agents/index.html
+++ b/site/insights/topics/ai-coding-agents/index.html
@@ -555,6 +555,12 @@
     </div>
   </div>
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/topics/architectural-governance/index.html
+++ b/site/insights/topics/architectural-governance/index.html
@@ -578,6 +578,12 @@
     </div>
   </div>
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/topics/engineering-performance/index.html
+++ b/site/insights/topics/engineering-performance/index.html
@@ -511,6 +511,12 @@
     </div>
   </div>
 </div>
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
 </main>
 
 <footer style="border-top: 1px solid var(--border); padding: 3rem 2rem 1.5rem; text-align: left;">

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -503,6 +503,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -375,6 +375,12 @@
       </details>
     </div>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
     <footer class="article-footer">
       <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -376,6 +376,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -700,6 +700,12 @@
     <li><a href="/insights/prompt-engineering-is-not-governance/">Prompt Engineering Is Not Governance</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -646,6 +646,12 @@
     <li><a href="/benchmark/">Mneme Benchmark &mdash; Retrieval &amp; Enforcement Methodology</a></li>
   </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -573,6 +573,12 @@
         <li><a href="/insights/ai-peer-review-context-loss-governance/">AI Peer Review Study: GPT-5.2 and Context Loss</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">← Back to Insights</a>
 

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -488,6 +488,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -505,6 +505,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -420,6 +420,12 @@
         <li><a href="/insights/shared-memory-is-not-shared-intent/">Shared Memory Is Not Shared Intent</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
 

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -584,6 +584,12 @@
         <li><a href="/insights/long-context-windows-governance-infrastructure/">Long Context Does Not Eliminate Governance Infrastructure</a></li>
     </ul>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">← Back to Insights</a>
 

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -387,6 +387,12 @@
     </ul>
   </aside>
 
+<aside aria-label="Mneme HQ newsletter" style="max-width:760px;margin:3rem auto;padding:1.5rem 1.75rem;border:1px solid var(--border2);border-radius:10px;background:rgba(200,240,96,0.03);">
+  <div style="font-family:'DM Mono',monospace;font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin-bottom:0.5rem;">Newsletter</div>
+  <h3 style="font-family:'Inter',sans-serif;font-size:1.05rem;font-weight:600;color:var(--text);margin:0 0 0.4rem;">Engineering governance for AI-assisted development</h3>
+  <p style="font-size:0.9rem;color:var(--muted);margin:0 0 1rem;line-height:1.5;">New essays on architectural intent, engineering standards, agent coordination, and knowledge continuity. Delivered as they publish.</p>
+  <a href="https://mnemehq.substack.com/" target="_blank" rel="noopener" style="display:inline-block;padding:0.6rem 1.3rem;border:1px solid var(--accent);border-radius:6px;color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82rem;text-decoration:none;">Subscribe on Substack &rarr;</a>
+</aside>
   <footer class="article-footer">
     <a href="/insights/" class="back-link">&larr; Back to Insights</a>
     <div class="cta-block">


### PR DESCRIPTION
## What

Adds a newsletter subscribe CTA (link-out to https://mnemehq.substack.com/) across the Insights section.

- **Module:** one self-contained, inline-styled `<aside aria-label="Mneme HQ newsletter">` reusing existing site tokens (`--border2`, `--accent`, `--text`, `--muted`) and site fonts. No new CSS class, no iframe, no third-party scripts. Heading: "Engineering governance for AI-assisted development"; button "Subscribe on Substack →" (`target=_blank rel=noopener`).
- **Placement:** all 114 insight articles (before the final product/pilot `.article-footer` CTA, so the product funnel stays the last conversion action) + the 6 Insights index surfaces (`/insights/`, `/insights/all/`, the 4 topic hubs, before `</main>`). 120 pages total.
- **Not** on the main site homepage (kept focused on product/pilot conversion).

## Validation
`check_insights.py` (green — articles keep their /pilot|/demo funnel link; the Substack link is additive/external), `check_nav_footer.py`, `check_sticky_nav.py`, `check_encoding.py` all pass. Preview-verified: module renders, links to mnemehq.substack.com in a new tab, and sits before the product CTA on articles.

## Follow-up (separate PR)
Add a "Newsletter" link to the footer Connect column (snippet + propagate to all 236 pages, verified by `check_nav_footer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)