### PR TITLE
ci: run fix-waf-redirect on self-hosted runner so cPanel calls are whitelisted

### DIFF
--- a/.github/workflows/fix-waf-redirect.yml
+++ b/.github/workflows/fix-waf-redirect.yml
@@ -16,7 +16,12 @@ on:
 jobs:
   fix-waf:
     name: Add WAF exceptions (cPanel + Cloudflare)
-    runs-on: ubuntu-latest
+    # Runs on the self-hosted runner so cPanel API calls egress from the
+    # Krystal-whitelisted static IP (Cloud NAT on wp-proxy). ubuntu-latest
+    # exits from a non-whitelisted GitHub IP and is blocked by Imunify360.
+    # Triggers are trusted only (push to main, manual dispatch) — never
+    # pull_request — so untrusted PR code is not executed on the runner.
+    runs-on: [self-hosted, mneme-deploy]
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +32,12 @@ jobs:
       - name: Add ModSec / CF WAF exceptions
         env:
           CPANEL_API_TOKEN: ${{ secrets.CPANEL_API_TOKEN }}
+          # Point at the working HTTPS endpoint (cpanel.theovalmis.com / 443)
+          # via repo Variables, matching deploy-site.yml. Without these the
+          # script falls back to a hardcoded host:port that is not whitelisted.
+          CPANEL_HOST: ${{ vars.CPANEL_HOST }}
+          CPANEL_PORT: ${{ vars.CPANEL_PORT }}
+          CPANEL_USER: ${{ secrets.CPANEL_USER }}
           CF_WAF_TOKEN: ${{ secrets.CF_WAF_TOKEN }}
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}


### PR DESCRIPTION
## Problem
`fix-waf-redirect.yml` calls the cPanel API (`scripts/fix_waf_redirect.py` reads `CPANEL_API_TOKEN`) but ran on `ubuntu-latest`. GitHub-hosted runners egress from IPs that are **not** on the Krystal/Imunify360 whitelist, so the cPanel step would be blocked (403 / timeout). Only the self-hosted runner on `wp-proxy` egresses from the whitelisted Cloud NAT static IP `35.209.208.146`.

## Fix
- Move the job to `runs-on: [self-hosted, mneme-deploy]` (the runner `wp-proxy-mneme`, currently **online**), matching `deploy-site.yml`.
- Pass `CPANEL_HOST`/`CPANEL_PORT` (repo Variables) and `CPANEL_USER` (secret) so the script targets the working `cpanel.theovalmis.com:443` endpoint instead of its hardcoded `152.89.79.37:2083` default.

## Validated
- ✅ YAML parses; `runs-on: [self-hosted, mneme-deploy]`
- ✅ Triggers are `workflow_dispatch` + `push` only — no `pull_request` (untrusted code never runs on the self-hosted runner)
- ✅ `mneme-deploy` runner confirmed online

## Note (out of scope)
`CF_WAF_TOKEN` is referenced but not set in repo secrets. The script falls back to `CF_API_TOKEN` by design, so this is non-fatal — but add `CF_WAF_TOKEN` if zone-level Firewall/Page-Rule scope is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)