### PR TITLE
site: embed YouTube videos on insight/concept pages

### DIFF
--- a/scripts/embed_videos.py
+++ b/scripts/embed_videos.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Idempotent backfill of click-to-load YouTube facades on insight/concept pages.
+
+Mirrors the shared-asset pattern of ``site/assets/css/diagrams.css``: each page
+gets a ``<link>`` to ``/assets/css/video.css``, a ``<script>`` to
+``/assets/js/video.js``, and a facade ``<div>`` inserted mid-``.article-body``.
+Extension pages (``is_core=False``) additionally get a ``VideoObject`` JSON-LD
+block (the core 15 already carry one).
+
+Every insertion helper no-ops when its marker is already present, so re-running
+the script is safe.
+
+Usage:
+    python scripts/embed_videos.py [--dry-run] [--core-only]
+"""
+from __future__ import annotations
+
+import argparse
+import html as _html
+import json
+import re
+from pathlib import Path
+
+try:
+    from scripts.video_map import VIDEO_MAP, EXTENSION_META
+except ImportError:  # allow running as a plain script (python scripts/embed_videos.py)
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from video_map import VIDEO_MAP, EXTENSION_META
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CSS_HREF = "/assets/css/video.css"
+JS_SRC = "/assets/js/video.js"
+CSS_LINK = '<link rel="stylesheet" href="%s">' % CSS_HREF
+JS_SCRIPT = '<script src="%s" defer></script>' % JS_SRC
+THUMB_URL = "https://i.ytimg.com/vi/%s/maxresdefault.jpg"
+
+
+# --------------------------------------------------------------------------- #
+# Head / body asset references
+# --------------------------------------------------------------------------- #
+def insert_head_link(head_html: str) -> str:
+    """Insert the video.css <link> after the diagrams.css link if present,
+    else immediately before </head>. No-op if already present."""
+    if CSS_HREF in head_html:
+        return head_html
+    diagrams = '<link rel="stylesheet" href="/assets/css/diagrams.css">'
+    if diagrams in head_html:
+        return head_html.replace(diagrams, diagrams + "\n  " + CSS_LINK, 1)
+    if "</head>" in head_html:
+        return head_html.replace("</head>", "  " + CSS_LINK + "\n</head>", 1)
+    return head_html + "\n" + CSS_LINK
+
+
+def insert_body_script(html: str) -> str:
+    """Insert the video.js <script> immediately before the real closing
+    </body>. Targets the LAST </body> because real pages contain a literal
+    "</body>" inside an HTML comment (the consent-banner sync marker) that must
+    not be matched. No-op if already present."""
+    if JS_SRC in html:
+        return html
+    idx = html.rfind("</body>")
+    if idx != -1:
+        return html[:idx] + JS_SCRIPT + "\n" + html[idx:]
+    return html + "\n" + JS_SCRIPT
+
+
+# --------------------------------------------------------------------------- #
+# Facade block
+# --------------------------------------------------------------------------- #
+def facade_html(video_id: str, title: str) -> str:
+    """Return the click-to-load facade <div> block. No YouTube network calls
+    fire until the user activates it (handled in video.js)."""
+    safe_title = _html.escape(title, quote=True)
+    return (
+        '<div class="yt-facade" data-video-id="%s" data-title="%s" role="button" '
+        'tabindex="0" aria-label="Play video: %s">\n'
+        '      <img class="yt-facade__thumb" src="%s" alt="" loading="lazy">\n'
+        '      <span class="yt-facade__play" aria-hidden="true"></span>\n'
+        '    </div>'
+        % (video_id, safe_title, safe_title, THUMB_URL % video_id)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Article body location + midpoint insertion
+# --------------------------------------------------------------------------- #
+def find_article_body(html: str):
+    """Return (start, end) char offsets spanning the ``<div class="article-body">
+    ... </div>`` block, where ``start`` is the offset of the opening ``<div`` and
+    ``end`` is just past the matching ``</div>``. Returns None if not found.
+
+    Matches the opening tag, then balances nested ``<div>``/``</div>`` to find the
+    correct closing tag."""
+    m = re.search(r'<div class="article-body"[^>]*>', html)
+    if not m:
+        return None
+    start = m.start()
+    i = m.end()
+    depth = 1
+    tag_re = re.compile(r'<(/?)div\b[^>]*>', re.IGNORECASE)
+    for tm in tag_re.finditer(html, i):
+        if tm.group(1):  # closing </div>
+            depth -= 1
+            if depth == 0:
+                return (start, tm.end())
+        else:  # opening <div ...>
+            depth += 1
+    return None
+
+
+def insert_facade_midpoint(body_html: str, facade: str) -> str:
+    """Insert ``facade`` immediately before the midpoint top-level ``<h2>`` in
+    ``body_html``. If fewer than 2 ``<h2>`` are present, insert after the first
+    ``</p>``. No-op if a ``yt-facade`` is already present."""
+    if "yt-facade" in body_html:
+        return body_html
+
+    h2s = [m.start() for m in re.finditer(r'<h2\b', body_html, re.IGNORECASE)]
+    if len(h2s) >= 2:
+        idx = h2s[len(h2s) // 2]
+        return body_html[:idx] + facade + "\n\n    " + body_html[idx:]
+
+    # Fallback: after the first </p>.
+    pm = re.search(r'</p>', body_html, re.IGNORECASE)
+    if pm:
+        cut = pm.end()
+        return body_html[:cut] + "\n\n    " + facade + body_html[cut:]
+
+    # No <h2> and no </p>: append at end of body content.
+    return body_html + "\n    " + facade
+
+
+def replace_video_wrap(html: str, facade: str):
+    """If the page already carries a native ``<div class="video-wrap"> ...
+    </div>`` iframe embed, replace that whole block with the click-to-load
+    ``facade`` (in place, preserving any surrounding intro copy). Returns
+    (new_html, replaced). No-op (replaced=False) if no .video-wrap is present or
+    a yt-facade already exists."""
+    if "yt-facade" in html or 'class="video-wrap"' not in html:
+        return html, False
+    m = re.search(r'<div class="video-wrap"[^>]*>', html)
+    if not m:
+        return html, False
+    start = m.start()
+    i = m.end()
+    depth = 1
+    for tm in re.compile(r'<(/?)div\b[^>]*>', re.IGNORECASE).finditer(html, i):
+        if tm.group(1):
+            depth -= 1
+            if depth == 0:
+                end = tm.end()
+                return html[:start] + facade + html[end:], True
+        else:
+            depth += 1
+    return html, False
+
+
+# --------------------------------------------------------------------------- #
+# VideoObject schema (extension pages only)
+# --------------------------------------------------------------------------- #
+def video_object_schema(video_id: str, meta: dict) -> str:
+    """Return a ``<script type="application/ld+json" data-video-schema="...">``
+    block matching the shape of the existing 15 core schemas. ``duration`` is
+    emitted only when present and truthy (the YouTube MCP does not expose it)."""
+    schema = {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": meta["name"],
+        "description": meta["description"],
+        "thumbnailUrl": THUMB_URL % video_id,
+        "uploadDate": meta["uploadDate"],
+    }
+    if meta.get("duration"):
+        schema["duration"] = meta["duration"]
+    schema["embedUrl"] = "https://www.youtube.com/embed/%s" % video_id
+    schema["contentUrl"] = "https://www.youtube.com/watch?v=%s" % video_id
+    schema["publisher"] = {
+        "@type": "Organization",
+        "name": "Mneme HQ",
+        "logo": {"@type": "ImageObject", "url": "https://mnemehq.com/og.png"},
+    }
+    key = re.sub(r"[^a-z0-9]+", "_", video_id.lower()).strip("_")
+    body = json.dumps(schema, indent=2, ensure_ascii=False)
+    return (
+        '<script type="application/ld+json" data-video-schema="%s">\n%s\n</script>'
+        % (key, body)
+    )
+
+
+def insert_video_schema(html: str, video_id: str, meta: dict) -> str:
+    """Insert the VideoObject JSON-LD block just before </head>.
+    No-op if a data-video-schema block is already present."""
+    if "data-video-schema" in html:
+        return html
+    block = video_object_schema(video_id, meta)
+    if "</head>" in html:
+        return html.replace("</head>", block + "\n</head>", 1)
+    return html + "\n" + block
+
+
+# --------------------------------------------------------------------------- #
+# Page processing
+# --------------------------------------------------------------------------- #
+def _page_title(html: str, fallback: str) -> str:
+    m = re.search(r"<title>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+    if m:
+        title = _html.unescape(m.group(1)).strip()
+        title = re.split(r"\s+[—\-|]\s+Mneme HQ", title)[0].strip()
+        if title:
+            return title
+    return fallback
+
+
+def process_page(path: Path, video_id: str, is_core: bool, meta: dict | None) -> dict:
+    """Apply head link + facade + body script to the page at ``path``. For
+    extension pages (``is_core=False``), also insert the VideoObject schema.
+    Idempotent: re-running makes no further change. Returns a per-page summary.
+    """
+    original = path.read_text(encoding="utf-8")
+    html = original
+
+    title = _page_title(html, video_id)
+    html = insert_head_link(html)
+
+    facade = facade_html(video_id, title)
+    facade_added = False
+
+    # If the page already has a native auto-loading .video-wrap embed, replace it
+    # in place with the click-to-load facade (privacy upgrade + avoids a duplicate
+    # player). Otherwise insert the facade at the article-body midpoint.
+    html, replaced = replace_video_wrap(html, facade)
+    if replaced:
+        facade_added = True
+    else:
+        span = find_article_body(html)
+        if span and "yt-facade" not in html:
+            start, end = span
+            body = html[start:end]
+            new_body = insert_facade_midpoint(body, facade)
+            if new_body != body:
+                html = html[:start] + new_body + html[end:]
+                facade_added = True
+
+    html = insert_body_script(html)
+
+    schema_added = False
+    if not is_core:
+        if meta is None:
+            raise ValueError("extension page %s missing EXTENSION_META" % path)
+        before = html
+        html = insert_video_schema(html, video_id, meta)
+        schema_added = html != before
+
+    changed = html != original
+    return {
+        "path": path,
+        "video_id": video_id,
+        "is_core": is_core,
+        "exists": True,
+        "changed": changed,
+        "facade_added": facade_added,
+        "schema_added": schema_added,
+        "_new_html": html,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what would change without writing files")
+    parser.add_argument("--core-only", action="store_true",
+                        help="process only the core (is_core=True) pages")
+    args = parser.parse_args(argv)
+
+    core_n = sum(1 for _id, core in VIDEO_MAP.values() if core)
+    ext_n = sum(1 for _id, core in VIDEO_MAP.values() if not core)
+    print("VIDEO_MAP: %d pages (%d core, %d extension)" % (len(VIDEO_MAP), core_n, ext_n))
+    if args.dry_run:
+        print("[dry-run] no files will be written")
+    if args.core_only:
+        print("[core-only] extension pages skipped")
+
+    written = 0
+    skipped_missing = 0
+    unchanged = 0
+    for slug, (video_id, is_core) in VIDEO_MAP.items():
+        if args.core_only and not is_core:
+            continue
+        path = REPO_ROOT / "site" / slug / "index.html"
+        if not path.exists():
+            print("  MISSING  %s (%s)" % (slug, path))
+            skipped_missing += 1
+            continue
+        meta = None if is_core else EXTENSION_META.get(video_id)
+        result = process_page(path, video_id, is_core, meta)
+        tag = "core" if is_core else "ext "
+        flags = []
+        if result["facade_added"]:
+            flags.append("facade")
+        if result["schema_added"]:
+            flags.append("schema")
+        if not result["changed"]:
+            unchanged += 1
+            print("  ok       [%s] %s (already current)" % (tag, slug))
+            continue
+        if args.dry_run:
+            print("  would    [%s] %s -> %s" % (tag, slug, "+".join(flags) or "head/body"))
+        else:
+            path.write_text(result["_new_html"], encoding="utf-8")
+            written += 1
+            print("  WROTE    [%s] %s -> %s" % (tag, slug, "+".join(flags) or "head/body"))
+
+    print("---")
+    print("written=%d unchanged=%d missing=%d%s"
+          % (written, unchanged, skipped_missing, " (dry-run)" if args.dry_run else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/video_map.py
+++ b/scripts/video_map.py
@@ -1,0 +1,85 @@
+"""slug -> (video_id, is_core). Core pages already carry VideoObject schema."""
+
+VIDEO_MAP = {
+    # --- Core: already have VideoObject schema, need facade only ---
+    "concepts/architectural-compiler": ("jNXDtxu0_-s", True),
+    "concepts/architectural-drift": ("hP8jMyVA6D4", True),
+    "concepts/governance-before-generation": ("tO_Z9rqXXfQ", True),
+    "concepts/precedence-semantics": ("tktp6ik0Gxk", True),
+    "insights/ai-native-engineering-intent-debt": ("nwSBZXolBhA", True),
+    "insights/architectural-governance-across-heterogeneous-ai-coding-agents": ("xtTDcb2JB2c", True),
+    "insights/autonomous-code-remediation-requires-architectural-governance": ("DDo0x1lkBNI", True),
+    "insights/github-copilot-space-framework": ("Rjlzm0psfB4", True),
+    "insights/harness-engineering-still-needs-governance": ("kHDZshGw7M8", True),
+    "insights/memory-is-not-governance": ("EDBVYFtkOb4", True),
+    "insights/prompt-engineering-is-not-governance": ("kIswxPe7bGc", True),
+    "insights/why-claude-md-stops-scaling": ("5QxAbdLg0nw", True),
+    "insights/why-code-review-cannot-scale-with-ai-output": ("8sklibjfO6A", True),
+    "insights/why-observability-is-not-governance": ("yAwz5SISip8", True),
+    "insights/why-rag-fails-for-architectural-governance": ("0kC4OEG-yig", True),
+    # --- Extension: confirmed title match, need schema + facade ---
+    "insights/rag-is-not-memory": ("4EbbZojgWKs", False),
+    "insights/spec-driven-development-still-needs-governance": ("pcL4fD5MyC8", False),
+    "insights/why-context-alone-doesnt-prevent-architectural-drift": ("fseagcnHzhU", False),
+    "concepts/model-independent-governance": ("W4MG-SQY20o", False),
+    "concepts/deterministic-enforcement": ("k5lpI83ONnI", False),
+}
+
+# Real YouTube metadata for the 5 extension videos (confirmed 1:1 title matches
+# via the mneme-youtube MCP youtube_get_video / youtube_list_videos on 2026-06-29).
+# `description` is the real first ~200 chars of the channel description.
+# `duration` is omitted: the youtube_get_video MCP does not expose contentDetails
+# duration, and the plan forbids fabricating metadata. A VideoObject is valid
+# without `duration`; process_page emits it only when present and truthy.
+EXTENSION_META = {
+    "4EbbZojgWKs": {
+        "name": "RAG Is Not Memory | Architectural Governance for AI Coding Teams — Mneme HQ",
+        "description": (
+            "👉 Try Mneme HQ — architectural governance for AI coding: "
+            "https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=rag_is_not_memory\n"
+            "Mneme HQ turns architectural decisions into enforceable rules for AI coding agents."
+        ),
+        "uploadDate": "2026-06-23T17:37:02Z",
+        "duration": "",
+    },
+    "pcL4fD5MyC8": {
+        "name": "Spec-Driven Development Still Needs Governance | Architectural Governance for AI Coding Teams — Mneme HQ",
+        "description": (
+            "👉 Try Mneme HQ — architectural governance for AI coding: "
+            "https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=spec_driven_development_governance\n"
+            "Mneme HQ turns architectural decisions into enforceable rules for AI coding agents."
+        ),
+        "uploadDate": "2026-06-23T17:36:34Z",
+        "duration": "",
+    },
+    "fseagcnHzhU": {
+        "name": "Why Context Alone Doesn't Prevent Architectural Drift | Architectural Governance for AI Coding Teams — Mneme HQ",
+        "description": (
+            "👉 Try Mneme HQ — architectural governance for AI coding: "
+            "https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=context_alone_doesnt_prevent_drift\n"
+            "Mneme HQ turns architectural decisions into enforceable rules for AI coding agents."
+        ),
+        "uploadDate": "2026-06-23T17:38:08Z",
+        "duration": "",
+    },
+    "W4MG-SQY20o": {
+        "name": "Model-Independent Governance: Why Your Architecture Outlives the Model | Architectural Governance for AI Coding Teams — Mneme HQ",
+        "description": (
+            "👉 Try Mneme HQ — architectural governance for AI coding: "
+            "https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=model_independent_governance\n"
+            "Mneme HQ turns architectural decisions into enforceable rules for AI coding agents."
+        ),
+        "uploadDate": "2026-06-23T17:35:14Z",
+        "duration": "",
+    },
+    "k5lpI83ONnI": {
+        "name": "What Is Deterministic Enforcement? | Architectural Governance for AI Coding Teams — Mneme HQ",
+        "description": (
+            "👉 Try Mneme HQ — architectural governance for AI coding: "
+            "https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=deterministic_enforcement\n"
+            "Mneme HQ turns architectural decisions into enforceable rules for AI coding agents."
+        ),
+        "uploadDate": "2026-06-23T17:20:49Z",
+        "duration": "",
+    },
+}

--- a/site/assets/css/video.css
+++ b/site/assets/css/video.css
@@ -1,0 +1,44 @@
+.yt-facade {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin: 2.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface2);
+  cursor: pointer;
+}
+.yt-facade__thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: opacity 0.2s;
+}
+.yt-facade:hover .yt-facade__thumb { opacity: 0.85; }
+.yt-facade__play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 68px;
+  height: 48px;
+  transform: translate(-50%, -50%);
+  background: rgba(20, 24, 22, 0.82);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+.yt-facade__play::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 52%;
+  transform: translate(-50%, -50%);
+  border-style: solid;
+  border-width: 11px 0 11px 18px;
+  border-color: transparent transparent transparent var(--accent, #c8f060);
+}
+.yt-facade:hover .yt-facade__play { background: rgba(20, 24, 22, 0.95); }
+.yt-facade:focus-visible { outline: 2px solid var(--accent, #c8f060); outline-offset: 2px; }
+.yt-facade iframe { width: 100%; height: 100%; border: 0; display: block; }

--- a/site/assets/js/video.js
+++ b/site/assets/js/video.js
@@ -1,0 +1,26 @@
+(function () {
+  function activate(el) {
+    var id = el.getAttribute("data-video-id");
+    if (!id || el.querySelector("iframe")) return;
+    var iframe = document.createElement("iframe");
+    iframe.setAttribute("src",
+      "https://www.youtube-nocookie.com/embed/" + id + "?autoplay=1&rel=0");
+    iframe.setAttribute("title", el.getAttribute("data-title") || "YouTube video");
+    iframe.setAttribute("allow",
+      "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture");
+    iframe.setAttribute("allowfullscreen", "");
+    el.innerHTML = "";
+    el.appendChild(iframe);
+  }
+  document.addEventListener("DOMContentLoaded", function () {
+    var nodes = document.querySelectorAll(".yt-facade");
+    for (var i = 0; i < nodes.length; i++) {
+      (function (el) {
+        el.addEventListener("click", function () { activate(el); });
+        el.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); activate(el); }
+        });
+      })(nodes[i]);
+    }
+  });
+})();

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -424,6 +424,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -630,6 +631,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </div>
 
     <p>A model receiving RAG context about a PostgreSQL decision can still choose to write SQLite code. The decision is context, not enforcement. A model evaluated against a compiled constraint record that says <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">services/payments/** must not use SQLite</code> produces a binary verdict: the constraint was respected or violated. The compiled record is not advice — it is enforcement.</p>
+
+    <div class="yt-facade" data-video-id="jNXDtxu0_-s" data-title="Architectural Compiler" role="button" tabindex="0" aria-label="Play video: Architectural Compiler">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/jNXDtxu0_-s/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>The five stages in detail</h2>
 
@@ -962,5 +968,6 @@ PostgreSQL only.</span>
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -8,6 +8,7 @@
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <link rel="stylesheet" href="/assets/css/diagrams.css">
+  <link rel="stylesheet" href="/assets/css/video.css">
   <meta name="description" content="Architectural drift is the compound degradation in codebase coherence caused by AI agents producing code inconsistent with established decisions, uncorrected across sessions and agents." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -543,6 +544,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <p>The timeline above is not a worst case. It is the expected outcome of AI-assisted development without pre-generation governance. The compounding is not exceptional behavior — it is the natural result of agents using existing code as context, applied at high generation velocity.</p>
 
+    <div class="yt-facade" data-video-id="hP8jMyVA6D4" data-title="Architectural Drift" role="button" tabindex="0" aria-label="Play video: Architectural Drift">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/hP8jMyVA6D4/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
+
     <h2>The common misread: treating drift as a per-PR problem</h2>
 
     <p>Teams that approach architectural drift with per-PR tooling — code review checklists, PR linting, violation count metrics — are measuring the wrong thing. They are measuring incidents when the problem is system-level degradation.</p>
@@ -804,5 +810,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -398,6 +398,27 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
+<script type="application/ld+json" data-video-schema="k5lpi83onni">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "What Is Deterministic Enforcement? | Architectural Governance for AI Coding Teams — Mneme HQ",
+  "description": "👉 Try Mneme HQ — architectural governance for AI coding: https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=deterministic_enforcement\nMneme HQ turns architectural decisions into enforceable rules for AI coding agents.",
+  "thumbnailUrl": "https://i.ytimg.com/vi/k5lpI83ONnI/maxresdefault.jpg",
+  "uploadDate": "2026-06-23T17:20:49Z",
+  "embedUrl": "https://www.youtube.com/embed/k5lpI83ONnI",
+  "contentUrl": "https://www.youtube.com/watch?v=k5lpI83ONnI",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Mneme HQ",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://mnemehq.com/og.png"
+    }
+  }
+}
+</script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -560,6 +581,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <div class="callout-teal">
       <p><strong>A governance failure that wasn't caused by a code change cannot be meaningfully acted on.</strong> It is noise in the governance signal — indistinguishable from a real violation, but caused by retrieval drift. Teams that rely on probabilistic retrieval cannot distinguish genuine violations from retrieval variance in their governance history.</p>
+    </div>
+
+    <div class="yt-facade" data-video-id="k5lpI83ONnI" data-title="Deterministic Enforcement" role="button" tabindex="0" aria-label="Play video: Deterministic Enforcement">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/k5lpI83ONnI/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>The common misread: confusing compliance with determinism</h2>
@@ -899,5 +925,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -8,6 +8,7 @@
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
   <link rel="stylesheet" href="/assets/css/diagrams.css">
+  <link rel="stylesheet" href="/assets/css/video.css">
   <meta name="description" content="Governance before generation means enforcing architectural constraints before the AI writes code, not after it reaches review. The enforcement point is the strategic variable." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
@@ -656,6 +657,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <p>The table above describes a cost gradient. Every row to the right of pre-generation enforcement represents a stage where the violation already exists as written code and must be undone. The only enforcement point where the violation never exists is pre-generation. Every other point is catching something that already happened.</p>
 
+    <div class="yt-facade" data-video-id="tO_Z9rqXXfQ" data-title="Governance Before Generation" role="button" tabindex="0" aria-label="Play video: Governance Before Generation">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/tO_Z9rqXXfQ/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
+
     <h2>The common misread: treating post-generation enforcement as equivalent</h2>
 
     <p>Teams that have invested in strong CI pipelines and thorough code review often argue that their post-generation enforcement is functionally equivalent to pre-generation governance. The reasoning: if the CI gate catches every violation and blocks every non-compliant merge, then no violations reach production — which is the goal.</p>
@@ -974,5 +980,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -331,6 +331,27 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
+<script type="application/ld+json" data-video-schema="w4mg_sqy20o">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Model-Independent Governance: Why Your Architecture Outlives the Model | Architectural Governance for AI Coding Teams — Mneme HQ",
+  "description": "👉 Try Mneme HQ — architectural governance for AI coding: https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=model_independent_governance\nMneme HQ turns architectural decisions into enforceable rules for AI coding agents.",
+  "thumbnailUrl": "https://i.ytimg.com/vi/W4MG-SQY20o/maxresdefault.jpg",
+  "uploadDate": "2026-06-23T17:35:14Z",
+  "embedUrl": "https://www.youtube.com/embed/W4MG-SQY20o",
+  "contentUrl": "https://www.youtube.com/watch?v=W4MG-SQY20o",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Mneme HQ",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://mnemehq.com/og.png"
+    }
+  }
+}
+</script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -423,6 +444,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </div>
 
     <p>Each surface is wired to the same governance engine consulting the same repo-native corpus. A change that violates ADR-007 at the pre-tool-use hook in Claude Code violates ADR-007 at the CI gate when GPT-driven CI tries to commit the same diff, and violates ADR-007 at the PR check no matter which agent opened the PR. The model and the runtime do not affect the verdict.</p>
+
+    <div class="yt-facade" data-video-id="W4MG-SQY20o" data-title="Model-Independent Governance" role="button" tabindex="0" aria-label="Play video: Model-Independent Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/W4MG-SQY20o/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>Provider lock-in vs governance lock-in</h2>
     <p>The conversation about "lock-in" in AI infrastructure usually focuses on the API. That is the visible cost &mdash; multi-provider routing, fallback chains, vendor diversification. There is a second, less visible kind of lock-in that is more expensive to discover later.</p>
@@ -693,5 +719,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -358,6 +358,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </script>
 <!-- mneme:vendor:rb2b:end -->
 <!-- mneme:marketing-head:end -->
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -517,6 +518,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </ul>
 
     <p>Runtime precedence, by contrast, leaves each consumer to implement its own resolution. Two consumers can disagree about the winner, and the disagreement is invisible until both produce different verdicts. This is one of the most common failure modes in ad-hoc governance setups: every tool reads the same rules and quietly applies them differently.</p>
+
+    <div class="yt-facade" data-video-id="tktp6ik0Gxk" data-title="Precedence Semantics" role="button" tabindex="0" aria-label="Play video: Precedence Semantics">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/tktp6ik0Gxk/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>The common misread: longest-rule-wins or first-match-wins</h2>
 
@@ -783,5 +789,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -356,6 +356,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -486,6 +487,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <div class="tool">Intent governance</div>
         <div class="desc">Asks: "Should this change have been generated this way in the first place?" Operates before the diff exists. Prevents the violation from being written.</div>
       </div>
+    </div>
+
+    <div class="yt-facade" data-video-id="nwSBZXolBhA" data-title="State of AI-Native Engineering 2026: The Intent Debt Behind AI-Generated Code" role="button" tabindex="0" aria-label="Play video: State of AI-Native Engineering 2026: The Intent Debt Behind AI-Generated Code">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/nwSBZXolBhA/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>Memory and orchestration are not governance</h2>
@@ -757,5 +763,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -402,6 +402,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -688,6 +689,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </figure>
 
     <p>If the AI coding category follows the same arc — and the early signals say it is — the practical question for engineering leaders is not <em>whether</em> a shared format will arrive, but <em>what to do during the years before it lands</em>. The answer is the same one teams used during every prior cycle: build above the eventual standard, not inside any one vendor's format.</p>
+
+    <div class="yt-facade" data-video-id="xtTDcb2JB2c" data-title="Architectural Governance Across Heterogeneous AI Coding Agents" role="button" tabindex="0" aria-label="Play video: Architectural Governance Across Heterogeneous AI Coding Agents">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/xtTDcb2JB2c/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2 id="standards">Where the standards landscape stands today</h2>
 
@@ -985,5 +991,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -317,6 +317,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -412,6 +413,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p>The result is oscillation. The system never converges because no single agent holds the full constraint space. Each agent resolves one violation and either introduces another, or restores a violation the previous agent had suppressed.</p>
 
     <p>This is not fixable at the model layer. Larger context windows help individual agents see more, but they do not make constraints deterministic, persistent across sessions, or consistent across the multi-agent boundary. Architectural constraints need to be an infrastructure property, not a context property.</p>
+
+    <div class="yt-facade" data-video-id="DDo0x1lkBNI" data-title="Autonomous Code Remediation Requires Architectural Governance" role="button" tabindex="0" aria-label="Play video: Autonomous Code Remediation Requires Architectural Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/DDo0x1lkBNI/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>Why review cannot govern autonomous loops</h2>
 
@@ -736,5 +742,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -327,6 +327,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -382,14 +383,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <p>We put together a video walking through what the framework reveals when applied to <a href="https://github.com/features/copilot">GitHub Copilot</a> adoption data:</p>
 
-    <div class="video-wrap">
-      <iframe
-        src="https://www.youtube-nocookie.com/embed/Rjlzm0psfB4"
-        title="The SPACE Framework: Measuring GitHub Copilot's Real Productivity Impact"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        loading="lazy">
-      </iframe>
+    <div class="yt-facade" data-video-id="Rjlzm0psfB4" data-title="The SPACE Framework: Measuring GitHub Copilot&#x27;s Real Productivity Impact" role="button" tabindex="0" aria-label="Play video: The SPACE Framework: Measuring GitHub Copilot&#x27;s Real Productivity Impact">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/Rjlzm0psfB4/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>What SPACE measures — and what it doesn't</h2>
@@ -669,5 +665,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -386,6 +386,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -580,6 +581,11 @@ Tools / Memory / Execution / Retries</code></pre>
     <p>Observability is necessary &mdash; you cannot govern what you cannot see &mdash; but it sits on the wrong side of the action. By the time the trace reaches the dashboard, the commit has already happened, the PR may already be merged, the artifact may already be deployed. Governance has to sit <em>in front of</em> the action it constrains, with a deterministic rule about whether to allow it.</p>
 
     <p>The next layer is not better dashboards. It is enforceable contracts.</p>
+
+    <div class="yt-facade" data-video-id="kHDZshGw7M8" data-title="Harness Engineering Still Needs Governance" role="button" tabindex="0" aria-label="Play video: Harness Engineering Still Needs Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/kHDZshGw7M8/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2 id="propagation">Governance propagation across execution surfaces</h2>
 
@@ -943,5 +949,6 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -411,6 +411,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -663,6 +664,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       </svg>
       <figcaption id="fig1-cap">Fig 1 &middot; The same query, two optimization targets. The memory system returns relevance; the governance system returns a rule. Different jobs.</figcaption>
     </figure>
+
+    <div class="yt-facade" data-video-id="EDBVYFtkOb4" data-title="Memory Is Not Governance" role="button" tabindex="0" aria-label="Play video: Memory Is Not Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/EDBVYFtkOb4/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2 id="stack">Memory is an input to governance, not a substitute</h2>
 
@@ -1022,5 +1028,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -408,6 +408,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -500,6 +501,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <strong>Provide an audit trail.</strong> There is no record of which rules were active when a file was written, whether a rule was in the prompt when a violation occurred, or what the prompt looked like when an agent made a particular decision. Debugging governance failures after the fact requires reconstructing the session — which is often impossible. Without a structured decision record, you have no basis for a governance audit.
       </li>
     </ol>
+
+    <div class="yt-facade" data-video-id="kIswxPe7bGc" data-title="Prompt Engineering Is Not Governance" role="button" tabindex="0" aria-label="Play video: Prompt Engineering Is Not Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/kIswxPe7bGc/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>The session-boundary problem</h2>
 
@@ -789,5 +795,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -351,6 +351,27 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
+<script type="application/ld+json" data-video-schema="4ebbzojgwks">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "RAG Is Not Memory | Architectural Governance for AI Coding Teams — Mneme HQ",
+  "description": "👉 Try Mneme HQ — architectural governance for AI coding: https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=rag_is_not_memory\nMneme HQ turns architectural decisions into enforceable rules for AI coding agents.",
+  "thumbnailUrl": "https://i.ytimg.com/vi/4EbbZojgWKs/maxresdefault.jpg",
+  "uploadDate": "2026-06-23T17:37:02Z",
+  "embedUrl": "https://www.youtube.com/embed/4EbbZojgWKs",
+  "contentUrl": "https://www.youtube.com/watch?v=4EbbZojgWKs",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Mneme HQ",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://mnemehq.com/og.png"
+    }
+  }
+}
+</script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -496,6 +517,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </ul>
 
     <p class="pull-quote"><em>The failures are not memory bugs.</em> They are retrieval behaving exactly as designed.</p>
+
+    <div class="yt-facade" data-video-id="4EbbZojgWKs" data-title="RAG Is Not Memory" role="button" tabindex="0" aria-label="Play video: RAG Is Not Memory">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/4EbbZojgWKs/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2 id="why-it-spreads">Why the conflation keeps spreading</h2>
 
@@ -751,5 +777,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -362,6 +362,27 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .related-list a:hover .rel-title::after { opacity: 1; transform: translateX(3px); }
     .related-list .rel-desc { color: var(--muted); font-size: 0.82rem; line-height: 1.65; margin: 0; }
   </style>
+  <link rel="stylesheet" href="/assets/css/video.css">
+<script type="application/ld+json" data-video-schema="pcl4fd5myc8">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Spec-Driven Development Still Needs Governance | Architectural Governance for AI Coding Teams — Mneme HQ",
+  "description": "👉 Try Mneme HQ — architectural governance for AI coding: https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=spec_driven_development_governance\nMneme HQ turns architectural decisions into enforceable rules for AI coding agents.",
+  "thumbnailUrl": "https://i.ytimg.com/vi/pcL4fD5MyC8/maxresdefault.jpg",
+  "uploadDate": "2026-06-23T17:36:34Z",
+  "embedUrl": "https://www.youtube.com/embed/pcL4fD5MyC8",
+  "contentUrl": "https://www.youtube.com/watch?v=pcL4fD5MyC8",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Mneme HQ",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://mnemehq.com/og.png"
+    }
+  }
+}
+</script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -453,6 +474,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </ul>
     <div class="callout"><p><strong>A spec answers &ldquo;what should the agent build?&rdquo;</strong> It does not answer &ldquo;which architectural decisions must remain true while it builds?&rdquo; Those are different questions, and only the second one prevents <a href="/concepts/architectural-drift/">architectural drift</a>.</p></div>
     <p>The gap is structural, not a maturity problem with any particular spec tool. A spec is scoped to a feature or task. Architecture is scoped to the system, and it persists across every feature, session, and agent that touches the repository.</p>
+
+    <div class="yt-facade" data-video-id="pcL4fD5MyC8" data-title="Spec-Driven Development Still Needs Architectural Governance" role="button" tabindex="0" aria-label="Play video: Spec-Driven Development Still Needs Architectural Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/pcL4fD5MyC8/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2 id="mature-workflow">The mature workflow</h2>
     <p>The fix is not to abandon spec-driven development. It is to insert a governance step between planning and execution &mdash; constraints retrieved and injected <a href="/concepts/governance-before-generation/">before the agent generates code</a>, and proven afterward with <a href="/concepts/verification-contracts/">verification contracts</a>.</p>
@@ -695,5 +721,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -424,6 +424,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -588,6 +589,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         </div>
       </div>
 
+    </div>
+
+    <div class="yt-facade" data-video-id="5QxAbdLg0nw" data-title="Why CLAUDE.md Stops Scaling" role="button" tabindex="0" aria-label="Play video: Why CLAUDE.md Stops Scaling">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/5QxAbdLg0nw/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>The real category shift</h2>
@@ -924,5 +930,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -407,6 +407,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -548,6 +549,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <span>cheap to fix &middot; before code exists</span>
         <span>expensive &middot; after merge, after deploy &rarr;</span>
       </div>
+    </div>
+
+    <div class="yt-facade" data-video-id="8sklibjfO6A" data-title="Why Code Review Cannot Scale With AI Output" role="button" tabindex="0" aria-label="Play video: Why Code Review Cannot Scale With AI Output">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/8sklibjfO6A/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>The shift-left argument</h2>
@@ -840,5 +846,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -333,6 +333,27 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     .gov-table tr.accent-row td { color: var(--accent); }
     .gov-table tr.accent-row td:first-child { color: var(--accent); }
   </style>
+  <link rel="stylesheet" href="/assets/css/video.css">
+<script type="application/ld+json" data-video-schema="fseagcnhzhu">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Why Context Alone Doesn't Prevent Architectural Drift | Architectural Governance for AI Coding Teams — Mneme HQ",
+  "description": "👉 Try Mneme HQ — architectural governance for AI coding: https://mnemehq.com/?utm_source=youtube&utm_medium=video&utm_campaign=mneme_youtube&utm_content=context_alone_doesnt_prevent_drift\nMneme HQ turns architectural decisions into enforceable rules for AI coding agents.",
+  "thumbnailUrl": "https://i.ytimg.com/vi/fseagcnHzhU/maxresdefault.jpg",
+  "uploadDate": "2026-06-23T17:38:08Z",
+  "embedUrl": "https://www.youtube.com/embed/fseagcnHzhU",
+  "contentUrl": "https://www.youtube.com/watch?v=fseagcnHzhU",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Mneme HQ",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://mnemehq.com/og.png"
+    }
+  }
+}
+</script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -443,6 +464,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         <text x="350" y="375" text-anchor="middle" class="diag-text diag-accent-text">Verification</text>
       </svg>
       <p class="diag-caption">The missing tier &mdash; governance sits between orchestration and verification</p>
+    </div>
+
+    <div class="yt-facade" data-video-id="fseagcnHzhU" data-title="Why Context Alone Doesn&#x27;t Prevent Architectural Drift" role="button" tabindex="0" aria-label="Play video: Why Context Alone Doesn&#x27;t Prevent Architectural Drift">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/fseagcnHzhU/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
 
     <h2>Why orchestration makes this worse</h2>
@@ -754,5 +780,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -349,6 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -468,6 +469,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p class="pull-quote">You can perfectly observe drift, and continuously ship drift, at the same time.<span class="attrib">— the failure mode</span></p>
 
     <p>This is the failure mode that observability-as-governance produces. The team feels in control because they can see everything. The codebase, meanwhile, accumulates exactly the violations the dashboard is reporting. Visibility is not control. <strong>Observability without enforcement becomes operational archaeology</strong> — a precise catalog of what already happened, with no mechanism to change what happens next.</p>
+
+    <div class="yt-facade" data-video-id="yAwz5SISip8" data-title="Why Observability Is Not Governance" role="button" tabindex="0" aria-label="Play video: Why Observability Is Not Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/yAwz5SISip8/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>Governance before generation</h2>
 
@@ -770,5 +776,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -395,6 +395,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   }
 }
 </script>
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
@@ -529,6 +530,11 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p>RAG retrieval quality is a function of embedding model quality, corpus size, and query construction. In small corpora (&lt;100 documents), RAG works reasonably well. As your decision corpus grows to hundreds of ADRs, style guides, runbooks, and policy documents, retrieval precision drops and recall degrades.</p>
 
     <p>More importantly, architectural decisions have precise scope signals — file patterns, service names, module boundaries — that embedding-based retrieval handles poorly. The embedding for "use dependency injection for service construction" is not significantly closer to a file path like <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">services/payments/handler.py</code> than it is to an unrelated document. Scope-aware retrieval requires structured matching, not vector similarity.</p>
+
+    <div class="yt-facade" data-video-id="0kC4OEG-yig" data-title="Why RAG Fails for Architectural Governance" role="button" tabindex="0" aria-label="Play video: Why RAG Fails for Architectural Governance">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/0kC4OEG-yig/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
+    </div>
 
     <h2>Failure mode 4: Suggestion, not enforcement</h2>
 
@@ -851,5 +857,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>

--- a/tests/test_embed_videos.py
+++ b/tests/test_embed_videos.py
@@ -1,0 +1,93 @@
+# tests/test_embed_videos.py
+from scripts.embed_videos import (
+    insert_head_link, insert_body_script, facade_html, insert_facade_midpoint,
+    replace_video_wrap,
+)
+
+HEAD = '<head>\n<link rel="stylesheet" href="/assets/css/diagrams.css">\n</head>'
+BODY_END = '<script><!-- nav-active --></script>\n</body>'
+
+
+def test_insert_head_link_is_idempotent():
+    once = insert_head_link(HEAD)
+    twice = insert_head_link(once)
+    assert once.count("/assets/css/video.css") == 1
+    assert once == twice
+
+
+def test_insert_body_script_is_idempotent():
+    once = insert_body_script(BODY_END)
+    twice = insert_body_script(once)
+    assert once.count("/assets/js/video.js") == 1
+    assert once == twice
+
+
+def test_insert_body_script_targets_real_body_not_comment():
+    # Real pages contain a literal </body> inside the consent-banner comment
+    # BEFORE the real closing tag. The script must land before the real </body>,
+    # not get buried in the comment (regression: it was inserted into the comment).
+    html = (
+        "<body>\n"
+        "<!-- marketing-body: synced before </body> by sync_shared.py. -->\n"
+        "<div>content</div>\n"
+        "</body>"
+    )
+    out = insert_body_script(html)
+    assert out.count("/assets/js/video.js") == 1
+    # the script tag must sit AFTER the comment's </body>, immediately before the real one
+    comment_close = out.index("by sync_shared.py.")
+    script_at = out.index("/assets/js/video.js")
+    assert script_at > comment_close
+    # and it must be immediately before the final </body>
+    assert out.rstrip().endswith("</body>")
+    assert out.index("/assets/js/video.js") > out.rindex("<!--")
+    # idempotent
+    assert insert_body_script(out) == out
+
+
+def test_facade_html_contains_id_and_nocookie_free_thumb():
+    html = facade_html("ABC123", "My Title")
+    assert 'data-video-id="ABC123"' in html
+    assert "i.ytimg.com/vi/ABC123/maxresdefault.jpg" in html
+    assert "My Title" in html
+
+
+def test_replace_video_wrap_swaps_native_embed_in_place():
+    html = (
+        '<p>intro</p>\n'
+        '    <div class="video-wrap">\n'
+        '      <iframe src="https://www.youtube-nocookie.com/embed/ABC"></iframe>\n'
+        '    </div>\n'
+        '    <h2>next</h2>'
+    )
+    facade = '<div class="yt-facade" data-video-id="ABC"></div>'
+    out, replaced = replace_video_wrap(html, facade)
+    assert replaced is True
+    assert "video-wrap" not in out
+    assert "<iframe" not in out          # native auto-loading embed gone
+    assert out.count("yt-facade") == 1
+    assert "<p>intro</p>" in out and "<h2>next</h2>" in out  # surrounding copy kept
+    # idempotent: facade already present -> no-op
+    out2, replaced2 = replace_video_wrap(out, facade)
+    assert replaced2 is False and out2 == out
+
+
+def test_replace_video_wrap_noop_without_native_embed():
+    html = '<p>no embed here</p>'
+    out, replaced = replace_video_wrap(html, '<div class="yt-facade"></div>')
+    assert replaced is False and out == html
+
+
+def test_insert_facade_midpoint_picks_middle_h2():
+    body = ('<div class="article-body">'
+            '<p>lede</p>'
+            '<h2>One</h2><p>a</p>'
+            '<h2>Two</h2><p>b</p>'
+            '<h2>Three</h2><p>c</p>'
+            '</div>')
+    out = insert_facade_midpoint(body, '<div class="yt-facade"></div>')
+    # facade inserted immediately before the midpoint <h2> (the 2nd of 3)
+    assert out.index('yt-facade') < out.index('<h2>Two')
+    assert out.count('yt-facade') == 1
+    # idempotent
+    assert insert_facade_midpoint(out, '<div class="yt-facade"></div>') == out


### PR DESCRIPTION
## What

Click-to-load YouTube facades on 20 insight/concept pages, plus a shared facade asset and an idempotent backfill script.

- **Facade asset** (`site/assets/css/video.css` + `js/video.js`): renders only the YouTube thumbnail; loads a `youtube-nocookie.com` iframe on click/Enter. **No YouTube JS, iframe, or cookies fire before user action** — consent-safe by construction, matching the site's GTM/RB2B posture.
- **15 core pages** already carried a `VideoObject` schema (authoritative video IDs) but had no visible player — they now render the facade mid-article.
- **5 extension pages** are confirmed 1:1 title matches (verified against the YouTube API); they get the facade **and** a new `VideoObject` schema.
- The one pre-existing native auto-loading embed (`github-copilot-space-framework`) is **replaced** in place by the facade — a privacy upgrade, not a duplicate.

## How

`scripts/embed_videos.py` (idempotent) drives the backfill from `scripts/video_map.py`; `tests/test_embed_videos.py` covers the insertion logic (incl. regressions for the real-`</body>` target and native-embed replacement).

## Verification

- `python -m pytest tests/test_embed_videos.py` → 7 passed
- `python scripts/check_insights.py` → exit 0 (no contract regressions)
- Static sweep of all 20 pages: exactly 1 facade each, css/js referenced once, **0 YouTube iframe/script at load**, 0 leftover `.video-wrap`, script before the real `</body>`, IDs match, extension schemas valid JSON.

## Notes

- dev.to backfill is handled separately (the SPACE/Copilot article already embeds its video).
- `duration` is omitted from the 5 new `VideoObject` schemas because the YouTube MCP doesn't expose it (not fabricated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)