### PR TITLE
ci: harden deploy verification against transient-timeout flake

### DIFF
--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -1,0 +1,45 @@
+name: test deploy verification helpers
+
+# Runs the unit tests for the pure post-deploy verification helpers
+# (scripts/deploy_verify.py) so the changed-URL / stale-200 / transient
+# classification logic cannot regress. deploy_site.py itself runs the deploy at
+# import time and is not importable in tests, which is why the logic lives in a
+# separate, tested module.
+#
+# Validator: scripts/test_deploy_verify.py
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/deploy_verify.py'
+      - 'scripts/test_deploy_verify.py'
+      - 'scripts/deploy_site.py'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/deploy_verify.py'
+      - 'scripts/test_deploy_verify.py'
+      - 'scripts/deploy_site.py'
+
+permissions:
+  contents: read
+
+jobs:
+  test-deploy-verify:
+    name: test_deploy_verify.py
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run deploy-verify unit tests
+        run: python scripts/test_deploy_verify.py
+
+      - name: Syntax-check deploy_site.py
+        run: python -m py_compile scripts/deploy_site.py

--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -1,6 +1,10 @@
 import urllib.request, urllib.parse, urllib.error, ssl, json, os, subprocess, sys, xml.etree.ElementTree as ET
 from pathlib import Path
 
+# Pure verification helpers live alongside this script (importable + unit-tested).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from deploy_verify import content_needle, classify  # noqa: E402
+
 # Load .env if present (never committed — credentials stay local)
 _env = Path(__file__).parent.parent / '.env'
 if _env.exists():
@@ -311,43 +315,105 @@ import time as _time
 if CF_TOKEN and CF_ZONE_ID:
     _time.sleep(3)  # brief pause for CF edge nodes to propagate the purge
 
-# ── Post-deploy verification: every sitemap URL must return 200 ───────────────
-print("\n-- Post-deploy verification --")
+# ── Post-deploy verification ──────────────────────────────────────────────────
+# Two tiers, so a slow unrelated page can never fail a clean delta deploy:
+#
+#   1. Changed URLs (this deploy's delta) are verified STRICTLY: each must return
+#      200 AND serve the bytes we just uploaded. A 404/410, or a "stale 200" (the
+#      old page still served because an optimistic upload never landed), is a
+#      real failure that blocks the marker so the next run retries the delta.
+#      Transient timeouts / 5xx are retried, then downgraded to a warning -- they
+#      are infra noise, not a bad deploy.
+#   2. Every other sitemap URL is a best-effort health probe: retried, and any
+#      non-200 is reported as a WARNING only. (A single slow /demo/ page used to
+#      abort an otherwise-perfect deploy.)
+VERIFY_TIMEOUT = 30
+VERIFY_RETRIES = 3
+
+def _verify_fetch(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req, timeout=VERIFY_TIMEOUT) as r:
+        return r.status, r.read()
+
+# Fingerprint each changed HTML page: the uploaded content up to </body>.
+changed_fp = {}
+for _lp, _sd, _label in files_to_upload:
+    _u = label_to_url(_label)
+    if _u and _label.endswith('.html'):
+        try:
+            changed_fp[_u] = content_needle(Path(_lp).read_bytes())
+        except OSError:
+            pass
+
+print("\n-- Post-deploy verification: changed URLs (strict) --")
+hard_failures = []
+for url, needle in changed_fp.items():
+    verdict, detail = 'warn', 'no response'
+    for attempt in range(VERIFY_RETRIES):
+        try:
+            status, body = _verify_fetch(url)
+        except urllib.error.HTTPError as e:
+            status, body = e.code, b''
+        except Exception as e:
+            verdict, detail = 'warn', f'transient: {e}'
+            _time.sleep(2 + attempt * 2)
+            continue
+        verdict, detail = classify(status, body, needle)
+        if verdict == 'ok':
+            break
+        if verdict == 'fail' and status in (404, 410):
+            break  # definitively missing; retrying will not help
+        _time.sleep(2 + attempt * 2)  # retry 5xx; re-check a stale 200 after cache propagation
+    if verdict == 'ok':
+        print(f'OK    {url}')
+    elif verdict == 'fail':
+        print(f'FAIL  {url}  -- {detail}')
+        hard_failures.append((url, detail))
+    else:
+        print(f'WARN  {url}  -- {detail} (not blocking)')
+
+if hard_failures:
+    print(f"\nVERIFICATION FAILED - {len(hard_failures)} changed URL(s) not serving fresh content:")
+    for url, detail in hard_failures:
+        print(f'  {detail}  {url}')
+    raise SystemExit(1)
+
+# Best-effort health probe of the rest of the sitemap (warn-only, never blocks).
+print("\n-- Sitemap health probe (warn-only) --")
 sitemap_path = os.path.join(BASE_LOCAL, 'sitemap.xml')
 tree = ET.parse(sitemap_path)
 sitemap_urls = [loc.text for loc in tree.findall('.//{http://www.sitemaps.org/schemas/sitemap/0.9}loc')]
-
-verify_failures = []
+probe_warnings = []
 for url in sitemap_urls:
-    try:
-        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-        with urllib.request.urlopen(req, timeout=10) as r:
-            status = r.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    except Exception as e:
-        status = str(e)
-    ok = status == 200
-    print(f'{"OK" if ok else "FAIL"}  {status}  {url}')
-    if not ok:
-        verify_failures.append((url, status))
+    if url in changed_fp:
+        continue  # already strictly verified above
+    status = None
+    for attempt in range(VERIFY_RETRIES):
+        try:
+            status, _ = _verify_fetch(url)
+        except urllib.error.HTTPError as e:
+            status = e.code
+        except Exception as e:
+            status = str(e)
+        if status == 200:
+            break
+        _time.sleep(1 + attempt)
+    if status != 200:
+        probe_warnings.append((url, status))
 
-if verify_failures:
-    print(f"\nVERIFICATION FAILED - {len(verify_failures)} URL(s) not returning 200:")
-    for url, status in verify_failures:
+if probe_warnings:
+    print(f"[WARN] {len(probe_warnings)} sitemap URL(s) not returning 200 (not blocking deploy):")
+    for url, status in probe_warnings:
         print(f'  {status}  {url}')
-    raise SystemExit(1)
+else:
+    print(f"[OK] all {len(sitemap_urls)} sitemap URLs healthy")
 
-print(f"\n[OK] All {len(sitemap_urls)} sitemap URLs verified - deploy complete")
+print(f"\n[OK] Deploy verified -- {len(changed_fp)} changed URL(s) serving fresh content")
 
-# Advance the deploy marker ONLY after every sitemap URL has verified 200.
-# Previously tag_deployed() ran right after upload, before this verification --
-# so a deploy whose pages never actually served (silent upload miss, or an
-# "optimistic" flaky upload) still moved the marker, and the next delta deploy
-# skipped re-uploading them. That left 9 pages 404 on the origin for ~3 days
-# while the marker claimed they were deployed. Tagging here means a failed
-# verification leaves the marker behind, so the next deploy retries the same
-# delta and re-uploads the missing pages.
+# Advance the deploy marker ONLY after the strict tier passed. A failed strict
+# verification leaves the marker behind so the next deploy retries the same delta
+# -- this is what stops a silent upload-miss from sitting stale while the marker
+# claims it shipped (previously 9 pages 404'd on the origin for ~3 days).
 tag_deployed()
 
 

--- a/scripts/deploy_verify.py
+++ b/scripts/deploy_verify.py
@@ -1,0 +1,48 @@
+"""Pure helpers for post-deploy verification.
+
+No side effects and no network, so they are safe to import in unit tests (unlike
+deploy_site.py, which runs the deploy at import time). The deploy script wires
+these into its retry/HTTP loop.
+"""
+from __future__ import annotations
+
+
+def norm(b: bytes) -> bytes:
+    """Normalize newlines and per-line trailing whitespace.
+
+    Lets us compare a local file against the served response without benign
+    encoding differences (CRLF vs LF, trailing spaces) registering as changes.
+    """
+    return b"\n".join(line.rstrip() for line in b.replace(b"\r\n", b"\n").split(b"\n")).strip()
+
+
+def content_needle(local_bytes: bytes) -> bytes:
+    """The uploaded page content we expect to find in the live response.
+
+    Everything up to ``</body>``. Cloudflare appends its analytics beacon just
+    before ``</body>``, so we match this prefix as a substring rather than
+    comparing the whole body byte-for-byte (which would false-fail on the
+    injected beacon).
+    """
+    return norm(local_bytes).split(b"</body>")[0]
+
+
+def classify(status, body: bytes, needle: bytes):
+    """Classify one verification fetch of a CHANGED url.
+
+    Returns ``(verdict, detail)`` where verdict is one of:
+      - ``"ok"``   -- 200 and the uploaded content is present
+      - ``"fail"`` -- page missing (404/410) or a "stale 200" (served content
+                      does not contain what we uploaded; an optimistic upload
+                      never landed). A real failure: it must block the marker.
+      - ``"warn"`` -- transient (5xx or other non-200). The caller retries and,
+                      if it never clears, tolerates it rather than failing the
+                      deploy, because it is infra noise rather than a bad deploy.
+    """
+    if status in (404, 410):
+        return "fail", f"HTTP {status} (page missing)"
+    if status != 200:
+        return "warn", f"HTTP {status}"
+    if needle and needle in norm(body):
+        return "ok", ""
+    return "fail", "stale 200 (served content does not match uploaded file)"

--- a/scripts/test_deploy_verify.py
+++ b/scripts/test_deploy_verify.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for the pure post-deploy verification helpers (deploy_verify).
+
+Runnable directly (`python scripts/test_deploy_verify.py`) and as pytest.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from deploy_verify import norm, content_needle, classify  # noqa: E402
+
+PAGE = b"<!DOCTYPE html>\n<html>\n<head><title>X</title></head>\n<body>\n<p>fresh content</p>\n</body>\n</html>\n"
+# What Cloudflare actually serves: identical page with the analytics beacon
+# injected just before </body>.
+LIVE_OK = PAGE.replace(
+    b"</body>",
+    b'<script defer src="https://static.cloudflareinsights.com/beacon.min.js"></script>\n</body>',
+)
+LIVE_STALE = b"<!DOCTYPE html>\n<html>\n<head><title>X</title></head>\n<body>\n<p>OLD content</p>\n</body>\n</html>\n"
+
+
+def test_norm_tolerates_crlf_and_trailing_ws():
+    assert norm(b"a \r\nb\t\r\n") == norm(b"a\nb")
+
+
+def test_needle_is_content_before_body():
+    needle = content_needle(PAGE)
+    assert b"fresh content" in needle
+    assert b"</body>" not in needle
+
+
+def test_fresh_page_with_cf_beacon_is_ok():
+    needle = content_needle(PAGE)
+    assert classify(200, LIVE_OK, needle) == ("ok", "")
+
+
+def test_identical_page_is_ok():
+    needle = content_needle(PAGE)
+    assert classify(200, PAGE, needle)[0] == "ok"
+
+
+def test_stale_200_is_fail():
+    needle = content_needle(PAGE)
+    verdict, detail = classify(200, LIVE_STALE, needle)
+    assert verdict == "fail"
+    assert "stale" in detail
+
+
+def test_404_is_fail():
+    assert classify(404, b"", content_needle(PAGE))[0] == "fail"
+
+
+def test_410_is_fail():
+    assert classify(410, b"", content_needle(PAGE))[0] == "fail"
+
+
+def test_5xx_is_warn_not_fail():
+    # transient server error must not hard-fail the deploy
+    assert classify(503, b"", content_needle(PAGE))[0] == "warn"
+    assert classify(502, b"", content_needle(PAGE))[0] == "warn"
+
+
+def _run():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"PASS  {fn.__name__}")
+    print(f"\n{len(fns)} passed")
+
+
+if __name__ == "__main__":
+    _run()


### PR DESCRIPTION
## Problem

The merge-deploy of #197 **failed** even though all 21 files uploaded fine. Root cause in `scripts/deploy_site.py`:

- Post-deploy verification fetched **every** sitemap URL (~232), sequentially, `timeout=10`, **no retries**. One transient read-timeout on *any* page (the 4 that failed were `/demo/`, `/concepts/intent-debt/`, etc. — none touched by the PR) aborts the whole deploy via `SystemExit(1)`.
- The abort left the marker un-advanced (correct), but trained us to "just re-run."
- Worse blind spot: verification only checked **HTTP 200**, never content. Combined with the optimistic upload (`return 'OK' # verification will catch a real miss`), a silently-missed upload that still serves the **old** page (200) would *pass* and advance the marker — a stale page believed-deployed, invisible because it's 200 not 404.

## Fix

Two-tier verification:

1. **Changed (delta) URLs — strict, with retries.** Each must return 200 **and** serve the bytes we uploaded. Empirically, Cloudflare leaves the page byte-identical and only appends its analytics beacon before `</body>`, so we match *content-up-to-`</body>`* as a substring (tolerant of the beacon, CRLF/LF, trailing whitespace). A **404/410 or a "stale 200" hard-fails** and blocks the marker; **transient timeouts/5xx are retried then warned**, never failing the deploy.
2. **Rest of sitemap — warn-only health probe.** Retried; any non-200 is a WARNING, never a deploy gate.

Pure logic extracted to `scripts/deploy_verify.py` with unit tests in `scripts/test_deploy_verify.py` (deploy_site.py runs the deploy at import time, so it can't be imported in tests).

## Verification
- `python -m py_compile scripts/deploy_site.py` → clean
- `python scripts/test_deploy_verify.py` → 8 passed (fresh+beacon→ok, stale-200→fail, 404/410→fail, 5xx→warn)
- Live integration against mnemehq.com: the 3 expanded pages classify **fresh→ok**, and a simulated stale body classifies **fail (stale 200)** — i.e. it would have caught the exact silent-staleness failure mode.

## Note
Supersedes two stale branches — `ci/harden-deploy-marker` (its marker-after-verification change is already in `main`) and `fix/deploy-script-syntax-error` (its IndexNow typo fix is already in `main`). I'll close both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)