### PR TITLE
site: add Newsletter (Substack) link to footer Connect column

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -177,6 +177,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/_snippets/footer.html
+++ b/site/_snippets/footer.html
@@ -51,6 +51,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -1305,6 +1305,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -802,6 +802,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -718,6 +718,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -406,6 +406,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -1071,6 +1071,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/aider/index.html
+++ b/site/compare/aider/index.html
@@ -493,6 +493,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -538,6 +538,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/claude-md/index.html
+++ b/site/compare/claude-md/index.html
@@ -561,6 +561,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -545,6 +545,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -491,6 +491,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -558,6 +558,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -413,6 +413,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/github-copilot/index.html
+++ b/site/compare/github-copilot/index.html
@@ -493,6 +493,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -273,6 +273,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -701,6 +701,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -503,6 +503,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -503,6 +503,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/sourcegraph-cody/index.html
+++ b/site/compare/sourcegraph-cody/index.html
@@ -491,6 +491,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/compare/windsurf/index.html
+++ b/site/compare/windsurf/index.html
@@ -491,6 +491,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/agent-verification/index.html
+++ b/site/concepts/agent-verification/index.html
@@ -512,6 +512,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -538,6 +538,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/agentic-ide-governance/index.html
+++ b/site/concepts/agentic-ide-governance/index.html
@@ -305,6 +305,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -629,6 +629,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -273,6 +273,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -526,6 +526,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/ai-operating-layer/index.html
+++ b/site/concepts/ai-operating-layer/index.html
@@ -500,6 +500,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/antigravity-governance/index.html
+++ b/site/concepts/antigravity-governance/index.html
@@ -255,6 +255,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -756,6 +756,7 @@ PostgreSQL only.</span>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -598,6 +598,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -669,6 +669,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/artifact-provenance/index.html
+++ b/site/concepts/artifact-provenance/index.html
@@ -271,6 +271,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/autonomous-software-engineering-governance/index.html
+++ b/site/concepts/autonomous-software-engineering-governance/index.html
@@ -416,6 +416,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -535,6 +535,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -693,6 +693,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -557,6 +557,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/executable-architectural-intent/index.html
+++ b/site/concepts/executable-architectural-intent/index.html
@@ -478,6 +478,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/execution-surfaces/index.html
+++ b/site/concepts/execution-surfaces/index.html
@@ -530,6 +530,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -768,6 +768,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -827,6 +827,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -552,6 +552,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/governance-provenance/index.html
+++ b/site/concepts/governance-provenance/index.html
@@ -574,6 +574,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -907,6 +907,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/intent-debt/index.html
+++ b/site/concepts/intent-debt/index.html
@@ -486,6 +486,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -487,6 +487,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -265,6 +265,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -565,6 +565,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/objective-driven-development/index.html
+++ b/site/concepts/objective-driven-development/index.html
@@ -514,6 +514,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -561,6 +561,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/reliable-delegation/index.html
+++ b/site/concepts/reliable-delegation/index.html
@@ -570,6 +570,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/runtime-governance/index.html
+++ b/site/concepts/runtime-governance/index.html
@@ -476,6 +476,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/spec-driven-development/index.html
+++ b/site/concepts/spec-driven-development/index.html
@@ -300,6 +300,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -691,6 +691,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -640,6 +640,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -544,6 +544,7 @@ Result: WARN</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -519,6 +519,7 @@ python run.py</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -639,6 +639,7 @@ python run.py</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -476,6 +476,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -416,6 +416,7 @@ Result: WARN</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -627,6 +627,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -520,6 +520,7 @@ python run.py</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -469,6 +469,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -488,6 +488,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -646,6 +646,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -601,6 +601,7 @@ jobs:
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -550,6 +550,7 @@ def create_app():
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -302,6 +302,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -243,6 +243,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -485,6 +485,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -521,6 +521,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -509,6 +509,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -486,6 +486,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -499,6 +499,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -719,6 +719,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1687,6 +1687,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -510,6 +510,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -288,6 +288,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-formation-engineering-performance-metrics/index.html
+++ b/site/insights/agent-formation-engineering-performance-metrics/index.html
@@ -483,6 +483,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -446,6 +446,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -277,6 +277,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -487,6 +487,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -510,6 +510,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -565,6 +565,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -648,6 +648,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agentic-resource-discovery-agent-governance/index.html
+++ b/site/insights/agentic-resource-discovery-agent-governance/index.html
@@ -495,6 +495,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agentic-workforce-visibility-crisis/index.html
+++ b/site/insights/agentic-workforce-visibility-crisis/index.html
@@ -453,6 +453,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -514,6 +514,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -466,6 +466,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -537,6 +537,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -583,6 +583,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -523,6 +523,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -459,6 +459,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
+++ b/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
@@ -440,6 +440,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-coding-agents-life-sciences-governance/index.html
+++ b/site/insights/ai-coding-agents-life-sciences-governance/index.html
@@ -436,6 +436,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -534,6 +534,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -451,6 +451,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-governance-for-regulated-industries/index.html
+++ b/site/insights/ai-governance-for-regulated-industries/index.html
@@ -458,6 +458,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -328,6 +328,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -573,6 +573,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -562,6 +562,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -521,6 +521,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
+++ b/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
@@ -450,6 +450,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -478,6 +478,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -490,6 +490,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/all/index.html
+++ b/site/insights/all/index.html
@@ -1897,6 +1897,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -471,6 +471,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -487,6 +487,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -298,6 +298,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -790,6 +790,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -278,6 +278,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -530,6 +530,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -454,6 +454,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -331,6 +331,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -469,6 +469,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -455,6 +455,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/block-builderbot-coordination-governance/index.html
+++ b/site/insights/block-builderbot-coordination-governance/index.html
@@ -438,6 +438,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -454,6 +454,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -440,6 +440,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -556,6 +556,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -477,6 +477,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -574,6 +574,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -652,6 +652,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -523,6 +523,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -452,6 +452,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -557,6 +557,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -678,6 +678,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
+++ b/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
@@ -477,6 +477,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -455,6 +455,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -704,6 +704,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -454,6 +454,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -502,6 +502,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -486,6 +486,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -427,6 +427,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -672,6 +672,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -504,6 +504,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -590,6 +590,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/governance-control-plane-after-agent-frameworks/index.html
+++ b/site/insights/governance-control-plane-after-agent-frameworks/index.html
@@ -468,6 +468,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/governance-layers-for-ai-coding-assistants/index.html
+++ b/site/insights/governance-layers-for-ai-coding-assistants/index.html
@@ -453,6 +453,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -510,6 +510,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -737,6 +737,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -504,6 +504,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -514,6 +514,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -457,6 +457,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -623,6 +623,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -440,6 +440,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -470,6 +470,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -497,6 +497,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -822,6 +822,7 @@ mneme check --mode warn</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -441,6 +441,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -572,6 +572,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -460,6 +460,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -595,6 +595,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -827,6 +827,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -497,6 +497,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -448,6 +448,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -505,6 +505,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -448,6 +448,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -456,6 +456,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -423,6 +423,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -547,6 +547,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -463,6 +463,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/open-knowledge-format-vs-governance/index.html
+++ b/site/insights/open-knowledge-format-vs-governance/index.html
@@ -467,6 +467,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -544,6 +544,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -509,6 +509,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -518,6 +518,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -500,6 +500,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -594,6 +594,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -541,6 +541,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -556,6 +556,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/recursive-self-improvement-orchestration-problem/index.html
+++ b/site/insights/recursive-self-improvement-orchestration-problem/index.html
@@ -468,6 +468,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -459,6 +459,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -633,6 +633,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -464,6 +464,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -445,6 +445,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -481,6 +481,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -441,6 +441,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -466,6 +466,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -493,6 +493,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -500,6 +500,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/stanford-ai-index-2026-engineering-governance/index.html
+++ b/site/insights/stanford-ai-index-2026-engineering-governance/index.html
@@ -454,6 +454,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/topics/agent-infrastructure/index.html
+++ b/site/insights/topics/agent-infrastructure/index.html
@@ -717,6 +717,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/topics/ai-coding-agents/index.html
+++ b/site/insights/topics/ai-coding-agents/index.html
@@ -616,6 +616,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/topics/architectural-governance/index.html
+++ b/site/insights/topics/architectural-governance/index.html
@@ -639,6 +639,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/topics/engineering-performance/index.html
+++ b/site/insights/topics/engineering-performance/index.html
@@ -572,6 +572,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -574,6 +574,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -445,6 +445,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -447,6 +447,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -772,6 +772,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -718,6 +718,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -645,6 +645,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -559,6 +559,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -577,6 +577,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -492,6 +492,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -656,6 +656,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -458,6 +458,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -506,6 +506,7 @@ Result: WARN</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/antigravity/index.html
+++ b/site/integrations/antigravity/index.html
@@ -299,6 +299,7 @@ CI records the governance result</pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -666,6 +666,7 @@ jobs:
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -587,6 +587,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -442,6 +442,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -450,6 +450,7 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -464,6 +464,7 @@ jobs:
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -452,6 +452,7 @@ mneme-governance:
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -497,6 +497,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -530,6 +530,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/microsoft-agent-forge/index.html
+++ b/site/integrations/microsoft-agent-forge/index.html
@@ -427,6 +427,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/opencode/index.html
+++ b/site/integrations/opencode/index.html
@@ -440,6 +440,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -367,6 +367,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -505,6 +505,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/integrations/warp/index.html
+++ b/site/integrations/warp/index.html
@@ -405,6 +405,7 @@ mneme check --mode warn   # try locally first</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -552,6 +552,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -399,6 +399,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -442,6 +442,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/qa-glossary/index.html
+++ b/site/qa-glossary/index.html
@@ -770,6 +770,7 @@ Body markdown follows.</code></pre>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -481,6 +481,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -466,6 +466,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/fastapi-governance/index.html
+++ b/site/supported-languages/fastapi-governance/index.html
@@ -388,6 +388,7 @@ router = APIRouter(prefix=<span class="kw">"/admin"</span>)  <span class="cm"># 
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -336,6 +336,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -332,6 +332,7 @@ cron.schedule(<span class="kw">"0 3 * * *"</span>, <span class="kw">async</span>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -357,6 +357,7 @@ app = Celery(<span class="kw">'tasks'</span>, broker=<span class="kw">'redis://l
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/spring-boot-governance/index.html
+++ b/site/supported-languages/spring-boot-governance/index.html
@@ -387,6 +387,7 @@ http.csrf(csrf -&gt; csrf.disable())
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/terraform-governance/index.html
+++ b/site/supported-languages/terraform-governance/index.html
@@ -399,6 +399,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -347,6 +347,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/ci-governance-for-ai-generated-code/index.html
+++ b/site/use-cases/ci-governance-for-ai-generated-code/index.html
@@ -445,6 +445,7 @@ mneme-check:
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -613,6 +613,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -538,6 +538,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -538,6 +538,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -699,6 +699,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -620,6 +620,7 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -575,6 +575,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -624,6 +624,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/works-with/antigravity/index.html
+++ b/site/works-with/antigravity/index.html
@@ -244,6 +244,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/works-with/claude-marketplace/index.html
+++ b/site/works-with/claude-marketplace/index.html
@@ -396,6 +396,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/works-with/devin/index.html
+++ b/site/works-with/devin/index.html
@@ -441,6 +441,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -723,6 +723,7 @@
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
+        <li><a href="https://mnemehq.substack.com/" target="_blank" rel="noopener">Newsletter</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## What

Follow-up to #195. Adds a **Newsletter** link (link-out to https://mnemehq.substack.com/, new tab) to the footer Connect column, after YouTube.

- Updated the canonical `site/_snippets/footer.html` and propagated the identical one-line `<li>` to all 235 pages that inline the footer.
- One insertion per file (236 files changed, +236 lines) — minimal, reviewable diff.
- `nav.html` correctly skipped (no Connect column).

## Validation
`check_nav_footer.py` green (all 235 pages match the updated snippet — this lint guarantees completeness), plus `check_encoding.py`, `check_sticky_nav.py`, `check_insights.py`. Preview-verified the link renders in the footer and resolves to mnemehq.substack.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)