### PR TITLE
feat: add mneme init command to scaffold .mneme/project_memory.json

### DIFF
--- a/mneme-project-memory/CHANGELOG.md
+++ b/mneme-project-memory/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `mneme init` subcommand — scaffolds a valid, empty, neutral
+  `project_memory.json` (default `.mneme/project_memory.json`). Writes a
+  minimal skeleton (`meta` + empty `items` / `examples` / `decisions`) that
+  round-trips through `MemoryStore.load()` and passes `mneme check` with
+  nothing to enforce. No seeded decisions (every decision is enforceable, so
+  sample content would create phantom rules). Refuses to overwrite an existing
+  file unless `--force` is given; `--path` overrides the output location.
+
+### Tests
+
+- `tests/test_cli_init.py` — 6 tests (fresh create, MemoryStore round-trip,
+  refuse-existing, `--force` overwrite, custom `--path`, clean `mneme check`).
+- Full suite: 354 passed, 52 warnings.
+
+---
+
 ## v0.4.2 — 2026-05-05
 
 **Fix: module execution and exit propagation (completes hook reliability)**

--- a/mneme-project-memory/mneme/cli.py
+++ b/mneme-project-memory/mneme/cli.py
@@ -3,6 +3,7 @@ cli.py — Command-line interface for Mneme.
 
 Subcommands
 -----------
+  init              Scaffold an empty project_memory.json.
   add_decision      Append a new Decision to a project_memory.json file.
   list_decisions    Print every Decision in the memory file.
   test_query        Run a query through the retriever and show scores + injected.
@@ -10,6 +11,7 @@ Subcommands
 
 Usage::
 
+    mneme init
     mneme list_decisions --memory examples/project_memory.json
     mneme add_decision --memory examples/project_memory.json \\
         --id mneme_042 --decision "Use JSON" --scope storage \\
@@ -48,6 +50,55 @@ from mneme.memory_store import MemoryStore
 
 def _utc_now() -> str:
     return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ── Subcommand: init ─────────────────────────────────────────────────────────
+
+DEFAULT_MEMORY_PATH = ".mneme/project_memory.json"
+
+
+def _scaffold_memory() -> dict:
+    """Return a valid, empty, neutral project_memory.json skeleton.
+
+    No seeded decisions: every decision is enforceable, so sample content
+    would create phantom rules. The empty arrays let MemoryStore.load()
+    round-trip the file and let `mneme check` run cleanly (nothing to
+    enforce). meta.name and meta.description are the only fields the loader
+    requires; created_by and project are recorded for provenance.
+    """
+    return {
+        "meta": {
+            "name": "",
+            "description": "",
+            "project": "",
+            "created_by": "mneme init",
+            "created": _utc_now(),
+        },
+        "items": [],
+        "examples": [],
+        "decisions": [],
+    }
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    path = Path(args.path)
+    if path.exists() and not args.force:
+        print(
+            f"ERROR: {path} already exists. Use --force to overwrite.",
+            flush=True,
+        )
+        return 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_scaffold_memory(), indent=2) + "\n", encoding="utf-8")
+
+    print(f"Created {path}")
+    print()
+    print("Next steps:")
+    print(f"  mneme add_decision --memory {path} \\")
+    print('      --id my_001 --decision "..." --scope <area> --constraint "..."')
+    print(f"  mneme check --memory {path} --input <file> --query <context>")
+    return 0
 
 
 # ── Subcommand: list_decisions ───────────────────────────────────────────────
@@ -286,6 +337,20 @@ def _cmd_adr_import(args: argparse.Namespace) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="mneme")
     sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # init
+    p_init = sub.add_parser(
+        "init", help="Scaffold an empty project_memory.json"
+    )
+    p_init.add_argument(
+        "--path", default=DEFAULT_MEMORY_PATH,
+        help=f"Output path (default: {DEFAULT_MEMORY_PATH})",
+    )
+    p_init.add_argument(
+        "--force", action="store_true",
+        help="Overwrite an existing file at --path",
+    )
+    p_init.set_defaults(func=_cmd_init)
 
     # list_decisions
     p_list = sub.add_parser("list_decisions", help="List all decisions")

--- a/mneme-project-memory/mneme/cli.py
+++ b/mneme-project-memory/mneme/cli.py
@@ -64,13 +64,12 @@ def _scaffold_memory() -> dict:
     would create phantom rules. The empty arrays let MemoryStore.load()
     round-trip the file and let `mneme check` run cleanly (nothing to
     enforce). meta.name and meta.description are the only fields the loader
-    requires; created_by and project are recorded for provenance.
+    requires; created_by is recorded for provenance.
     """
     return {
         "meta": {
             "name": "",
             "description": "",
-            "project": "",
             "created_by": "mneme init",
             "created": _utc_now(),
         },

--- a/mneme-project-memory/tests/test_cli_init.py
+++ b/mneme-project-memory/tests/test_cli_init.py
@@ -18,7 +18,8 @@ def test_init_creates_default_path(tmp_path, monkeypatch, capsys):
 
     data = json.loads(target.read_text(encoding="utf-8"))
     assert data["meta"]["created_by"] == "mneme init"
-    assert data["meta"]["project"] == ""
+    assert data["meta"]["name"] == ""
+    assert data["meta"]["description"] == ""
     assert data["decisions"] == []
     # Success output should point at the created file.
     assert ".mneme" in captured

--- a/mneme-project-memory/tests/test_cli_init.py
+++ b/mneme-project-memory/tests/test_cli_init.py
@@ -1,0 +1,101 @@
+"""CLI — init (scaffold a valid, empty, neutral project_memory.json)."""
+import json
+import os
+from pathlib import Path
+
+from mneme.cli import main
+from mneme.memory_store import MemoryStore
+
+
+def test_init_creates_default_path(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    exit_code = main(["init"])
+    captured = capsys.readouterr().out
+
+    target = tmp_path / ".mneme" / "project_memory.json"
+    assert exit_code == 0
+    assert target.exists()
+
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["meta"]["created_by"] == "mneme init"
+    assert data["meta"]["project"] == ""
+    assert data["decisions"] == []
+    # Success output should point at the created file.
+    assert ".mneme" in captured
+
+
+def test_init_roundtrips_through_memory_store(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    exit_code = main(["init"])
+    assert exit_code == 0
+
+    target = tmp_path / ".mneme" / "project_memory.json"
+    # The critical validity guarantee: the scaffold must load cleanly.
+    store = MemoryStore(target)
+    memory = store.load()
+    assert store.decisions() == []
+    assert memory.items == []
+    assert memory.examples == []
+
+
+def test_init_refuses_existing_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / ".mneme" / "project_memory.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    original = '{"sentinel": true}'
+    target.write_text(original, encoding="utf-8")
+
+    exit_code = main(["init"])
+    captured = capsys.readouterr()
+
+    assert exit_code != 0
+    # The existing file must be left untouched.
+    assert target.read_text(encoding="utf-8") == original
+    # A clear refusal message should be emitted.
+    assert "exists" in (captured.out + captured.err).lower()
+
+
+def test_init_force_overwrites_existing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / ".mneme" / "project_memory.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('{"sentinel": true}', encoding="utf-8")
+
+    exit_code = main(["init", "--force"])
+    assert exit_code == 0
+
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert "sentinel" not in data
+    assert data["meta"]["created_by"] == "mneme init"
+
+
+def test_init_custom_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    custom = tmp_path / "nested" / "custom_memory.json"
+
+    exit_code = main(["init", "--path", str(custom)])
+    assert exit_code == 0
+    assert custom.exists()
+
+    data = json.loads(custom.read_text(encoding="utf-8"))
+    assert data["meta"]["created_by"] == "mneme init"
+    # Default location must NOT be created when --path is given.
+    assert not (tmp_path / ".mneme" / "project_memory.json").exists()
+
+
+def test_init_scaffold_passes_check(tmp_path, monkeypatch):
+    """A fresh scaffold has no decisions, so `mneme check` exits 0."""
+    monkeypatch.chdir(tmp_path)
+    assert main(["init"]) == 0
+
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("any prompt text", encoding="utf-8")
+
+    exit_code = main([
+        "check",
+        "--memory", str(memory),
+        "--input", str(prompt),
+        "--query", "anything",
+    ])
+    assert exit_code == 0


### PR DESCRIPTION
## Summary

Adds a real `mneme init` subcommand. The product CLI had no `init` command, yet ~17 places on mnemehq.com (demo copy-paste blocks, the integrations hub, founder page, and JSON-LD HowTo schema) document `mneme init` as the scaffold step. This makes those references accurate and gives new users a one-command path from install to a governed repo.

## Behavior
- `mneme init` writes a valid, empty, **neutral** `.mneme/project_memory.json` (the path the Claude Code hook and `mneme check` default to). Creates `.mneme/` if absent.
- **No seeded decision** — every decision is enforceable, so sample content would create phantom rules. The scaffold is `meta` (loader-required `name`/`description`, empty; `created_by: "mneme init"` + `created` for provenance) plus empty `items`/`examples`/`decisions`.
- Round-trips through `MemoryStore.load()` and `mneme check` exits 0 on it (nothing to enforce).
- **Safe:** refuses if the target exists (exit 1) unless `--force`. Flags: `--path`, `--force` (YAGNI).
- Prints the created path + real next steps (`mneme add_decision …`, then `mneme check …`).

## Scaffold written
```json
{
  "meta": { "name": "", "description": "", "created_by": "mneme init", "created": "<utc>" },
  "items": [], "examples": [], "decisions": []
}
```

## Test plan
- [x] `tests/test_cli_init.py` — 6 tests (fresh create, MemoryStore round-trip, refuse-existing, `--force`, `--path`, `mneme check` exits 0 on scaffold). Written test-first (RED→GREEN).
- [x] Full suite: **354 passed** (was 348; +6), no regressions.
- [x] `mneme check --mode warn` on the repo passes.
- [x] Manual: create → refuse-without-force → `--force` overwrite, all verified.

## Notes
- No version bump in `pyproject.toml` (kept for the release PR); CHANGELOG `## Unreleased` entry added.
- Follow-up (separate, after this releases): site-wide CLI-accuracy sweep to verify all `mneme init` references match this command and align the few that say "repo root" with the `.mneme/` default. Site GEO work that found this is in #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)