### PR TITLE
fix(site): re-sync footer Privacy-choices consent link across all pages

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -250,6 +250,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -1378,6 +1378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -875,6 +875,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -791,6 +791,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -479,6 +479,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -1144,6 +1144,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/aider/index.html
+++ b/site/compare/aider/index.html
@@ -566,6 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -611,6 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/claude-md/index.html
+++ b/site/compare/claude-md/index.html
@@ -634,6 +634,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -618,6 +618,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -564,6 +564,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -631,6 +631,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -486,6 +486,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/github-copilot/index.html
+++ b/site/compare/github-copilot/index.html
@@ -566,6 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -372,6 +372,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -774,6 +774,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -576,6 +576,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -576,6 +576,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/sourcegraph-cody/index.html
+++ b/site/compare/sourcegraph-cody/index.html
@@ -564,6 +564,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/compare/windsurf/index.html
+++ b/site/compare/windsurf/index.html
@@ -564,6 +564,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/agent-verification/index.html
+++ b/site/concepts/agent-verification/index.html
@@ -585,6 +585,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -611,6 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/agentic-ide-governance/index.html
+++ b/site/concepts/agentic-ide-governance/index.html
@@ -386,6 +386,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -702,6 +702,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -354,6 +354,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -599,6 +599,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/ai-operating-layer/index.html
+++ b/site/concepts/ai-operating-layer/index.html
@@ -573,6 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/antigravity-governance/index.html
+++ b/site/concepts/antigravity-governance/index.html
@@ -367,6 +367,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -829,6 +829,7 @@ PostgreSQL only.</span>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -671,6 +671,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -742,6 +742,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/artifact-provenance/index.html
+++ b/site/concepts/artifact-provenance/index.html
@@ -352,6 +352,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/autonomous-software-engineering-governance/index.html
+++ b/site/concepts/autonomous-software-engineering-governance/index.html
@@ -489,6 +489,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -608,6 +608,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -766,6 +766,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -665,6 +665,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/executable-architectural-intent/index.html
+++ b/site/concepts/executable-architectural-intent/index.html
@@ -551,6 +551,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/execution-surfaces/index.html
+++ b/site/concepts/execution-surfaces/index.html
@@ -603,6 +603,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -841,6 +841,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -900,6 +900,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -660,6 +660,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/governance-provenance/index.html
+++ b/site/concepts/governance-provenance/index.html
@@ -647,6 +647,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -980,6 +980,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/intent-debt/index.html
+++ b/site/concepts/intent-debt/index.html
@@ -559,6 +559,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -560,6 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -346,6 +346,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -673,6 +673,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/objective-driven-development/index.html
+++ b/site/concepts/objective-driven-development/index.html
@@ -587,6 +587,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -669,6 +669,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/reliable-delegation/index.html
+++ b/site/concepts/reliable-delegation/index.html
@@ -678,6 +678,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/runtime-governance/index.html
+++ b/site/concepts/runtime-governance/index.html
@@ -549,6 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/spec-driven-development/index.html
+++ b/site/concepts/spec-driven-development/index.html
@@ -381,6 +381,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -764,6 +764,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -713,6 +713,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -617,6 +617,7 @@ Result: WARN</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -592,6 +592,7 @@ python run.py</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -712,6 +712,7 @@ python run.py</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -549,6 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -489,6 +489,7 @@ Result: WARN</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -700,6 +700,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -593,6 +593,7 @@ python run.py</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -542,6 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -561,6 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -719,6 +719,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -674,6 +674,7 @@ jobs:
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -623,6 +623,7 @@ def create_app():
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -375,6 +375,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -316,6 +316,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -558,6 +558,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -621,6 +621,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -582,6 +582,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -561,6 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -574,6 +574,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -792,6 +792,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/index.html
+++ b/site/index.html
@@ -1760,6 +1760,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -583,6 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -361,6 +361,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-formation-engineering-performance-metrics/index.html
+++ b/site/insights/agent-formation-engineering-performance-metrics/index.html
@@ -556,6 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -519,6 +519,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -350,6 +350,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -560,6 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -583,6 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -638,6 +638,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -721,6 +721,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agentic-resource-discovery-agent-governance/index.html
+++ b/site/insights/agentic-resource-discovery-agent-governance/index.html
@@ -568,6 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agentic-workforce-visibility-crisis/index.html
+++ b/site/insights/agentic-workforce-visibility-crisis/index.html
@@ -526,6 +526,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -587,6 +587,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -539,6 +539,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -610,6 +610,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -656,6 +656,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -596,6 +596,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -532,6 +532,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
+++ b/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
@@ -513,6 +513,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-coding-agents-life-sciences-governance/index.html
+++ b/site/insights/ai-coding-agents-life-sciences-governance/index.html
@@ -509,6 +509,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -607,6 +607,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -524,6 +524,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-governance-for-regulated-industries/index.html
+++ b/site/insights/ai-governance-for-regulated-industries/index.html
@@ -531,6 +531,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -401,6 +401,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -646,6 +646,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -635,6 +635,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -594,6 +594,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
+++ b/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
@@ -523,6 +523,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -551,6 +551,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -563,6 +563,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/all/index.html
+++ b/site/insights/all/index.html
@@ -1970,6 +1970,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -544,6 +544,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -560,6 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -371,6 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -863,6 +863,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -351,6 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -603,6 +603,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -527,6 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -404,6 +404,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -542,6 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -528,6 +528,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/block-builderbot-coordination-governance/index.html
+++ b/site/insights/block-builderbot-coordination-governance/index.html
@@ -511,6 +511,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -527,6 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -513,6 +513,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -629,6 +629,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -550,6 +550,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -647,6 +647,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -725,6 +725,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -596,6 +596,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -525,6 +525,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -630,6 +630,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -751,6 +751,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
+++ b/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
@@ -550,6 +550,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -528,6 +528,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -777,6 +777,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -527,6 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -575,6 +575,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -559,6 +559,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -500,6 +500,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -745,6 +745,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -577,6 +577,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -663,6 +663,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/governance-control-plane-after-agent-frameworks/index.html
+++ b/site/insights/governance-control-plane-after-agent-frameworks/index.html
@@ -541,6 +541,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/governance-layers-for-ai-coding-assistants/index.html
+++ b/site/insights/governance-layers-for-ai-coding-assistants/index.html
@@ -526,6 +526,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -583,6 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -810,6 +810,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -577,6 +577,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -587,6 +587,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -530,6 +530,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -696,6 +696,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -513,6 +513,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -543,6 +543,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -570,6 +570,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -895,6 +895,7 @@ mneme check --mode warn</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -514,6 +514,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -645,6 +645,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -533,6 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -668,6 +668,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -900,6 +900,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -570,6 +570,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -521,6 +521,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -578,6 +578,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -521,6 +521,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -529,6 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -496,6 +496,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -620,6 +620,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -536,6 +536,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/open-knowledge-format-vs-governance/index.html
+++ b/site/insights/open-knowledge-format-vs-governance/index.html
@@ -540,6 +540,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -617,6 +617,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -582,6 +582,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -591,6 +591,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -573,6 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -667,6 +667,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -614,6 +614,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -629,6 +629,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/recursive-self-improvement-orchestration-problem/index.html
+++ b/site/insights/recursive-self-improvement-orchestration-problem/index.html
@@ -541,6 +541,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -532,6 +532,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -706,6 +706,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -537,6 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -518,6 +518,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -554,6 +554,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -514,6 +514,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -539,6 +539,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -566,6 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -573,6 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/stanford-ai-index-2026-engineering-governance/index.html
+++ b/site/insights/stanford-ai-index-2026-engineering-governance/index.html
@@ -527,6 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/topics/agent-infrastructure/index.html
+++ b/site/insights/topics/agent-infrastructure/index.html
@@ -790,6 +790,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/topics/ai-coding-agents/index.html
+++ b/site/insights/topics/ai-coding-agents/index.html
@@ -689,6 +689,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/topics/architectural-governance/index.html
+++ b/site/insights/topics/architectural-governance/index.html
@@ -712,6 +712,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/topics/engineering-performance/index.html
+++ b/site/insights/topics/engineering-performance/index.html
@@ -645,6 +645,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -647,6 +647,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -518,6 +518,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -520,6 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -845,6 +845,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -791,6 +791,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -718,6 +718,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -632,6 +632,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -650,6 +650,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -565,6 +565,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -729,6 +729,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -531,6 +531,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -579,6 +579,7 @@ Result: WARN</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/antigravity/index.html
+++ b/site/integrations/antigravity/index.html
@@ -372,6 +372,7 @@ CI records the governance result</pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -739,6 +739,7 @@ jobs:
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -660,6 +660,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -515,6 +515,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -523,6 +523,7 @@ mneme export --format cursor-rules > .cursorrules</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -537,6 +537,7 @@ jobs:
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -525,6 +525,7 @@ mneme-governance:
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -570,6 +570,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -603,6 +603,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/microsoft-agent-forge/index.html
+++ b/site/integrations/microsoft-agent-forge/index.html
@@ -500,6 +500,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/opencode/index.html
+++ b/site/integrations/opencode/index.html
@@ -513,6 +513,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -440,6 +440,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -578,6 +578,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/integrations/warp/index.html
+++ b/site/integrations/warp/index.html
@@ -478,6 +478,7 @@ mneme check --mode warn   # try locally first</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -625,6 +625,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -472,6 +472,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -528,6 +528,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/qa-glossary/index.html
+++ b/site/qa-glossary/index.html
@@ -843,6 +843,7 @@ Body markdown follows.</code></pre>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -554,6 +554,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -539,6 +539,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/fastapi-governance/index.html
+++ b/site/supported-languages/fastapi-governance/index.html
@@ -486,6 +486,7 @@ router = APIRouter(prefix=<span class="kw">"/admin"</span>)  <span class="cm"># 
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -409,6 +409,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -430,6 +430,7 @@ cron.schedule(<span class="kw">"0 3 * * *"</span>, <span class="kw">async</span>
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -455,6 +455,7 @@ app = Celery(<span class="kw">'tasks'</span>, broker=<span class="kw">'redis://l
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/spring-boot-governance/index.html
+++ b/site/supported-languages/spring-boot-governance/index.html
@@ -485,6 +485,7 @@ http.csrf(csrf -&gt; csrf.disable())
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/terraform-governance/index.html
+++ b/site/supported-languages/terraform-governance/index.html
@@ -497,6 +497,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -445,6 +445,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/ci-governance-for-ai-generated-code/index.html
+++ b/site/use-cases/ci-governance-for-ai-generated-code/index.html
@@ -518,6 +518,7 @@ mneme-check:
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -686,6 +686,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -611,6 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -611,6 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -772,6 +772,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -693,6 +693,7 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -648,6 +648,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -697,6 +697,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/works-with/antigravity/index.html
+++ b/site/works-with/antigravity/index.html
@@ -317,6 +317,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/works-with/claude-marketplace/index.html
+++ b/site/works-with/claude-marketplace/index.html
@@ -469,6 +469,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/works-with/devin/index.html
+++ b/site/works-with/devin/index.html
@@ -514,6 +514,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -796,6 +796,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <li><a href="/roadmap/">Roadmap</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="#" onclick="if(window.MnemeConsent){window.MnemeConsent.reopen();}return false;">Privacy choices</a></li>
       </ul>
     </div>
     <div>


### PR DESCRIPTION
## Summary

Fixes a **pre-existing** failure of the `check_nav_footer` drift guard on `main`. The canonical `site/_snippets/footer.html` gained a **"Privacy choices"** consent link (`window.MnemeConsent.reopen()`) in #200, but the per-page footers were never re-synced — so the drift guard has been red for **all 235 content pages** (verified on a clean `origin/main` checkout, not caused by any feature branch).

## Fix
Propagate the single missing `<li>` into each page's footer **Company** column, matching the canonical snippet exactly:
- **One line per file** (235 files, +235 insertions, 0 deletions) — the same shape as the prior footer-link propagation in #196.
- **CRLF-preserving** (reads/writes bytes, matches each file's existing line endings) and **idempotent** (skips any page that already has the link) — no whitespace or line-ending churn.
- The link is inert (`if(window.MnemeConsent){…}return false;`) until the consent controller is injected at deploy, so committing it is safe and consistent with the deploy-time RB2B model.

## Result
`check_nav_footer: OK (235 pages match _snippets/, 210 excluded)`. Other guards still green: `check_encoding`, `check_sticky_nav`, `check_compare`.

## Why separate
This is unrelated to the GEO content work in #202 — it's a sitewide footer re-sync. Landing it green first unblocks #202 (rebase + merge).

## Test plan
- [x] `check_nav_footer.py` → OK (was failing on main)
- [x] `check_encoding.py` → OK (498 files)
- [x] `check_sticky_nav.py` → OK
- [x] `check_compare.py` → OK
- [x] Diff is exactly +1 `<li>` per page, no line-ending churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)