### PR TITLE
ci: deploy via a Mneme-specific self-hosted runner on the whitelisted-egress VM

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,11 +16,20 @@ permissions:
 jobs:
   deploy:
     name: Upload changed site files via cPanel API
-    # Self-hosted runner on the private wp-proxy VM: egress via the NAT IP
-    # whitelisted in Krystal. GitHub-hosted runners use rotating IPs that the
-    # cPanel firewall blocks (TCP connection timeouts to :2083), so the upload
-    # must originate from the whitelisted static IP. Shared with cdus.
-    runs-on: wp-private-runner
+    # Runs on a Mneme-specific self-hosted runner registered on the shared
+    # static-egress GCP VM (Cloud NAT egress 35.209.208.146, whitelisted in
+    # Krystal). GitHub-hosted runners use rotating IPs the cPanel firewall
+    # blocks, so the upload must leave from the whitelisted static IP.
+    #
+    # This is a SEPARATE runner registration from cdus's wp-private-runner —
+    # repo-scoped self-hosted runners are not shared across repositories, so the
+    # cdus runner is left untouched. Register a second runner service on the same
+    # VM, attached to this repo, with the labels `self-hosted` + `mneme-deploy`.
+    #
+    # Security: this job runs ONLY on trusted events (push to main, manual
+    # dispatch, schedule) and never on pull_request, so untrusted PR code is
+    # never executed on the self-hosted runner. Do not add a pull_request trigger.
+    runs-on: [self-hosted, mneme-deploy]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,6 +43,11 @@ jobs:
       - name: Deploy
         env:
           CPANEL_API_TOKEN: ${{ secrets.CPANEL_API_TOKEN }}
+          # cPanel endpoint is configurable via repo Variables so we can point at
+          # the working HTTPS endpoint (e.g. cpanel.theovalmis.com / 443) without a
+          # code change. If unset, deploy_site.py falls back to its built-in default.
+          CPANEL_HOST: ${{ vars.CPANEL_HOST }}
+          CPANEL_PORT: ${{ vars.CPANEL_PORT }}
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
         run: python scripts/deploy_site.py

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,7 +16,11 @@ permissions:
 jobs:
   deploy:
     name: Upload changed site files via cPanel API
-    runs-on: ubuntu-latest
+    # Self-hosted runner on the private wp-proxy VM: egress via the NAT IP
+    # whitelisted in Krystal. GitHub-hosted runners use rotating IPs that the
+    # cPanel firewall blocks (TCP connection timeouts to :2083), so the upload
+    # must originate from the whitelisted static IP. Shared with cdus.
+    runs-on: wp-private-runner
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -112,7 +112,7 @@ def mkdir(remote_path):
         headers={'Authorization': AUTH},
     )
     try:
-        with urllib.request.urlopen(req, context=ctx) as r:
+        with urllib.request.urlopen(req, context=ctx, timeout=60) as r:
             raw = r.read()
     except urllib.error.HTTPError as e:
         raw = e.read()
@@ -168,7 +168,7 @@ def upload(local_path, remote_subdir):
     import time
     for attempt in range(3):
         try:
-            with urllib.request.urlopen(req, context=ctx) as r:
+            with urllib.request.urlopen(req, context=ctx, timeout=60) as r:
                 raw = r.read()
         except (urllib.error.URLError, OSError):
             time.sleep(1 + attempt)

--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -83,8 +83,11 @@ def purge_cf_cache(urls=None):
         print(f'[WARN] Cloudflare purge error (deploy succeeded): {e}')
 
 # ── cPanel credentials ────────────────────────────────────────────────────────
-HOST  = os.environ.get('CPANEL_HOST',  '152.89.79.37')
-PORT  = os.environ.get('CPANEL_PORT',  '2083')
+# Endpoint is overridable via env (set CPANEL_HOST/CPANEL_PORT as repo Variables
+# in CI, e.g. cpanel.theovalmis.com / 443). `or` so an empty value falls back to
+# the default rather than blanking the host.
+HOST  = os.environ.get('CPANEL_HOST')  or '152.89.79.37'
+PORT  = os.environ.get('CPANEL_PORT')  or '2083'
 USER  = os.environ.get('CPANEL_USER',  'cadafdd1')
 TOKEN = os.environ.get('CPANEL_API_TOKEN', '')
 if not TOKEN:


### PR DESCRIPTION
## Problem
Every recent deploy of mnemehq.com fails/hangs: the cPanel host firewall blocks GitHub-hosted runners' **rotating IPs** (`[Errno 110]` timeouts to the cPanel API). The upload dies before IndexNow, so nothing merged to `main` (#202/#203/#204) is live and IndexNow never submits. The host is up; it's specifically GitHub's IP ranges being dropped, and shared hosting can't whitelist rotating IPs.

## Fix (corrected approach)
The reusable asset is the **static egress IP `35.209.208.146`** (the GCP VM's Cloud NAT, whitelisted in Krystal) — **not** cdus's runner. Repo-scoped self-hosted runners aren't shared across repos, so `runs-on: wp-private-runner` would never pick up this job. So:

- `deploy-site.yml`: `runs-on: [self-hosted, mneme-deploy]` (a Mneme-specific runner, see setup below).
- cPanel endpoint made configurable via **repo Variables** (`CPANEL_HOST`/`CPANEL_PORT`) so the working HTTPS endpoint (likely `cpanel.theovalmis.com:443`) can be set without a code change; `deploy_site.py` `or`-falls-back to defaults if unset.
- Added 60s timeouts to the two cPanel `urlopen` calls (they had none → the last run hung ~20 min instead of failing fast).
- Documented that the job runs **only on trusted events** (push to main / dispatch / schedule), never `pull_request`, per GitHub's self-hosted-runner security guidance.

## ⚠️ Required setup before this works (owner)
1. **Register a SECOND runner service on the existing static-egress VM**, attached to `MnemeHQ/mneme`, with labels `self-hosted` + `mneme-deploy`. Leave cdus's `wp-private-runner` untouched. (Repo-level runners are per-repo; org-level would also work.)
2. Restrict it to trusted events (this workflow already does — no `pull_request`).

## ⚠️ Then verify (the whitelist only proved Imunify360 web/WP traffic, NOT cPanel API access)
- Valid cPanel API **token** for the account.
- Correct **HTTPS endpoint** — likely `cpanel.theovalmis.com:443`; set `CPANEL_HOST`/`CPANEL_PORT` repo Variables accordingly.
- Confirm **Krystal permits the cPanel API request from `35.209.208.146`** (the firewall allowance may be web-traffic only; the API on the cPanel port could still 403/deny). If it 403s, fallback is SFTP/FTPS from the same runner.

## After it's green
Re-run the deploy → upload leaves from the whitelisted IP → #202/#203/#204 go live → IndexNow submits the changed URLs.

## Test plan
- [x] `deploy_site.py` compiles
- [ ] `mneme-deploy` runner registered + online on the VM
- [ ] Deploy run reaches the upload from `35.209.208.146`
- [ ] Upload returns 200 (not 403) at the configured endpoint; IndexNow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)