### PR TITLE
site: GEO gap remediation (docs, concepts, compare, integrations, pilot)

### DIFF
--- a/site/compare/aider/index.html
+++ b/site/compare/aider/index.html
@@ -515,7 +515,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Architectural enforcement underneath every coding agent</h3>
       <p>Mneme HQ hooks into Aider, Cursor, Claude Code, Copilot, and other AI coding agents at the Edit and Write boundary, matches your typed architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" class="cta-secondary">Read: Architectural governance across heterogeneous AI coding agents &rarr;</a>
     </div>
   </footer>

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -560,7 +560,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt engineering is not governance &rarr;</a>
     </div>
   </footer>

--- a/site/compare/claude-md/index.html
+++ b/site/compare/claude-md/index.html
@@ -582,7 +582,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Keep your CLAUDE.md. Enforce the rules that matter.</h3>
       <p>Mneme HQ promotes the load-bearing rules out of your instructions file into typed decisions with a precedence engine and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/why-claude-md-stops-scaling/" class="cta-secondary">Read: Why CLAUDE.md Stops Scaling →</a>
       <a href="/integrations/claude-code/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Claude Code — integration guide →</a>
     </div>

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -567,7 +567,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/ai-code-review-does-not-scale-linearly/" class="cta-secondary">Read: AI Code Review Does Not Scale Linearly →</a>
     </div>
   </footer>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -353,6 +353,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   </header>
 
   <div class="article-body">
+    <div class="callout"><p><strong>The bottom line.</strong> Continue.dev is an IDE coding assistant with rules files; Mneme is a governance layer that enforces architectural decisions at Edit/Write with a precedence engine, so decisions are enforced rather than suggested. They compose: Continue generates, Mneme governs.</p></div>
+
     <h2>What Continue.dev brings to the IDE</h2>
 
     <p>Continue.dev is the closest open-source sibling to Cursor and the commercial AI coding assistants. It runs inside VS Code and JetBrains, supports a configurable model backend (Anthropic, OpenAI, local Ollama, others), and exposes two of the surfaces most relevant to a governance comparison: <strong>rules</strong> defined in <code style="font-family:'DM Mono',monospace;font-size:0.88em;color:var(--text);">config.yaml</code>, and <strong>context providers</strong> that pull project information into each session.</p>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -521,7 +521,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Precedence-aware governance underneath every coding agent</h3>
       <p>Mneme HQ enforces architectural decisions with explicit scope and a precedence engine. It runs at the Edit/Write hook for Continue, Cursor, Claude Code, Copilot, and any other AI coding agent. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-architectural-governance-needs-precedence-semantics/" class="cta-secondary">Read: Why architectural governance needs precedence semantics &rarr;</a>
     </div>
   </footer>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -171,6 +171,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
 
+    .cmd-snippet { background: var(--surface2); border: 1px solid var(--border2); border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1rem 0 1.5rem; font-family: 'DM Mono', monospace; font-size: 0.8rem; color: var(--text); overflow-x: auto; white-space: pre; line-height: 1.5; }
+    .cmd-snippet .cp { color: var(--accent); user-select: none; margin-right: 0.5rem; }
+
     .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
     .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
     .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -474,6 +477,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <li><strong>Hook Mneme into Edit/Write.</strong> When Continue proposes an edit, Mneme matches the scope, resolves precedence, and blocks violations before they land.</li>
       <li><strong>Encode supersessions and overrides as decisions, not config ordering.</strong> Reading <code style="font-family:'DM Mono',monospace;font-size:0.88em;color:var(--text);">config.yaml</code> top-to-bottom should not be how a team learns which rule wins.</li>
     </ol>
+
+    <p>Mneme runs as the enforcement step on whatever Continue proposes. When Continue produces an edit, the same command evaluates it against your typed decisions at the Edit/Write hook:</p>
+    <pre class="cmd-snippet"><span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input src/orchestration/runner.py --query "orchestration layer style"</pre>
 
     <p>In this architecture, Continue is the engineer&rsquo;s coding surface; Mneme is the team&rsquo;s enforcement layer. The two compose without overlap, and the failure modes of prose-as-rules disappear because prose is no longer being asked to do the work of typed precedence.</p>
 

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -579,7 +579,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/mneme-vs-cursor-rules/" class="cta-secondary">Read: Mneme vs Cursor Rules (editorial) →</a>
       <a href="/integrations/cursor/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Cursor — integration guide →</a>
     </div>

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -441,7 +441,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Devin executes. Mneme governs.</h3>
       <p>Use them together. Mneme is open source, repo-native, and works alongside Devin and every other AI coding agent on the codebase.</p>
-      <a href="/works-with/devin/" class="btn-primary" style="margin-right:0.5rem;">Works with Devin &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="/works-with/devin/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Works with Devin &rarr;</a>
       <a href="/insights/devin-ai-software-engineer-governance/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Read the analysis</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -323,6 +323,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <div class="article-body">
 
+    <div class="callout"><p><strong>The bottom line.</strong> Devin autonomously implements tasks; Mneme is not an agent. Mneme deterministically enforces your architectural decisions on whatever Devin (or any agent) writes, before the change reaches review. Use them together: Devin executes, Mneme governs.</p></div>
+
     <h2>Execution plane vs governance plane</h2>
     <p>The clearest way to read what each layer does:</p>
     <div class="plane-split">

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -127,6 +127,9 @@
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
 
+    .cmd-snippet { background: var(--surface2); border: 1px solid var(--border2); border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1rem 0 1.5rem; font-family: 'DM Mono', monospace; font-size: 0.8rem; color: var(--text); overflow-x: auto; white-space: pre; line-height: 1.5; }
+    .cmd-snippet .cp { color: var(--accent); user-select: none; margin-right: 0.5rem; }
+
     .compare-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.9rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
     .compare-table th { background: var(--surface2); color: var(--muted); font-family: 'DM Mono', monospace; font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.95rem 1.1rem; text-align: left; border-bottom: 1px solid var(--border2); }
     .compare-table th.col-mneme { color: var(--accent); }
@@ -408,6 +411,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <li><strong>CI</strong> blocks merges that violate architectural invariants, with a provenance trace pointing back to the originating decision.</li>
       <li><strong>The reviewer</strong> sees both the agent&rsquo;s output and the structured governance verdict, so review focuses on judgment rather than constraint-spotting.</li>
     </ul>
+    <p>Mneme runs as the enforcement step on whatever Devin produces. The same deterministic command evaluates the changed file against your compiled decisions before the change reaches review:</p>
+    <pre class="cmd-snippet"><span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input changed_file.py --query "service boundaries"</pre>
 
   </div><!-- /.article-body -->
 

--- a/site/compare/github-copilot/index.html
+++ b/site/compare/github-copilot/index.html
@@ -515,7 +515,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Enforce architectural decisions across every coding agent</h3>
       <p>Mneme HQ hooks into AI coding agents &mdash; Copilot, Cursor, Claude Code, and others &mdash; at the Edit and Write boundary, matches your typed architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/github-copilot-space-framework/" class="cta-secondary">Read: What the SPACE framework reveals about Copilot &rarr;</a>
     </div>
   </footer>

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -324,7 +324,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Use Mneme to add architectural governance to agent-first development workflows</h3>
       <p>Open source. Repo-native. Works alongside Antigravity and every other agentic IDE on the codebase.</p>
-      <a href="/integrations/antigravity/" class="btn-primary" style="margin-right:0.5rem;">Works with Antigravity &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="/integrations/antigravity/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Works with Antigravity &rarr;</a>
       <a href="/insights/antigravity-solves-coordination-not-governance/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Read the analysis</a>
       <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -83,6 +83,8 @@
     .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 1.25rem 1.5rem; margin: 2rem 0; }
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
+    .cmd-snippet { background: var(--surface2); border: 1px solid var(--border2); border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1rem 0 1.5rem; font-family: 'DM Mono', monospace; font-size: 0.8rem; color: var(--text); overflow-x: auto; white-space: pre; line-height: 1.5; }
+    .cmd-snippet .cp { color: var(--accent); user-select: none; margin-right: 0.5rem; }
     .compare-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.9rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
     .compare-table th { background: var(--surface2); color: var(--muted); font-family: 'DM Mono', monospace; font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.95rem 1.1rem; text-align: left; border-bottom: 1px solid var(--border2); }
     .compare-table th.col-mneme { color: var(--accent); }
@@ -289,6 +291,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <li><strong>Mneme</strong> sits one layer up. It injects the architectural decisions relevant to the task before the agent generates, and validates outputs against compiled constraints at hook, commit, and CI time.</li>
       <li>The reviewer sees both the agent&rsquo;s Artifacts (what it did) and the structured governance verdict (whether the work belongs in the system). Review focuses on judgment.</li>
     </ul>
+    <p>Mneme runs as the enforcement step on whatever Antigravity produces. When an Artifact lands, the same command evaluates the changed file against your decisions:</p>
+    <pre class="cmd-snippet"><span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input changed_file.py --query "service boundaries"</pre>
 
     <h2>How they meet in a real workflow</h2>
     <p>Picture an agent in Antigravity picking up a task. It drafts a plan, edits files, runs the terminal, and verifies the result in a browser, then posts an Artifact. With Mneme in place, the relevant architectural decisions are compiled in before that work starts, so the agent is steered away from a forbidden dependency or a cross-layer call as it writes. When the change reaches a commit or CI, Mneme evaluates the diff against those compiled rules and returns a verdict with provenance attached. The reviewer opens one place and sees two things: the Artifact that says what the agent did, and the governance verdict that says whether it belongs in the system. Nothing about the agent's speed changes; what changes is that an architectural violation is caught at the seam instead of in production.</p>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -533,7 +533,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Decision memory that recalls every time</h3>
       <p>Mneme HQ hooks into your AI coding agent&rsquo;s Edit and Write operations, looks up architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-prompt-memory-fails-at-scale/" class="cta-secondary">Read: Why prompt memory fails at scale &rarr;</a>
     </div>
   </footer>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -354,6 +354,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <div class="article-body">
 
+    <div class="callout"><p><strong>The bottom line.</strong> RAG surfaces contextual examples by probabilistic ranking; Mneme compiles architectural decisions into deterministic constraints that execute before generation. Use RAG for contextual memory and Mneme for decision memory. They solve different halves of project memory.</p></div>
+
     <h2>What teams mean by &ldquo;RAG for coding memory&rdquo;</h2>
 
     <p>The pattern is now familiar: index a repository&rsquo;s ADRs, design docs, code snippets, prior commits, and engineering wiki pages into a vector store. At each coding agent turn, retrieve the top-k most relevant chunks and inject them into the model&rsquo;s context. The goal is persistent project memory &mdash; the agent &ldquo;remembers&rdquo; what your team has decided, even across new sessions.</p>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -171,6 +171,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
 
+    .cmd-snippet { background: var(--surface2); border: 1px solid var(--border2); border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1rem 0 1.5rem; font-family: 'DM Mono', monospace; font-size: 0.8rem; color: var(--text); overflow-x: auto; white-space: pre; line-height: 1.5; }
+    .cmd-snippet .cp { color: var(--accent); user-select: none; margin-right: 0.5rem; }
+
     .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
     .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
     .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -486,6 +489,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <li><strong>Use Mneme to enforce decision recall at edit time.</strong> Hook into Edit and Write operations. When the model produces an edit that violates an architectural decision, Mneme blocks it before it reaches the codebase.</li>
       <li><strong>Track overrides as first-class decision records.</strong> When a team intentionally diverges from a decision, the override is itself recorded with rationale and scope. RAG can surface the override discussion; Mneme governs the new boundary.</li>
     </ol>
+
+    <p>Mneme runs as the decision-recall step at edit time, independent of whatever RAG surfaced into context. The same command looks up the decisions that apply to the edited file and returns a deterministic verdict:</p>
+    <pre class="cmd-snippet"><span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input services/auth/session.py --query "auth service boundaries"</pre>
 
     <p>In this architecture, RAG is the memory of <em>what we have written</em>. Mneme is the memory of <em>what we have decided</em>. A coding agent that uses both has stronger context and harder compliance guarantees than either provides alone &mdash; and the failure modes of RAG-as-decision-memory disappear, because RAG is no longer being asked to do the work it was never built for.</p>
 

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -533,7 +533,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Deterministic enforcement, not better retrieval</h3>
       <p>Mneme HQ hooks into your AI coding agent&rsquo;s Edit and Write operations and blocks architectural violations before they reach the codebase. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-rag-fails-for-architectural-governance/" class="cta-secondary">Read: Why RAG fails for architectural governance &rarr;</a>
     </div>
   </footer>

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -171,6 +171,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .callout p { margin: 0; color: var(--muted); font-size: 0.88rem; }
     .callout p strong { color: var(--accent); }
 
+    .cmd-snippet { background: var(--surface2); border: 1px solid var(--border2); border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1rem 0 1.5rem; font-family: 'DM Mono', monospace; font-size: 0.8rem; color: var(--text); overflow-x: auto; white-space: pre; line-height: 1.5; }
+    .cmd-snippet .cp { color: var(--accent); user-select: none; margin-right: 0.5rem; }
+
     .comparison-table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.85rem; }
     .comparison-table th { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border2); color: var(--muted); font-weight: 500; }
     .comparison-table td { padding: 0.9rem 1rem; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -486,6 +489,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <li><strong>Use Mneme to enforce the hard constraints</strong> at operation time. When the model generates an Edit or Write, Mneme checks it against the decision corpus deterministically and blocks violations.</li>
       <li><strong>Track overrides explicitly.</strong> When a developer overrides a governance decision, the override is itself a decision record &mdash; with rationale, scope, and provenance. RAG can surface override history in future sessions.</li>
     </ol>
+
+    <p>Mneme runs as the enforcement step on whatever the model produces, independent of what RAG retrieved into context. The same command evaluates the edit against the decision corpus and blocks violations deterministically:</p>
+    <pre class="cmd-snippet"><span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input changed_file.py --query "architectural constraints"</pre>
 
     <p>In this architecture, RAG and Mneme are not substitutes. They are sequential layers operating on the same corpus. Retrieval improves generation quality. Enforcement guarantees architectural integrity. A codebase governed by both has better outputs and harder compliance guarantees than either provides alone.</p>
 

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -354,6 +354,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <div class="article-body">
 
+    <div class="callout"><p><strong>The bottom line.</strong> Retrieval surfaces relevant context probabilistically; governance enforces architectural decisions deterministically. RAG improves what the model sees; Mneme constrains what it is allowed to produce. They are complementary layers, not alternatives.</p></div>
+
     <h2>What RAG-based governance does</h2>
 
     <p>RAG (retrieval-augmented generation) applied to governance typically works like this: a vector store is indexed with ADRs, coding standards, architecture docs, or decision records. When a developer asks the AI to generate code, the relevant documents are retrieved and injected into the context window alongside the task.</p>

--- a/site/compare/sourcegraph-cody/index.html
+++ b/site/compare/sourcegraph-cody/index.html
@@ -513,7 +513,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Enterprise governance that pairs with grounded retrieval</h3>
       <p>Mneme HQ enforces typed architectural decisions at the Edit/Write boundary &mdash; alongside Sourcegraph Cody&rsquo;s codebase retrieval, the IDE coding assistant of your choice, and your CI. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-rag-fails-for-architectural-governance/" class="cta-secondary">Read: Why RAG fails for architectural governance &rarr;</a>
     </div>
   </footer>

--- a/site/compare/windsurf/index.html
+++ b/site/compare/windsurf/index.html
@@ -513,7 +513,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Governance that holds across long autonomous runs</h3>
       <p>Mneme HQ fires on every Edit and Write Cascade (or any other coding agent) proposes &mdash; independent of how many planning steps preceded it. Typed decisions, explicit scope, precedence engine. Open source, self-hosted, model-agnostic.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
+      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/long-running-agents-need-governance/" class="cta-secondary">Read: Long-running agents need governance &rarr;</a>
     </div>
   </footer>

--- a/site/concepts/agentic-ide-governance/index.html
+++ b/site/concepts/agentic-ide-governance/index.html
@@ -110,6 +110,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -245,6 +247,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Agentic IDE governance is the control layer that keeps autonomous coding agents aligned with architectural decisions, security constraints, and repository policies while they operate inside development environments.</strong> As IDEs like Antigravity, Cursor, Claude Code, and Copilot become execution environments, this layer constrains what an agent is allowed to do, not just what it did.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -105,6 +105,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -227,6 +229,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>AI governance infrastructure is the deterministic enforcement layer that preserves architectural intent across AI-assisted software development.</strong> It compiles architectural decisions into machine-evaluable constraints, applies them at every execution surface an AI agent touches, and produces structured verdicts that travel with the codebase no matter which agent or tool produced the change.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/antigravity-governance/index.html
+++ b/site/concepts/antigravity-governance/index.html
@@ -106,6 +106,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -228,6 +230,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Antigravity governance is the practice of applying architectural constraints, decision provenance, and verification checks to agent-first development workflows where coding agents operate across editor, terminal, and browser surfaces.</strong> It is the Antigravity-specific specialization of agentic IDE governance: deterministic, repo-native rules tied to ADRs that enforce architecture at the speed and surfaces autonomous agents work.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/artifact-provenance/index.html
+++ b/site/concepts/artifact-provenance/index.html
@@ -107,6 +107,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -229,6 +231,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Artifact provenance is the record of plans, diffs, screenshots, browser recordings, test outputs, and verification evidence produced by autonomous agents during a task.</strong> It makes an agent's work inspectable, telling you what happened. Provenance is not enforcement: it cannot prove the agent respected your architecture. Governance is the separate layer that constrains what is allowed.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/autonomous-software-engineering-governance/index.html
+++ b/site/concepts/autonomous-software-engineering-governance/index.html
@@ -154,6 +154,9 @@
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -292,6 +295,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Autonomous software engineering governance is the enforcement layer that preserves architectural, operational, and organizational constraints across AI-driven software execution systems.</strong> Once agents plan, edit, refactor, test, and deploy on their own, they are execution systems, not suggestion systems. This layer keeps architectural intent enforced regardless of which agent, model, or runtime produces the work.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -108,6 +108,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -230,6 +232,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Multi-agent architectural drift is what happens when multiple autonomous coding agents make locally reasonable changes that gradually diverge from shared architectural decisions, abstractions, and repository conventions.</strong> No agent has to be wrong for the system to drift collectively. Each change is explainable in isolation; the aggregate is not. A shared enforcement layer is what holds the architecture together.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/runtime-governance/index.html
+++ b/site/concepts/runtime-governance/index.html
@@ -261,6 +261,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -318,6 +321,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Runtime governance is the enforcement of architectural, operational, and policy constraints across long-running autonomous execution environments.</strong> It keeps persistent agents aligned with system invariants as they execute, mutate state, coordinate workflows, and operate across infrastructure over time. As agents gain persistent runtimes and deployment authority, governance shifts from a review-time concern to a runtime systems concern.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/concepts/spec-driven-development/index.html
+++ b/site/concepts/spec-driven-development/index.html
@@ -110,6 +110,8 @@
     .byline a { color: var(--muted); text-decoration: none; }
     .byline a:hover { color: var(--text); }
     .byline .sep { color: var(--border2); margin: 0 0.5rem; }
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -245,6 +247,10 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </nav>
 
 <main>
+<div class="answer-capsule">
+  <strong>Spec-driven development (SDD) is an AI-assisted software engineering workflow in which a structured specification becomes the source of truth for implementation.</strong> Work moves through requirements, design, planning, task decomposition, and code generation. A spec defines what to build; it does not define which architectural decisions must remain true while the agent builds it. Specification and governance are complementary layers.
+</div>
+
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li><a href="/">Home</a></li>

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -227,6 +227,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .cross-card .cl-title { font-family: 'Inter', sans-serif; font-size: 0.95rem; font-weight: 600; }
     .cross-card .cl-sub { font-size: 0.8rem; color: var(--muted); line-height: 1.6; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--text); }
@@ -346,6 +349,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <li aria-current="page">CLI reference</li>
   </ol>
 </nav>
+
+<div class="answer-capsule"><strong>The <code>mneme</code> CLI</strong> exposes <code>list_decisions</code>, <code>add_decision</code>, <code>test_query</code>, <code>check</code>, and <code>cursor generate</code>. Every subcommand reads a <code>project_memory.json</code> corpus via <code>--memory</code> and returns Unix exit codes (0 pass, 1 warn, 2 fail).</div>
 
 <section class="hero">
   <div class="section-eyebrow">CLI reference</div>

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -375,10 +375,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h2>Install</h2>
     <p class="sub">Python 3.10+. MIT-licensed. No vector store, no ML runtime.</p>
     <div class="cmd-card">
-<pre><span class="cp">$</span> git clone https://github.com/TheoV823/mneme
-<span class="cp">$</span> cd mneme
-<span class="cp">$</span> pip install -e .</pre>
-      <p class="cdesc" style="margin-bottom:0;">After install, the <code>mneme</code> entry point is on your PATH. Every subcommand requires <code>--memory</code> pointing at a <code>project_memory.json</code> file. An example corpus ships at <code>examples/project_memory.json</code>.</p>
+<pre><span class="cp">$</span> pip install mneme-hq</pre>
+      <p class="cdesc">Installs the <code>mneme</code> entry point on your PATH. Every subcommand requires <code>--memory</code> pointing at a <code>project_memory.json</code> file. An example corpus ships at <code>examples/project_memory.json</code>.</p>
+      <p class="cdesc" style="margin-bottom:0;">From source (contributors): <code>git clone https://github.com/TheoV823/mneme &amp;&amp; cd mneme/mneme-project-memory &amp;&amp; pip install -e .</code></p>
     </div>
   </section>
 

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -219,6 +219,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
     .answer-capsule strong { color: var(--accent); }
 
+    .resolution { background: var(--surface2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 6px 6px 0; padding: 0.85rem 1rem; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--text); overflow-x: auto; line-height: 1.6; margin: 0.5rem 0 0; }
+    .violation pre.resolution .comment { color: var(--accent-dim); }
+
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--text); }
@@ -397,6 +400,12 @@ const client = new BigQuery();</pre>
         <span class="flag">ADR violation</span>
         <span class="flag">architectural boundary breach</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The frontend route calls a backend service over HTTP; only the backend holds the BigQuery client.</p>
+      <pre class="resolution"><span class="comment">// compliant - the route fetches from a backend endpoint, no DB client in the frontend</span>
+export async function GET() {
+  const res = await fetch(`${process.env.API_URL}/reports/summary`);
+  return Response.json(await res.json());
+}</pre>
     </div>
 
     <div class="violation" id="v2">
@@ -411,6 +420,11 @@ def checkout():
         <span class="flag">logic in presentation layer</span>
         <span class="flag">missing service abstraction</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The controller stays thin and delegates pricing, tax, and inventory to a service.</p>
+      <pre class="resolution"><span class="comment"># compliant - business logic lives in the service layer</span>
+@app.post("/checkout")
+def checkout(cart: Cart):
+    return checkout_service.place_order(cart)</pre>
     </div>
 
     <div class="violation" id="v3">
@@ -421,6 +435,10 @@ def checkout():
         <span class="flag">non-approved state management</span>
         <span class="flag">stack divergence</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> State management uses the approved library, Zustand.</p>
+      <pre class="resolution"><span class="comment">// compliant - uses the standardized Zustand store</span>
+import { create } from "zustand";
+const useStore = create((set) => ({ count: 0 }));</pre>
     </div>
   </section>
 
@@ -441,6 +459,11 @@ packages/auth/*</pre>
         <span class="flag">scoped ownership breach</span>
         <span class="flag">out-of-domain modification</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The billing agent edits only its own package and consumes auth through its published interface.</p>
+      <pre class="resolution"><span class="comment"># compliant - edits stay inside the owned package</span>
+packages/billing/*
+<span class="comment"># auth is imported, never modified</span>
+import { verifyToken } from "@org/auth";</pre>
     </div>
 
     <div class="violation" id="v10">
@@ -452,6 +475,10 @@ db/prod/migrations/*</pre>
         <span class="flag">restricted execution scope</span>
         <span class="flag">protected path mutation</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The agent writes proposed migrations to a staging directory; promotion to the production path is a human-gated step.</p>
+      <pre class="resolution"><span class="comment"># compliant - agent writes to the reviewable staging path only</span>
+db/staging/migrations/*
+<span class="comment"># a maintainer promotes to db/prod/migrations/ after review</span></pre>
     </div>
 
     <div class="violation" id="v11">
@@ -463,6 +490,12 @@ db/prod/migrations/*</pre>
         <span class="flag">policy conflict before generation</span>
         <span class="flag">governance-before-generation</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The agent declines the mock and wires in the vetted auth library to verify real tokens.</p>
+      <pre class="resolution"><span class="comment"># compliant - real verification, no fake validator</span>
+from app.auth import verify_jwt
+
+def authenticate(token: str) -> User:
+    return verify_jwt(token)  <span class="comment"># signature + expiry checked</span></pre>
     </div>
   </section>
 
@@ -482,6 +515,12 @@ db/prod/migrations/*</pre>
         <span class="flag">unsafe query construction</span>
         <span class="flag">secure coding rule breach</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The user input is bound as a parameter, never interpolated into the SQL string.</p>
+      <pre class="resolution"><span class="comment"># compliant - parameterized query, no string interpolation</span>
+cursor.execute(
+    "SELECT * FROM users WHERE id = %s",
+    (user_id,),
+)</pre>
     </div>
   </section>
 
@@ -502,6 +541,9 @@ db/prod/migrations/*</pre>
         <span class="flag">licensing policy violation</span>
         <span class="flag">approved-list deviation</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The dependency is swapped for an approved permissively-licensed (MIT or Apache-2.0) equivalent.</p>
+      <pre class="resolution"><span class="comment">// compliant - MIT-licensed library from the approved list</span>
+"some-mit-library": "^3.0.0"</pre>
     </div>
 
     <div class="violation" id="v9">
@@ -513,6 +555,12 @@ db/prod/migrations/*</pre>
         <span class="flag">outdated architecture pattern</span>
         <span class="flag">precedence-aware enforcement</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> Async work is dispatched through Pub/Sub, the decision that supersedes Celery.</p>
+      <pre class="resolution"><span class="comment"># compliant - ADR-002: publish to Pub/Sub instead of Celery</span>
+from google.cloud import pubsub_v1
+
+publisher = pubsub_v1.PublisherClient()
+publisher.publish(topic_path, payload)</pre>
     </div>
   </section>
 
@@ -532,6 +580,12 @@ db/prod/migrations/*</pre>
         <span class="flag">bypassing approved infra workflow</span>
         <span class="flag">untracked change surface</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The instance is declared in a Terraform module and applied through the reviewed pipeline, not an imperative CLI call.</p>
+      <pre class="resolution"><span class="comment"># compliant - declarative Terraform, applied via CI</span>
+module "api_instance" {
+  source        = "./modules/compute"
+  machine_type  = "e2-standard-2"
+}</pre>
     </div>
 
     <div class="violation" id="v7">
@@ -542,6 +596,9 @@ db/prod/migrations/*</pre>
         <span class="flag">routing convention breach</span>
         <span class="flag">API governance mismatch</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The route is namespaced under the required <code>/v1/</code> version prefix.</p>
+      <pre class="resolution"><span class="comment"># compliant - versioned under /v1/</span>
+@app.route("/v1/users")</pre>
     </div>
 
     <div class="violation" id="v12">
@@ -555,6 +612,12 @@ def create_app():
         <span class="flag">observability standard breach</span>
         <span class="flag">platform compliance failure</span>
       </div>
+      <p class="rule" style="margin-top:1rem;"><strong>Enforced pattern.</strong> The service is instrumented with OpenTelemetry before it is returned.</p>
+      <pre class="resolution"><span class="comment"># compliant - emits OpenTelemetry traces</span>
+def create_app():
+    app = FastAPI()
+    FastAPIInstrumentor.instrument_app(app)
+    return app</pre>
     </div>
   </section>
 

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -219,7 +219,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
     .answer-capsule strong { color: var(--accent); }
 
-    .resolution { background: var(--surface2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 6px 6px 0; padding: 0.85rem 1rem; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--text); overflow-x: auto; line-height: 1.6; margin: 0.5rem 0 0; }
+    .violation pre.resolution { background: var(--surface2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 0 6px 6px 0; padding: 0.85rem 1rem; font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--text); overflow-x: auto; line-height: 1.6; margin: 0.5rem 0 0; }
     .violation pre.resolution .comment { color: var(--accent-dim); }
 
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -216,6 +216,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .cross-card .cl-title { font-family: 'Inter', sans-serif; font-size: 0.95rem; font-weight: 600; }
     .cross-card .cl-sub { font-size: 0.8rem; color: var(--muted); line-height: 1.6; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
     footer { border-top: 1px solid var(--border); text-align: center; padding: 1.5rem 2rem; font-size: 0.78rem; color: var(--muted); }
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--text); }
@@ -336,6 +339,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <li aria-current="page">Governance violations</li>
   </ol>
 </nav>
+
+<div class="answer-capsule"><strong>Mneme blocks five classes of governance violation before code is generated:</strong> architecture, workflow, security, dependency, and platform. Each rule maps a forbidden pattern to a deterministic verdict, so AI agents cannot ship the violation in the first place.</div>
 
 <section class="hero">
   <div class="section-eyebrow">What Mneme prevents</div>

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -115,6 +115,9 @@
     .cross-card .cl-title { font-family: 'Inter', sans-serif; font-size: 0.95rem; font-weight: 600; }
     .cross-card .cl-sub { font-size: 0.8rem; color: var(--muted); line-height: 1.6; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
     .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
     .nav-hamburger:hover { border-color: var(--accent); }
     .nav-hamburger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -246,6 +249,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <li aria-current="page">How enforcement works</li>
   </ol>
 </nav>
+
+<div class="answer-capsule"><strong>Mneme enforces architectural decisions at generation time.</strong> It retrieves the relevant decisions for the current edit, evaluates the staged change against them with a precedence engine, and returns a binary verdict before the code reaches review.</div>
 
 <section class="hero">
   <div class="section-eyebrow">How it works</div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -90,6 +90,12 @@
     .doc-card p { font-size: 0.86rem; color: var(--muted); line-height: 1.65; flex: 1; }
     .doc-card .read { font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--accent); margin-top: 0.3rem; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
+    .quickstart pre { background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: 0.95rem 1.1rem; font-family: 'DM Mono', monospace; font-size: 0.82rem; color: var(--text); overflow-x: auto; line-height: 1.7; margin: 1.25rem 0; max-width: 760px; }
+    .quickstart pre .cp { color: var(--accent); }
+
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--text); }
 
@@ -226,14 +232,22 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
 <main>
 
+<div class="answer-capsule"><strong>Mneme is an open-source CLI that governs AI coding agents.</strong> These docs cover installation, the <code>mneme check</code> enforcement flow, the governance violations Mneme blocks before generation, supported languages, and the deterministic benchmark methodology.</div>
+
 <section class="hero">
   <div class="section-eyebrow">Reference documentation</div>
   <h1>Docs.</h1>
   <p class="hero-sub">Reference for the CLI, the governance violations Mneme catches, supported languages, and the benchmark methodology.</p>
 </section>
 
-<div class="wrap">
-  <h2 style="font-family:'DM Mono',monospace;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);margin:0 0 1.25rem;">Reference surfaces</h2>
+<div class="wrap quickstart">
+  <h2 style="font-family:'DM Mono',monospace;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);margin:0 0 1.25rem;">Quick start</h2>
+  <p style="font-size:0.92rem;color:var(--muted);line-height:1.75;max-width:780px;margin:0;">Zero to a governed check in two commands. Python 3.10+.</p>
+<pre><span class="cp">$</span> pip install mneme-hq
+<span class="cp">$</span> mneme check --memory .mneme/project_memory.json --input prompt.txt --query "storage backend"</pre>
+  <p style="font-size:0.9rem;color:var(--muted);line-height:1.85;max-width:780px;margin:0 0 1rem;">Exit code <code>0</code> = pass, <code>1</code> = warn, <code>2</code> = fail. To enforce on every AI edit in Claude Code, install the PreToolUse hook: <code>python scripts/install_claude_code.py</code>. To generate a Cursor rules file: <code>mneme cursor generate --memory .mneme/project_memory.json --query "storage backend"</code>.</p>
+
+  <h2 style="font-family:'DM Mono',monospace;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);margin:3.5rem 0 1.25rem;">Reference surfaces</h2>
   <p style="font-size:0.92rem;color:var(--muted);line-height:1.75;max-width:780px;margin:0 0 2rem;">Mneme HQ's documentation is intentionally narrow. We document the surfaces that engineers actually need to operate the governance layer: the CLI you run, the violations Mneme catches, the languages Mneme governs today, and the methodology behind the benchmark. Everything else lives in the source repository.</p>
 
   <div class="doc-grid">

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -211,6 +211,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .cross-card .cl-title { font-family: 'Inter', sans-serif; font-size: 0.95rem; font-weight: 600; }
     .cross-card .cl-sub { font-size: 0.8rem; color: var(--muted); line-height: 1.6; }
 
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
 /* === Nav upgrade (injected, overrides existing) === */
 .nav-hamburger { display: none; background: none; border: 1px solid var(--border2); color: var(--text); width: 40px; height: 40px; border-radius: 8px; cursor: pointer; padding: 0; flex-shrink: 0; align-items: center; justify-content: center; flex-direction: column; gap: 4px; transition: border-color 0.15s, background 0.15s; }
 .nav-hamburger:hover { border-color: var(--accent); }
@@ -259,6 +262,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <li aria-current="page">Supported languages</li>
   </ol>
 </nav>
+
+<div class="answer-capsule"><strong>Mneme governs decisions, not syntax, so its enforcement is language-agnostic.</strong> It ships Tier 1 production-grade depth for Python, TypeScript, and JavaScript, and Tier 2 repository-level governance for Go, Java, C#, and Rust, with the same architectural, dependency, and workflow rules applied across every language a team writes.</div>
 
 <section class="hero">
   <div class="section-eyebrow">Reference</div>

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -263,7 +263,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   </ol>
 </nav>
 
-<div class="answer-capsule"><strong>Mneme governs decisions, not syntax, so its enforcement is language-agnostic.</strong> It ships Tier 1 production-grade depth for Python, TypeScript, and JavaScript, and Tier 2 repository-level governance for Go, Java, C#, and Rust, with the same architectural, dependency, and workflow rules applied across every language a team writes.</div>
+<div class="answer-capsule"><strong>Mneme governs decisions, not syntax, so its enforcement is language-agnostic.</strong> It ships production-grade depth for Python and operational support for TypeScript and JavaScript (Tier 1), plus Tier 2 repository-level governance for Go, Java, C#, and Rust, with the same architectural, dependency, and workflow rules applied across every language a team writes.</div>
 
 <section class="hero">
   <div class="section-eyebrow">Reference</div>

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -7,7 +7,7 @@
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta name="description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and generates ADR-backed rules into Cursor every session — with conflict resolution and versioning that flat Cursor Rules files lack." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/integrations/cursor/" />
@@ -15,12 +15,12 @@
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
   <meta property="og:title" content="Cursor Governance — Mneme HQ" />
-  <meta property="og:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta property="og:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and generates ADR-backed rules into Cursor every session — with conflict resolution and versioning that flat Cursor Rules files lack." />
   <meta property="og:url" content="https://mnemehq.com/integrations/cursor/" />
   <meta property="og:image" content="https://mnemehq.com/integrations/cursor/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Cursor Governance — Mneme HQ" />
-  <meta name="twitter:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and exports ADR-backed rules into Cursor every session — with conflict resolution and versioning that .cursorrules files lack." />
+  <meta name="twitter:description" content="Cursor governance for AI-assisted teams. Mneme HQ holds the structured decision corpus and generates ADR-backed rules into Cursor every session — with conflict resolution and versioning that flat Cursor Rules files lack." />
   <meta name="twitter:image" content="https://mnemehq.com/integrations/cursor/og.png" />
   <meta name="author" content="Theo Valmis" />
   <meta property="article:published_time" content="2026-05-07T00:00:00Z" />
@@ -314,7 +314,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       {
         "@type": "Article",
         "headline": "Mneme HQ + Cursor",
-        "description": "Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that .cursorrules files lack.",
+        "description": "Keep architectural decisions in Mneme HQ. Surface them as Cursor Rules every session — with conflict resolution and versioning that flat Cursor Rules files lack.",
         "url": "https://mnemehq.com/integrations/cursor/",
         "datePublished": "2026-05-07",
         "dateModified": "2026-05-07",
@@ -327,7 +327,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         "@type": "FAQPage",
         "mainEntity": [
           {"@type": "Question", "name": "Does Mneme replace Cursor Rules entirely?", "acceptedAnswer": {"@type": "Answer", "text": "No — Mneme generates the Cursor Rules file from a structured source. Cursor still reads .cursor/rules/ at session start; the difference is that the file is now a derived artifact with precedence resolution and version history rather than a manual document."}},
-          {"@type": "Question", "name": "Can I edit .cursorrules directly while Mneme is in place?", "acceptedAnswer": {"@type": "Answer", "text": "You can, but the next regenerate will overwrite it. The recommended workflow is to update project_memory.json and re-run mneme cursor generate. That way the change is tracked as a decision-record edit rather than a quiet rule-file change."}},
+          {"@type": "Question", "name": "Can I edit .cursor/rules/mneme.mdc directly while Mneme is in place?", "acceptedAnswer": {"@type": "Answer", "text": "You can, but the next regenerate will overwrite it. The recommended workflow is to update project_memory.json and re-run mneme cursor generate. That way the change is tracked as a decision-record edit rather than a quiet rule-file change."}},
           {"@type": "Question", "name": "Does this work with Cursor's MCP integration?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Mneme is on the roadmap to expose its decision store as an MCP server; once shipped, Cursor's MCP-aware sessions can query the corpus directly without going through the rules file."}}
         ]
       }
@@ -386,32 +386,32 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <ul>
       <li>Mneme HQ stores architectural decisions in <code>.mneme/project_memory.json</code> — typed, scoped, versioned</li>
-      <li>A single export command generates a <code>.cursorrules</code> file from the active decision corpus</li>
-      <li>Mneme's precedence engine resolves conflicts before export — Cursor sees a clean, non-contradictory rule set</li>
-      <li>You edit decisions in Mneme; re-export to update Cursor Rules</li>
+      <li>A single generate command writes a <code>.cursor/rules/mneme.mdc</code> file from the active decision corpus</li>
+      <li>Mneme's precedence engine resolves conflicts before generation — Cursor sees a clean, non-contradictory rule set</li>
+      <li>You edit decisions in Mneme; regenerate to update Cursor Rules</li>
     </ul>
 
     <h2>What Mneme adds to the workflow</h2>
 
     <ul>
-      <li><strong>Source of truth is structured JSON</strong> — not the <code>.cursorrules</code> file itself</li>
+      <li><strong>Source of truth is structured JSON</strong> — not the <code>.cursor/rules/mneme.mdc</code> file itself</li>
       <li><strong>Conflict resolution happens in Mneme</strong> before Cursor ever sees the rules</li>
-      <li>Decisions carry <code>rationale</code>, <code>supersedes</code>, and <code>status</code> fields — <code>.cursorrules</code> carries none of this</li>
+      <li>Decisions carry <code>rationale</code>, <code>supersedes</code>, and <code>status</code> fields — the generated rule file carries none of this</li>
       <li>When you add Claude Code to the stack, Mneme's hook-level enforcement applies automatically — no migration</li>
     </ul>
 
     <h2>Setup</h2>
 
     <pre><code>pip install mneme-hq
-# Export active decisions to .cursorrules
-mneme export --format cursor-rules > .cursorrules</code></pre>
+# Generate Cursor Rules from active decisions
+mneme cursor generate --memory .mneme/project_memory.json --query "service boundaries"</code></pre>
 
     <h2>Recommended workflow</h2>
 
     <ol>
       <li>Record decisions via <code>/mneme-record</code> (Claude Code) or edit <code>project_memory.json</code> directly</li>
-      <li>Re-export before opening Cursor: <code>mneme export --format cursor-rules &gt; .cursorrules</code></li>
-      <li>Commit both files — Mneme corpus is the source, <code>.cursorrules</code> is the derived surface</li>
+      <li>Regenerate before opening Cursor: <code>mneme cursor generate --memory .mneme/project_memory.json --query "..."</code></li>
+      <li>Commit both files — Mneme corpus is the source, <code>.cursor/rules/mneme.mdc</code> is the derived surface</li>
     </ol>
 
     <h2>If you use Cursor and Claude Code</h2>
@@ -419,7 +419,7 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
     <p>Running both editors against the same codebase? Mneme keeps them consistent without duplication:</p>
 
     <ul>
-      <li>Cursor sessions use the <code>.cursorrules</code> export for context injection</li>
+      <li>Cursor sessions use the generated <code>.cursor/rules/mneme.mdc</code> file for context injection</li>
       <li>Claude Code sessions use the PreToolUse hook for enforcement</li>
       <li>Both draw from the same Mneme corpus — one authoritative source, two surfaces</li>
     </ul>
@@ -430,7 +430,7 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
 
     <h2>What changes when you wire Mneme into Cursor</h2>
 
-    <p>Cursor's strength is interactive coding: an engineer types intent, the editor surfaces context, the model responds. The <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursorrules</code> file is how that context arrives at the model. Without governance, the file accumulates ad-hoc rules that the editor injects on every session &mdash; useful for personal preferences, weak as architectural enforcement.</p>
+    <p>Cursor's strength is interactive coding: an engineer types intent, the editor surfaces context, the model responds. The <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursor/rules/mneme.mdc</code> file is how that context arrives at the model. Without governance, that rule file accumulates ad-hoc rules that the editor injects on every session &mdash; useful for personal preferences, weak as architectural enforcement.</p>
 
     <p>With Mneme, the rules become a <em>generated artifact</em> rather than a hand-edited file. The decision corpus in <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">project_memory.json</code> is the source of truth; <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">mneme cursor generate</code> writes a scoped <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursor/rules/mneme.mdc</code> file that Cursor picks up automatically. Three things change in practice:</p>
 
@@ -448,7 +448,7 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
         <div style="padding-top:0.85rem; font-size:0.85rem; color:var(--muted); line-height:1.8;">No &mdash; Mneme generates the Cursor Rules file from a structured source. Cursor still reads <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursor/rules/</code> at session start; the difference is that the file is now a derived artifact with precedence resolution and version history rather than a manual document. See <a href="/compare/cursor-rules/" style="color:var(--accent);">the full comparison</a>.</div>
       </details>
       <details class="faq-item" style="border-top:1px solid var(--border); padding:1.05rem 0;">
-        <summary style="cursor:pointer; font-size:0.92rem; color:var(--text); font-weight:500; list-style:none; position:relative; padding-right:2rem;">Can I edit <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursorrules</code> directly while Mneme is in place?</summary>
+        <summary style="cursor:pointer; font-size:0.92rem; color:var(--text); font-weight:500; list-style:none; position:relative; padding-right:2rem;">Can I edit <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">.cursor/rules/mneme.mdc</code> directly while Mneme is in place?</summary>
         <div style="padding-top:0.85rem; font-size:0.85rem; color:var(--muted); line-height:1.8;">You can, but the next regenerate will overwrite it. The recommended workflow is to update <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">project_memory.json</code> and re-run <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">mneme cursor generate</code>. That way the change is tracked as a decision-record edit rather than a quiet rule-file change.</div>
       </details>
       <details class="faq-item" style="border-top:1px solid var(--border); border-bottom:1px solid var(--border); padding:1.05rem 0;">

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -384,6 +384,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <h2>How it works together</h2>
 
+    <p>Mneme regenerates the <code>.cursor/rules/mneme.mdc</code> file from the decision corpus each session, so Cursor always reads a current, conflict-resolved rule set rather than a hand-maintained file that drifts.</p>
+
     <ul>
       <li>Mneme HQ stores architectural decisions in <code>.mneme/project_memory.json</code> — typed, scoped, versioned</li>
       <li>A single generate command writes a <code>.cursor/rules/mneme.mdc</code> file from the active decision corpus</li>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -393,7 +393,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <h2>How it works</h2>
 
-    <p>The workflow runs <code>mneme check</code> against the changed files in the PR diff; exit 2 fails the job and blocks the merge, exit 0 lets it through.</p>
+    <p>The workflow runs <code>mneme check</code> against the changed files in the PR diff.</p>
 
     <ul>
       <li><code>mneme check</code> validates a file or diff against the decision corpus in <code>.mneme/project_memory.json</code></li>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -393,6 +393,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <h2>How it works</h2>
 
+    <p>The workflow runs <code>mneme check</code> against the changed files in the PR diff; exit 2 fails the job and blocks the merge, exit 0 lets it through.</p>
+
     <ul>
       <li><code>mneme check</code> validates a file or diff against the decision corpus in <code>.mneme/project_memory.json</code></li>
       <li>Run against changed files in a PR to surface any architectural violations</li>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -431,7 +431,7 @@ jobs:
       <li>CI enforcement gate is Phase 1 current focus — see the <a href="/roadmap/" style="color:var(--accent);text-decoration:none;">roadmap</a></li>
       <li>The <code>mneme check</code> command is available today via <code>pip install mneme-hq</code></li>
       <li>The GitHub Actions workflow above is the reference integration pattern</li>
-      <li>Managed GitHub Actions workflow artifact coming in Q3 2026</li>
+      <li>As of mneme-hq v0.4.x (June 2026), the manual workflow file above is the supported pattern. A managed GitHub Actions workflow artifact is slated for Q3 2026.</li>
     </ul>
 
     <h2>Layered governance model</h2>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -391,7 +391,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <h2>How it works</h2>
 
-    <p>The pipeline job runs <code>mneme check</code> against the changed files in the merge request diff; exit 2 fails the job and blocks the MR, exit 0 lets it through.</p>
+    <p>The pipeline job runs <code>mneme check</code> against the changed files in the merge request diff.</p>
 
     <ul>
       <li><code>mneme check</code> validates a file or diff against the decision corpus in <code>.mneme/project_memory.json</code></li>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -391,6 +391,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <h2>How it works</h2>
 
+    <p>The pipeline job runs <code>mneme check</code> against the changed files in the merge request diff; exit 2 fails the job and blocks the MR, exit 0 lets it through.</p>
+
     <ul>
       <li><code>mneme check</code> validates a file or diff against the decision corpus in <code>.mneme/project_memory.json</code></li>
       <li>Run against changed files in a merge request to surface any architectural violations</li>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -418,7 +418,7 @@ mneme-governance:
       <li>CI enforcement gate is Phase 1 current focus &mdash; see the <a href="/roadmap/" style="color:var(--accent);text-decoration:none;">roadmap</a></li>
       <li>The <code>mneme check</code> command is available today via <code>pip install mneme-hq</code></li>
       <li>The GitLab CI job above is the reference integration pattern</li>
-      <li>Managed GitLab CI template artifact coming in Q3 2026</li>
+      <li>As of mneme-hq v0.4.x (June 2026), the manual CI job above is the supported pattern. A managed GitLab CI template artifact is slated for Q3 2026.</li>
     </ul>
 
     <h2>Layered governance model</h2>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -337,6 +337,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         </div>
         <h3>Governing Claude Code Workflows</h3>
         <p>Hook-level enforcement for every Edit, Write, and MultiEdit Claude Code attempts. Violations block before they reach disk — no PR required.</p>
+        <code style="display:block; font-family:'DM Mono',monospace; font-size:0.74rem; color:var(--teal); background:var(--surface2); border:1px solid var(--border); border-radius:6px; padding:0.5rem 0.65rem; margin-top:0.4rem; overflow-x:auto; white-space:nowrap;">python scripts/install_claude_code.py</code>
         <div class="card-footer">
           <span class="read-link">Learn more →</span>
         </div>
@@ -363,6 +364,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         </div>
         <h3>Mneme HQ + Cursor</h3>
         <p>Keep architectural decisions in Mneme's structured corpus. Export to Cursor Rules for every session — one authoritative source, two surfaces.</p>
+        <code style="display:block; font-family:'DM Mono',monospace; font-size:0.74rem; color:var(--teal); background:var(--surface2); border:1px solid var(--border); border-radius:6px; padding:0.5rem 0.65rem; margin-top:0.4rem; overflow-x:auto; white-space:nowrap;">mneme cursor generate --memory .mneme/project_memory.json --query "service boundaries"</code>
         <div class="card-footer">
           <span class="read-link">Learn more →</span>
         </div>
@@ -376,6 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         </div>
         <h3>Architectural Governance in GitHub Actions</h3>
         <p>Run Mneme's enforcement checks against every PR diff. Block merges that violate architectural decisions — a second enforcement layer after generation.</p>
+        <code style="display:block; font-family:'DM Mono',monospace; font-size:0.74rem; color:var(--teal); background:var(--surface2); border:1px solid var(--border); border-radius:6px; padding:0.5rem 0.65rem; margin-top:0.4rem; overflow-x:auto; white-space:nowrap;">mneme check --memory .mneme/project_memory.json --input "$FILE" --query "service boundaries"</code>
         <div class="card-footer">
           <span class="read-link">Learn more →</span>
         </div>

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -131,6 +131,59 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://mnemehq.com/" },
           { "@type": "ListItem", "position": 2, "name": "Pilot", "item": "https://mnemehq.com/pilot/" }
         ]
+      },
+      {
+        "@type": "Service",
+        "name": "Mneme Architectural Governance Pilot",
+        "serviceType": "Architectural governance for AI-assisted engineering teams",
+        "provider": { "@type": "Organization", "name": "Mneme HQ", "url": "https://mnemehq.com/" },
+        "url": "https://mnemehq.com/pilot/",
+        "description": "A hands-on pilot that applies Mneme's deterministic architectural governance across a team's repositories, ADRs, and AI coding agent workflows."
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Who is the Mneme pilot for?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Engineering teams already using AI coding tools (Cursor, Claude Code, GitHub Copilot, or agentic workflows) that have existing ADRs, repo rules, or engineering standards to enforce, and are seeing architectural drift, review delays, or consistency issues in AI-generated code. Strongest fit: platform, backend, infrastructure, or data-heavy systems with non-trivial architectural constraints."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do I need a pilot to use Mneme?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Mneme is open source under the MIT license and self-hosted. You can install it yourself any time with pip install mneme-hq and run mneme check against your repo. The pilot is for teams who want help applying it across their repositories, ADRs, and agent workflows."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which AI coding tools does Mneme work with?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Mneme is repo-native and model-independent. It works alongside Cursor, Claude Code, GitHub Copilot, and agentic IDEs, enforcing the same architectural decisions regardless of which tool or model generates the code."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What do you need from us to start?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The AI coding tools your team uses, the architectural decisions or standards you want enforced (existing ADRs or repo rules are ideal), and the drift or consistency problem you are trying to solve. The form above captures this."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What happens after I submit the form?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Mneme reviews your request and responds within 1-2 business days."
+            }
+          }
+        ]
       }
     ]
   }
@@ -217,6 +270,49 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .breadcrumb a { color: var(--muted); text-decoration: none; }
     .breadcrumb a:hover { color: var(--text); }
     .breadcrumb .sep { color: var(--border2); }
+
+    /* â”€â”€ ANSWER CAPSULE â”€â”€ */
+    .answer-capsule { max-width: 820px; margin: 0 auto; padding: 1.5rem 2rem; background: var(--surface); border-bottom: 1px solid rgba(200,240,96,0.18); font-size: 0.88rem; color: var(--muted); line-height: 1.8; }
+    .answer-capsule strong { color: var(--accent); }
+
+    /* â”€â”€ FAQ â”€â”€ */
+    .faq-section { border-top: 1px solid var(--border); margin-top: 3.5rem; padding-top: 2.5rem; }
+    .faq-section h2 {
+      font-family: 'Instrument Serif', serif;
+      font-size: clamp(1.5rem, 4vw, 2rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.2;
+      margin-bottom: 1.75rem;
+    }
+    .faq-item {
+      border-top: 1px solid var(--border);
+      padding: 1.4rem 0;
+    }
+    .faq-item:last-child { border-bottom: 1px solid var(--border); }
+    .faq-item h3 {
+      font-family: 'Inter', sans-serif;
+      font-size: 0.92rem;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 0.6rem;
+      letter-spacing: -0.01em;
+    }
+    .faq-item p {
+      font-size: 0.86rem;
+      color: var(--muted);
+      line-height: 1.7;
+      margin: 0;
+    }
+    .faq-item code {
+      font-family: 'DM Mono', monospace;
+      font-size: 0.8rem;
+      background: var(--surface2);
+      border: 1px solid var(--border2);
+      border-radius: 4px;
+      padding: 0.05rem 0.35rem;
+      color: var(--teal);
+    }
 
     /* â”€â”€ HEADER â”€â”€ */
     .page-tag {
@@ -502,6 +598,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <span>Pilot</span>
   </div>
 
+  <div class="answer-capsule"><strong>A Mneme pilot brings deterministic architectural governance to engineering teams already using AI coding tools.</strong> Mneme enforces your team's architectural decisions across repositories, ADRs, and agent workflows in tools like Cursor, Claude Code, and GitHub Copilot, so standards are enforced at generation time rather than caught in review.</div>
+
   <div class="page-tag">Early access</div>
   <h1>Request a Mneme Pilot</h1>
   <p class="page-sub">Mneme is currently working with engineering teams using AI coding tools who need deterministic architectural governance across repositories, ADRs, and agent workflows.</p>
@@ -511,7 +609,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <ul class="fit-list">
       <li>Cursor, Claude Code, GitHub Copilot, or agentic coding workflows in active use</li>
       <li>Existing ADRs, repo rules, or engineering standards to enforce</li>
-      <li>Architectural drift, review bottlenecks, or consistency issues appearing in AI-generated code</li>
+      <li>Architectural drift, review delays, or consistency issues appearing in AI-generated code</li>
       <li>Platform, backend, infrastructure, or data-heavy systems with non-trivial architectural constraints</li>
     </ul>
   </div>
@@ -557,7 +655,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
       <div class="field">
         <label for="pilot-challenge">What governance challenge are you trying to solve?</label>
-        <textarea id="pilot-challenge" name="challenge" placeholder="Describe the architectural drift, review bottleneck, or consistency problem you're dealing with…"></textarea>
+        <textarea id="pilot-challenge" name="challenge" placeholder="Describe the architectural drift, review delays, or consistency problem you're dealing with…"></textarea>
         <span class="field-hint">No minimum length — a sentence is fine.</span>
       </div>
 
@@ -577,6 +675,35 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <p style="font-size:0.88rem;color:var(--muted);margin:0;line-height:1.6;">Something went wrong. Please email <a href="mailto:theo@mnemehq.com" style="color:var(--accent);">theo@mnemehq.com</a> directly.</p>
     </div>
   </div>
+
+  <section class="faq-section">
+    <h2>Frequently asked</h2>
+
+    <div class="faq-item">
+      <h3>Who is the Mneme pilot for?</h3>
+      <p>Engineering teams already using AI coding tools (Cursor, Claude Code, GitHub Copilot, or agentic workflows) that have existing ADRs, repo rules, or engineering standards to enforce, and are seeing architectural drift, review delays, or consistency issues in AI-generated code. Strongest fit: platform, backend, infrastructure, or data-heavy systems with non-trivial architectural constraints.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>Do I need a pilot to use Mneme?</h3>
+      <p>No. Mneme is open source under the MIT license and self-hosted. You can install it yourself any time with <code>pip install mneme-hq</code> and run <code>mneme check</code> against your repo. The pilot is for teams who want help applying it across their repositories, ADRs, and agent workflows.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>Which AI coding tools does Mneme work with?</h3>
+      <p>Mneme is repo-native and model-independent. It works alongside Cursor, Claude Code, GitHub Copilot, and agentic IDEs, enforcing the same architectural decisions regardless of which tool or model generates the code.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What do you need from us to start?</h3>
+      <p>The AI coding tools your team uses, the architectural decisions or standards you want enforced (existing ADRs or repo rules are ideal), and the drift or consistency problem you are trying to solve. The form above captures this.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What happens after I submit the form?</h3>
+      <p>Mneme reviews your request and responds within 1-2 business days.</p>
+    </div>
+  </section>
 
 </div>
 </main>


### PR DESCRIPTION
## Summary

Closes genuine Generative-Engine-Optimization (GEO) gaps across the site, derived from evaluating an external GEO advisory chat **against the actual repo** (most of the chat's suggestions were already shipped — llms.txt, AI-bot allowances, FAQPage/SoftwareApplication schema, comparison tables — so those were correctly skipped). 15 commits, ~5 surfaces. Every command on the site was verified against the real `mneme` CLI; no invented commands were introduced.

### Docs
- Lead CLI install with `pip install mneme-hq` (reconciles a 3-way install inconsistency); source path kept as secondary.
- Executable **Quick Start** on the docs hub (real commands only).
- Answer-first `.answer-capsule` TL;DRs on the 5 docs pages that lacked them.
- Compliant-pattern ("Enforced pattern") code blocks on all 12 governance violations.

### Concepts
- `.answer-capsule` TL;DRs on the 8 concept pages that lacked them (24 already had them).

### Compare
- Extractable "The bottom line" summaries on 4 pages.
- Real `mneme check` compose snippets in the "work together" sections of 5 pages.
- In-content **"Request a pilot"** CTA added to all 13 comparison pages (high-intent funnel).

### Integrations
- **Correctness fix:** replaced the non-existent `mneme export --format cursor-rules` with the real `mneme cursor generate` (including JSON-LD schema and the correct `.cursor/rules/mneme.mdc` output path).
- Embedded key commands on the integrations hub; standardized page anatomy to the Claude Code gold standard; version-anchored roadmap items to `v0.4.x (June 2026)`.

### Pilot
- `.answer-capsule` TL;DR + an FAQ section backed by **FAQPage** + **Service** JSON-LD (verifiable answers only — no fabricated duration/price/SLA).
- Removed the 2 "bottleneck" uses on the pilot page.

## Notable findings (follow-ups, not in this PR)
- The site documents a **non-existent `mneme init`** command in ~17 places (incl. copy-paste demo blocks + JSON-LD). Decision: **ship the command** — a separate product PR will implement + test `mneme init`, after which a site-wide CLI-accuracy sweep runs. References left intact here intentionally.
- "bottleneck" still appears ~120× sitewide (left for a separate copy pass per request).

## Test plan
- [x] `scripts/check_encoding.py` — OK (499 files)
- [x] `scripts/check_compare.py` — OK (13/13 registered)
- [x] `scripts/check_concepts_schema.py` — 32 pages, 0 errors
- [x] No invented commands: `mneme export` = 0 sitewide; `mneme init` unchanged (17, intentional)
- [x] JSON-LD on the pilot page parses; FAQPage/Service answers match visible copy
- [ ] Visual spot-check of rendered pages (capsules, compliant-block borders, pilot CTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)