### PR TITLE
feat(site): consent-gated RB2B visitor-identification pixel (US-only, high-intent)

### DIFF
--- a/scripts/sync_shared.py
+++ b/scripts/sync_shared.py
@@ -4,8 +4,14 @@ Sync canonical nav and footer snippets across all site HTML files.
 Skips og-*.html templates and site/_snippets/.
 Run before deploy or any time snippets change.
 """
+import os
 import re
 from pathlib import Path
+try:
+    from dotenv import load_dotenv   # RB2B_PIXEL_ID lives in .env (not committed)
+    load_dotenv()
+except Exception:
+    pass
 
 SITE = Path(__file__).parent.parent / "site"
 SNIPPETS = SITE / "_snippets"
@@ -24,6 +30,25 @@ FOOTER_PAT = re.compile(r"<footer>(.*?)</footer>", re.DOTALL)
 
 HAMBURGER_JS_BLOCK = f"<script>\n{HAMBURGER_JS}\n</script>"
 ACTIVE_JS_BLOCK    = f"<script><!-- nav-active -->\n{ACTIVE_JS}\n</script>"
+
+# ── Marketing pixels (RB2B only for now; Google Ads + LinkedIn are GTM-managed) ───────────────
+MK_HEAD = load("marketing-head.html")
+MK_BODY = load("marketing-body.html")
+
+RB2B_ID = os.environ.get("RB2B_PIXEL_ID", "").strip()
+RB2B_OK = bool(re.fullmatch(r"[A-Za-z0-9]{4,}", RB2B_ID))
+if RB2B_ID and not RB2B_OK:
+    print(f"  WARN: RB2B_PIXEL_ID={RB2B_ID!r} is not [A-Za-z0-9]{{4,}} — RB2B disabled")
+
+if RB2B_OK:
+    MK_HEAD_BLOCK = "<!-- mneme:marketing-head:start -->\n" + MK_HEAD.replace("__RB2B_PIXEL_ID__", RB2B_ID) + "\n<!-- mneme:marketing-head:end -->"
+    MK_BODY_BLOCK = "<!-- mneme:marketing-body:start -->\n" + MK_BODY + "\n<!-- mneme:marketing-body:end -->"
+else:
+    MK_HEAD_BLOCK = MK_BODY_BLOCK = ""   # nothing to consent to -> inject nothing / clean up existing
+    print("  RB2B disabled (RB2B_PIXEL_ID unset/invalid) — consent head + banner not injected")
+
+MK_HEAD_PAT = re.compile(r"\n?<!-- mneme:marketing-head:start -->.*?<!-- mneme:marketing-head:end -->", re.DOTALL)
+MK_BODY_PAT = re.compile(r"<!-- mneme:marketing-body:start -->.*?<!-- mneme:marketing-body:end -->\n?", re.DOTALL)
 
 updated = []
 skipped_og = []
@@ -74,6 +99,26 @@ for html in sorted(SITE.rglob("*.html")):
 
     # 5. Replace footer (plain <footer> only, not <footer class=...>)
     text = FOOTER_PAT.sub(adapt(FOOTER_HTML), text)
+
+    # 6. Consent controller + RB2B — after GTM in <head>, idempotent via markers.
+    #    lambda repl avoids re's backslash interpretation of the snippet JS.
+    if MK_HEAD_PAT.search(text):
+        text = MK_HEAD_PAT.sub((lambda _m: "\n" + adapt(MK_HEAD_BLOCK)) if MK_HEAD_BLOCK else (lambda _m: ""), text)
+    elif MK_HEAD_BLOCK and "<!-- End Google Tag Manager -->" in text:
+        text = text.replace("<!-- End Google Tag Manager -->",
+                            "<!-- End Google Tag Manager -->\n" + adapt(MK_HEAD_BLOCK), 1)
+    elif MK_HEAD_BLOCK and "</head>" in text:
+        text = text.replace("</head>", adapt(MK_HEAD_BLOCK) + adapt("\n") + "</head>", 1)
+    elif MK_HEAD_BLOCK:
+        print(f"  WARN: no head anchor in {html.relative_to(SITE)} — consent head not injected")
+
+    # 7. Consent banner — before </body>, idempotent via markers.
+    if MK_BODY_PAT.search(text):
+        text = MK_BODY_PAT.sub((lambda _m: adapt(MK_BODY_BLOCK) + adapt("\n")) if MK_BODY_BLOCK else (lambda _m: ""), text)
+    elif MK_BODY_BLOCK and "</body>" in text:
+        text = text.replace("</body>", adapt(MK_BODY_BLOCK) + adapt("\n") + "</body>", 1)
+    elif MK_BODY_BLOCK:
+        print(f"  WARN: no </body> in {html.relative_to(SITE)} — consent banner not injected")
 
     if text != original:
         html.write_bytes(text.encode("utf-8"))

--- a/site/404.html
+++ b/site/404.html
@@ -73,6 +73,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -244,5 +326,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/_snippets/footer.html
+++ b/site/_snippets/footer.html
@@ -42,6 +42,7 @@
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/_snippets/marketing-body.html
+++ b/site/_snippets/marketing-body.html
@@ -1,0 +1,31 @@
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>

--- a/site/_snippets/marketing-head.html
+++ b/site/_snippets/marketing-head.html
@@ -1,0 +1,80 @@
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("__RB2B_PIXEL_ID__");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <!-- Structured Data -->
@@ -1382,5 +1464,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -890,5 +972,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -806,5 +888,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -494,5 +576,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -35,6 +35,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <style>
@@ -1146,5 +1228,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/aider/index.html
+++ b/site/compare/aider/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -557,5 +639,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -615,5 +697,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/claude-md/index.html
+++ b/site/compare/claude-md/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -638,5 +720,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -622,5 +704,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -555,5 +637,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -635,5 +717,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -197,6 +197,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -490,5 +572,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/github-copilot/index.html
+++ b/site/compare/github-copilot/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -557,5 +639,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -133,6 +133,88 @@
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--text); }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -337,5 +419,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -778,5 +860,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -567,5 +649,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -578,5 +660,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/sourcegraph-cody/index.html
+++ b/site/compare/sourcegraph-cody/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -555,5 +637,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/compare/windsurf/index.html
+++ b/site/compare/windsurf/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -555,5 +637,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/agent-verification/index.html
+++ b/site/concepts/agent-verification/index.html
@@ -201,6 +201,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -570,5 +652,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -626,5 +708,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/agentic-ide-governance/index.html
+++ b/site/concepts/agentic-ide-governance/index.html
@@ -144,6 +144,88 @@
     .platform-chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1.25rem 0 2rem; }
     .platform-chips span { background: var(--surface); border: 1px solid var(--border); color: var(--text); padding: 0.5rem 0.95rem; border-radius: 100px; font-size: 0.82rem; font-family: 'DM Mono', monospace; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -351,5 +433,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -31,6 +31,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -697,5 +779,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -126,6 +126,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -319,5 +401,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -614,5 +696,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/ai-operating-layer/index.html
+++ b/site/concepts/ai-operating-layer/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -577,5 +659,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/antigravity-governance/index.html
+++ b/site/concepts/antigravity-governance/index.html
@@ -127,6 +127,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -332,5 +414,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -844,5 +926,40 @@ PostgreSQL only.</span>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -34,6 +34,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -686,5 +768,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -757,5 +839,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/artifact-provenance/index.html
+++ b/site/concepts/artifact-provenance/index.html
@@ -128,6 +128,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -317,5 +399,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/autonomous-software-engineering-governance/index.html
+++ b/site/concepts/autonomous-software-engineering-governance/index.html
@@ -189,6 +189,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -493,5 +575,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -623,5 +705,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -781,5 +863,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -255,6 +255,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -650,5 +732,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/executable-architectural-intent/index.html
+++ b/site/concepts/executable-architectural-intent/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -555,5 +637,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/execution-surfaces/index.html
+++ b/site/concepts/execution-surfaces/index.html
@@ -214,6 +214,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -588,5 +670,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -34,6 +34,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -856,5 +938,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -915,5 +997,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -32,6 +32,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -645,5 +727,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/governance-provenance/index.html
+++ b/site/concepts/governance-provenance/index.html
@@ -200,6 +200,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -632,5 +714,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -995,5 +1077,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/intent-debt/index.html
+++ b/site/concepts/intent-debt/index.html
@@ -31,6 +31,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -554,5 +636,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -564,5 +646,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -129,6 +129,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -311,5 +393,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -254,6 +254,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -658,5 +740,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/objective-driven-development/index.html
+++ b/site/concepts/objective-driven-development/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -591,5 +673,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -276,6 +276,88 @@
   }
 }
 </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -654,5 +736,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/reliable-delegation/index.html
+++ b/site/concepts/reliable-delegation/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -693,5 +775,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/runtime-governance/index.html
+++ b/site/concepts/runtime-governance/index.html
@@ -31,6 +31,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -553,5 +635,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/spec-driven-development/index.html
+++ b/site/concepts/spec-driven-development/index.html
@@ -144,6 +144,88 @@
     .platform-chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1.25rem 0 2rem; }
     .platform-chips span { background: var(--surface); border: 1px solid var(--border); color: var(--text); padding: 0.5rem 0.95rem; border-radius: 100px; font-size: 0.82rem; font-family: 'DM Mono', monospace; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -346,5 +428,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -779,5 +861,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <!-- Structured Data -->
@@ -717,5 +799,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -229,6 +229,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -712,5 +794,40 @@ Result: WARN</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -226,6 +226,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -588,5 +670,40 @@ python run.py</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -255,6 +255,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -819,6 +901,41 @@ python run.py</code></pre>
     }
   })();
   </script>
+
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
 
 </body>
 </html>

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -553,5 +635,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -198,6 +198,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -581,5 +663,40 @@ Result: WARN</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -726,5 +808,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -227,6 +227,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -589,5 +671,40 @@ python run.py</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -546,5 +628,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -565,5 +647,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -35,6 +35,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <style>
@@ -719,5 +801,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -678,5 +760,40 @@ jobs:
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -627,5 +709,40 @@ def create_app():
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -138,6 +138,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -390,5 +472,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -117,6 +117,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -301,5 +383,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -553,5 +635,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -624,5 +706,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -585,5 +667,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -564,5 +646,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -577,5 +659,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <!-- Structured Data -->
@@ -796,5 +878,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -32,6 +32,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -1826,5 +1908,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -589,5 +671,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -127,6 +127,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -326,5 +408,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-formation-engineering-performance-metrics/index.html
+++ b/site/insights/agent-formation-engineering-performance-metrics/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -560,5 +642,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -523,5 +605,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -127,6 +127,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -315,5 +397,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -564,5 +646,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -587,5 +669,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -653,5 +735,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -32,6 +32,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -725,5 +807,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agentic-resource-discovery-agent-governance/index.html
+++ b/site/insights/agentic-resource-discovery-agent-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -572,5 +654,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agentic-workforce-visibility-crisis/index.html
+++ b/site/insights/agentic-workforce-visibility-crisis/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -530,5 +612,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -602,5 +684,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -543,5 +625,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -614,5 +696,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -671,5 +753,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -600,5 +682,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -536,5 +618,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
+++ b/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -517,5 +599,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-coding-agents-life-sciences-governance/index.html
+++ b/site/insights/ai-coding-agents-life-sciences-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -513,5 +595,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -599,5 +681,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -528,5 +610,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-governance-for-regulated-industries/index.html
+++ b/site/insights/ai-governance-for-regulated-industries/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -535,5 +617,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -135,6 +135,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -366,5 +448,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -650,5 +732,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -31,6 +31,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -639,5 +721,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -598,5 +680,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
+++ b/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -527,5 +609,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -555,5 +637,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -567,5 +649,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/all/index.html
+++ b/site/insights/all/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -1998,5 +2080,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -548,5 +630,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -564,5 +646,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -134,6 +134,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -336,5 +418,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -867,5 +949,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -115,6 +115,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -316,5 +398,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -618,5 +700,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -531,5 +613,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -142,6 +142,88 @@
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -369,5 +451,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -546,5 +628,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -532,5 +614,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/block-builderbot-coordination-governance/index.html
+++ b/site/insights/block-builderbot-coordination-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -515,5 +597,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -531,5 +613,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -517,5 +599,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -633,5 +715,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -554,5 +636,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -651,5 +733,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -740,5 +822,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -600,5 +682,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -529,5 +611,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -634,5 +716,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -30,6 +30,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -755,5 +837,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
+++ b/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -554,5 +636,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -532,5 +614,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -781,5 +863,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -531,5 +613,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -579,5 +661,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -38,6 +38,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -551,5 +633,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -504,5 +586,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -749,5 +831,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -581,5 +663,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -667,5 +749,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/governance-control-plane-after-agent-frameworks/index.html
+++ b/site/insights/governance-control-plane-after-agent-frameworks/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -545,5 +627,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/governance-layers-for-ai-coding-assistants/index.html
+++ b/site/insights/governance-layers-for-ai-coding-assistants/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -530,5 +612,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -587,5 +669,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -30,6 +30,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -814,5 +896,51 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -581,5 +663,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -591,5 +673,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -534,5 +616,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -724,5 +806,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -517,5 +599,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -547,5 +629,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -574,5 +656,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -32,6 +32,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -910,5 +992,40 @@ mneme check --mode warn</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -518,5 +600,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -649,5 +731,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -537,5 +619,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -683,5 +765,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -904,5 +986,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -574,5 +656,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -525,5 +607,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -582,5 +664,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -525,5 +607,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -533,5 +615,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -500,5 +582,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -624,5 +706,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -540,5 +622,51 @@
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/open-knowledge-format-vs-governance/index.html
+++ b/site/insights/open-knowledge-format-vs-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -544,5 +626,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -621,5 +703,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -597,5 +679,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -595,5 +677,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -577,5 +659,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -671,5 +753,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -618,5 +700,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -32,6 +32,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -633,5 +715,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/recursive-self-improvement-orchestration-problem/index.html
+++ b/site/insights/recursive-self-improvement-orchestration-problem/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -545,5 +627,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -536,5 +618,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -710,5 +792,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -541,5 +623,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -522,5 +604,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -558,5 +640,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -518,5 +600,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -34,6 +34,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -543,5 +625,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -570,5 +652,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -577,5 +659,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/stanford-ai-index-2026-engineering-governance/index.html
+++ b/site/insights/stanford-ai-index-2026-engineering-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -531,5 +613,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/topics/agent-infrastructure/index.html
+++ b/site/insights/topics/agent-infrastructure/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -818,5 +900,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/topics/ai-coding-agents/index.html
+++ b/site/insights/topics/ai-coding-agents/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -717,5 +799,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/topics/architectural-governance/index.html
+++ b/site/insights/topics/architectural-governance/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -740,5 +822,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/topics/engineering-performance/index.html
+++ b/site/insights/topics/engineering-performance/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -673,5 +755,40 @@
   sections.forEach(function(s){ io.observe(s); });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -651,5 +733,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -38,6 +38,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -503,5 +585,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -524,5 +606,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -34,6 +34,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -849,5 +931,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -806,5 +888,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -722,5 +804,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -636,5 +718,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -31,6 +31,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -641,5 +723,51 @@
   window.addEventListener('resize', function(){ if (window.innerWidth > 900 && links.classList.contains('open')) setOpen(false); });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -569,5 +651,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -733,5 +815,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -535,5 +617,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -594,5 +676,40 @@ Result: WARN</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/antigravity/index.html
+++ b/site/integrations/antigravity/index.html
@@ -129,6 +129,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -337,5 +419,51 @@ CI records the governance result</pre>
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -247,6 +247,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -754,5 +836,40 @@ jobs:
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -664,5 +746,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -519,5 +601,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -527,5 +609,40 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -541,5 +623,40 @@ jobs:
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -529,5 +611,40 @@ mneme-governance:
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -574,5 +656,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -607,5 +689,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/microsoft-agent-forge/index.html
+++ b/site/integrations/microsoft-agent-forge/index.html
@@ -215,6 +215,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -504,5 +586,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/opencode/index.html
+++ b/site/integrations/opencode/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -517,5 +599,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -455,5 +537,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -582,5 +664,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/integrations/warp/index.html
+++ b/site/integrations/warp/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -482,5 +564,51 @@ mneme check --mode warn   # try locally first</code></pre>
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
 
   <script type="application/ld+json">
@@ -675,5 +757,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -164,6 +164,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -459,5 +541,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -344,19 +426,19 @@
   <!-- HEADER -->
   <div class="page-tag">Legal</div>
   <h1>Privacy Policy</h1>
-  <p class="page-sub">Mneme HQ is an open-source developer tool. We collect minimal data and never sell it.</p>
-  <p class="last-updated">Last updated: 1 May 2026</p>
+  <p class="page-sub">Mneme HQ is an open-source developer tool. We keep data collection minimal and explain below exactly what third parties receive.</p>
+  <p class="last-updated">Last updated: 25 June 2026</p>
 
   <div class="prose">
 
     <h2>What we collect</h2>
-    <p>When you visit mnemehq.com, we collect standard anonymous analytics data via Google Tag Manager:</p>
+    <p>When you visit mnemehq.com, we collect standard analytics data via Google Tag Manager and Google Analytics:</p>
     <ul>
       <li>Pages visited and time on page</li>
       <li>Referring URL and general geographic region (country/city level)</li>
       <li>Browser type and device category</li>
     </ul>
-    <p>We do not collect names, email addresses, or any personally identifiable information unless you contact us directly.</p>
+    <p>Except where you enable Visitor identification (see Third-party services below), we do not collect names, email addresses, or other personally identifiable information unless you contact us directly.</p>
 
     <h2>What we do not collect</h2>
     <ul>
@@ -367,7 +449,20 @@
     </ul>
 
     <h2>Third-party services</h2>
-    <p>This site uses Google Tag Manager and Google Analytics for anonymous usage analytics. Their privacy policies apply to data processed by those services. We use standard cookie consent defaults — no tracking cookies are set beyond what is necessary for analytics.</p>
+    <p>We use <strong>Google Tag Manager</strong> and <strong>Google Analytics</strong> (Google Ireland Ltd / Google LLC) for usage analytics; these set analytics cookies. With your consent — given via the banner on your first visit and changeable any time through <strong>Privacy choices</strong> in the footer — we also enable:</p>
+    <ul>
+      <li><strong>Visitor identification — RB2B</strong> (operated by GetEmails, LLC d/b/a RB2B): for eligible <strong>US-based</strong> visitors to our high-intent pages, RB2B associates the visit with the visitor's company and professional contact information (such as name, business email, or professional profile) so we can carry out B2B sales outreach. Company-level identification may be provided via RB2B's partner <strong>Demandbase, Inc.</strong> The precise controller/processor roles are set out in our agreements with these providers.</li>
+    </ul>
+    <p>RB2B processes data under its own privacy policy and may act as an independent controller. It sets first-party cookies (its longest-lived cookie persists for up to one year).</p>
+
+    <h2>Cookies and changing your choices</h2>
+    <p>Analytics cookies are set by default. Visitor identification is <strong>off until you accept it</strong>. You can change or withdraw consent at any time via the <strong>Privacy choices</strong> link in the footer; withdrawing stops the tool loading on future page views. Cookies already set by RB2B may also need removing through that provider, and you can use Google's <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener">Analytics opt-out</a>.</p>
+
+    <h2>US state privacy rights</h2>
+    <p>If you are a US resident, the visitor-identification activity above may be considered a "sale" or "sharing" of personal information under laws such as the California Consumer Privacy Act, even where no money changes hands. To opt out, use the <strong>Privacy choices</strong> link (leave Visitor identification off, or withdraw it), or email <a href="mailto:hi@theovalmis.com">hi@theovalmis.com</a> with "Your Privacy Choices" in the subject.</p>
+
+    <h2>International transfers</h2>
+    <p>RB2B is a US service and processes data in the United States. Where we transfer personal data outside the UK/EEA we rely on the provider's standard contractual clauses or equivalent safeguards. RB2B's person-level identification is offered for US visitors and we restrict it accordingly.</p>
 
     <h2>Contact and email</h2>
     <p>If you email us at <a href="mailto:hi@theovalmis.com">hi@theovalmis.com</a>, we will use your email address only to respond to your enquiry. We do not add you to any mailing list without explicit consent.</p>
@@ -519,5 +614,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/qa-glossary/index.html
+++ b/site/qa-glossary/index.html
@@ -294,6 +294,88 @@
     ]
   }
   </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -881,5 +963,51 @@ Body markdown follows.</code></pre>
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -558,5 +640,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -543,5 +625,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/fastapi-governance/index.html
+++ b/site/supported-languages/fastapi-governance/index.html
@@ -168,6 +168,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -473,5 +555,40 @@ router = APIRouter(prefix=<span class="kw">"/admin"</span>)  <span class="cm"># 
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -142,6 +142,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -396,5 +478,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -157,6 +157,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -417,5 +499,40 @@ cron.schedule(<span class="kw">"0 3 * * *"</span>, <span class="kw">async</span>
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -158,6 +158,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -442,5 +524,40 @@ app = Celery(<span class="kw">'tasks'</span>, broker=<span class="kw">'redis://l
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/spring-boot-governance/index.html
+++ b/site/supported-languages/spring-boot-governance/index.html
@@ -168,6 +168,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -472,5 +554,40 @@ http.csrf(csrf -&gt; csrf.disable())
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/terraform-governance/index.html
+++ b/site/supported-languages/terraform-governance/index.html
@@ -168,6 +168,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -484,5 +566,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -157,6 +157,88 @@
   
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -432,5 +514,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/ci-governance-for-ai-generated-code/index.html
+++ b/site/use-cases/ci-governance-for-ai-generated-code/index.html
@@ -33,6 +33,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -522,5 +604,51 @@ mneme-check:
   });
 })();
 </script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -689,5 +771,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -263,6 +263,88 @@
   ]
 }
 </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -614,5 +696,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -263,6 +263,88 @@
   ]
 }
 </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -614,5 +696,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -775,5 +857,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -696,5 +778,40 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -269,6 +269,88 @@
   ]
 }
 </script>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -651,5 +733,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -700,5 +782,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/works-with/antigravity/index.html
+++ b/site/works-with/antigravity/index.html
@@ -116,6 +116,88 @@
     }
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -282,5 +364,51 @@
 
 <script>(function(){var path=window.location.pathname;document.querySelectorAll('.nav-links a').forEach(function(a){var href=a.getAttribute('href');if(href&&href.startsWith('/')&&href!=='/'&&path.startsWith(href)){a.classList.add('active');}});})();</script>
 <script>(function(){var btn=document.querySelector('.nav-hamburger');var links=document.querySelector('.nav-links');if(!btn||!links)return;function setOpen(open){links.classList.toggle('open',open);btn.setAttribute('aria-expanded',String(open));document.body.classList.toggle('menu-open',open);}btn.addEventListener('click',function(e){e.stopPropagation();setOpen(!links.classList.contains('open'));});document.addEventListener('click',function(e){if(!links.classList.contains('open'))return;if(links.contains(e.target)||btn.contains(e.target))return;setOpen(false);});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&links.classList.contains('open'))setOpen(false);});links.addEventListener('click',function(e){if(e.target.tagName==='A')setOpen(false);});window.addEventListener('resize',function(){if(window.innerWidth>900&&links.classList.contains('open'))setOpen(false);});})();</script>
+<script><!-- nav-active -->
+(function(){
+  var path = window.location.pathname;
+  document.querySelectorAll('.nav-links a').forEach(function(a){
+    var href = a.getAttribute('href');
+    if (href && href.startsWith('/') && href !== '/' && path.startsWith(href)) {
+      a.classList.add('active');
+    }
+  });
+})();
+</script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/works-with/claude-marketplace/index.html
+++ b/site/works-with/claude-marketplace/index.html
@@ -204,6 +204,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -473,5 +555,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/works-with/devin/index.html
+++ b/site/works-with/devin/index.html
@@ -203,6 +203,88 @@
 
     @media (max-width: 768px) { nav, .mobile-menu { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; } }
   </style>
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -518,5 +600,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -29,6 +29,88 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KL7FB67N');</script>
   <!-- End Google Tag Manager -->
+<!-- mneme:marketing-head:start -->
+<!-- mneme:marketing-head — consent controller + RB2B (head). Synced into <head> by scripts/sync_shared.py.
+     SCOPE (step 1 of 2): RB2B visitor identification only. Advertising (Google Ads + LinkedIn via GTM)
+     and its consent category arrive in step 2 — when added, bump VERSION to re-prompt. -->
+<script>
+(function () {
+  var COOKIE = 'mneme_consent';
+  var VERSION = 1;   /* bump when categories/vendors change -> re-prompt */
+
+  function readRaw(n){var m=document.cookie.match('(?:^|; )'+n.replace(/([.$?*|{}()\[\]\\\/\+^])/g,'\\$1')+'=([^;]*)');return m?decodeURIComponent(m[1]):null;}
+  function writeCookie(value){
+    var secure = location.protocol === 'https:' ? ';secure' : '';
+    document.cookie = COOKIE+'='+encodeURIComponent(JSON.stringify(value))+';path=/;max-age=15552000;samesite=Lax'+secure; /* 180d */
+  }
+  function parse(){
+    var raw = readRaw(COOKIE); if(!raw) return null;
+    try { var o = JSON.parse(raw); if(!o || o.v !== VERSION || typeof o.visitor_id !== 'boolean') return null; return o; }
+    catch(e){ return null; }   /* invalid / stale version -> treat as unset (re-prompt) */
+  }
+
+  window.__mnemePixels = window.__mnemePixels || [];   /* registry: {done, cat, fn} */
+  var geoReady = false;
+  function runPixels(){
+    window.__mnemePixels.forEach(function(p){
+      if(p.done || !C.consent[p.cat]) return;
+      if(p.cat === 'visitor_id' && !geoReady) return;   /* RB2B waits for country resolution */
+      try { p.fn(); p.done = true; }     /* mark done only AFTER success */
+      catch(e){ if(window.console) console.warn('[mneme-consent] pixel failed:', p.cat, e); }
+    });
+  }
+  /* Resolve visitor country from Cloudflare's edge trace (same-origin; no dashboard config needed).
+     Only called once visitor_id consent is granted, so non-consenting visitors trigger no request. */
+  function resolveGeo(){
+    if (geoReady) { runPixels(); return; }
+    try {
+      fetch('/cdn-cgi/trace', {cache:'no-store'}).then(function(r){ return r.text(); }).then(function(t){
+        var m = t.match(/(?:^|\n)loc=([A-Z]{2})/); window.__mnemeCountry = m ? m[1] : '';
+      }).catch(function(){}).then(function(){ geoReady = true; runPixels(); });
+    } catch(e){ geoReady = true; runPixels(); }
+  }
+
+  var stored = parse();
+  var C = window.MnemeConsent = {
+    version: VERSION,
+    state: stored ? 'set' : 'unset',
+    consent: { visitor_id: stored ? stored.visitor_id : false },
+    save: function(choices){
+      this.consent.visitor_id = !!choices.visitor_id;
+      this.state = 'set';
+      writeCookie({ v:VERSION, visitor_id:this.consent.visitor_id, ts:new Date().toISOString() });
+      if (this.consent.visitor_id) resolveGeo(); else runPixels();
+    },
+    withdraw: function(){ this.save({ visitor_id:false }); location.reload(); },  /* reload stops an already-loaded script */
+    reopen: function(){ if(this._reopen) this._reopen(); }                        /* wired by the banner in <body> */
+  };
+
+  if (stored && stored.visitor_id) resolveGeo();   /* returning consenter: resolve country, then load RB2B */
+})();
+</script>
+
+<!-- mneme:vendor:rb2b:start -->
+<script>
+/* RB2B — VISITOR IDENTIFICATION. Person-level identification is US-only (RB2B / GetEmails).
+   Loads ONLY when: (1) visitor_id consent granted, (2) visitor is US (window.__mnemeCountry, resolved
+   from Cloudflare /cdn-cgi/trace by the controller above), (3) page is high-intent.
+   The loader below is RB2B's exact dashboard script; the key is injected from RB2B_PIXEL_ID at deploy time. */
+window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
+  if ((window.__mnemeCountry || '').toUpperCase() !== 'US') return;   /* US-only until intl DPA cleared */
+  var p = location.pathname;
+  if (!(/^\/concepts(\/|$)/.test(p) || /^\/qa-glossary(\/|$)/.test(p) || /^\/pricing(\/|$)/.test(p) || /^\/demo(\/|$)/.test(p))) return;
+  !function(key) {
+    if (window.reb2b) return;
+    window.reb2b = {loaded: true};
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+    document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);
+  }("46DJ4HG0DG61");
+}});
+</script>
+<!-- mneme:vendor:rb2b:end -->
+<!-- mneme:marketing-head:end -->
   <link rel="icon" href="/favicon.png" type="image/png">
   <script type="application/ld+json">
   {
@@ -800,5 +882,40 @@
   });
 })();
 </script>
+<!-- mneme:marketing-body:start -->
+<!-- mneme:marketing-body — visitor-identification consent banner (body). Synced before </body> by sync_shared.py.
+     SCOPE (step 1 of 2): RB2B only. The Advertising category (Google Ads + LinkedIn via GTM) is added in step 2. -->
+<style>
+  #mneme-consent{position:fixed;left:1rem;right:1rem;bottom:1rem;z-index:9999;max-width:600px;margin:0 auto;
+    background:var(--surface2,#1a1a1d);border:1px solid var(--border2,#2e2e34);border-radius:12px;
+    padding:1.1rem 1.2rem;box-shadow:0 8px 30px rgba(0,0,0,.45);font-size:.82rem;line-height:1.5;color:var(--text,#e8e8ec)}
+  #mneme-consent p{margin:0 0 .7rem}
+  #mneme-consent a{color:var(--accent,#c8f060)}
+  #mneme-consent .row{display:flex;gap:.6rem;justify-content:flex-end;flex-wrap:wrap}
+  /* Equal visual weight — no colour bias toward Accept. */
+  #mneme-consent button{font:inherit;cursor:pointer;border-radius:8px;padding:.5rem .95rem;
+    border:1px solid var(--border2,#2e2e34);background:var(--surface,#141416);color:var(--text,#e8e8ec)}
+</style>
+<div id="mneme-consent" hidden role="dialog" aria-modal="false" aria-label="Privacy choices">
+  <p><strong>Visitor identification.</strong> For eligible US visitors to certain pages, RB2B may associate your visit with your company and professional contact details (e.g. name, business email) so we can do B2B sales outreach. Analytics runs separately. See our <a href="/privacy/">Privacy Policy</a>.</p>
+  <div class="row">
+    <button type="button" id="mc-reject">Reject</button>
+    <button type="button" id="mc-accept">Accept</button>
+  </div>
+</div>
+<script>
+(function () {
+  var el = document.getElementById('mneme-consent');
+  if (!el || !window.MnemeConsent) return;
+  var C = window.MnemeConsent;
+  C._reopen = function(){ el.hidden = false; };
+  document.getElementById('mc-accept').addEventListener('click', function(){ C.save({visitor_id:true});  el.hidden = true; });
+  document.getElementById('mc-reject').addEventListener('click', function(){ C.save({visitor_id:false}); el.hidden = true; });
+  if (C.state === 'unset') el.hidden = false;   /* first visit / stale version -> prompt */
+})();
+</script>
+<!-- mneme:marketing-body:end -->
+
+
 </body>
 </html>


### PR DESCRIPTION
## What
Adds **RB2B person-level visitor identification** to mnemehq.com, fully consent-gated.

RB2B loads **only** when all of:
1. visitor grants **Visitor identification** consent (new banner; withdraw via **Privacy choices** in the footer),
2. visitor is **US** — resolved client-side from Cloudflare `/cdn-cgi/trace` (off everywhere else),
3. page is **high-intent**: `/concepts/*`, `/qa-glossary/`, `/demo/`, `/pricing/*`.

Analytics is unchanged (stays granted by default). Google Ads + LinkedIn (via GTM) are a **separate follow-up**.

## Substance (ignore the 235 mechanical page diffs)
- `site/_snippets/marketing-head.html` — consent controller + RB2B loader (RB2B's exact dashboard script)
- `site/_snippets/marketing-body.html` — visitor-identification consent banner
- `site/_snippets/footer.html` — "Privacy choices" withdrawal link
- `site/privacy/index.html` — RB2B (GetEmails) + Demandbase processors, cookies, US-state opt-out, transfers
- `scripts/sync_shared.py` — deploy-time key injection from `RB2B_PIXEL_ID` (.env), strip-if-unset, idempotent markers
- 235 pages = mechanical sync injection (key baked in; the key is a public client-side ID)

## Before / after merge
- Set `RB2B_PIXEL_ID` in `.env` (already set locally: `46DJ4HG0DG61`).
- Deploy from `main` via `scripts/deploy_site.py`.
- ⚠️ **Counsel on the RB2B Data Services Agreement (EU establishment / transfer position) is still outstanding** — this ships live US person-level identification ahead of that review, per explicit owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)