### PR TITLE
ci: pause daily deploy schedule while cPanel API access is blocked

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -7,8 +7,12 @@ on:
       - 'site/**'
       - 'scripts/deploy_site.py'
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *'  # 06:00 UTC daily — catches any commits that skipped the push trigger
+  # Daily schedule paused 2026-06-29: the cPanel upload from the whitelisted
+  # runner is blocked (cPHulk/Imunify on authenticated cPanel-API calls), so the
+  # scheduled run only fails daily and trips the host firewall. Re-enable once the
+  # cPanel API access / token is sorted. Push-to-main and manual dispatch remain.
+  # schedule:
+  #   - cron: '0 6 * * *'  # 06:00 UTC daily — catches any commits that skipped the push trigger
 
 permissions:
   contents: write


### PR DESCRIPTION
Pauses the 06:00 UTC scheduled deploy (keeps push-to-main + manual dispatch) so it stops failing daily and tripping the Krystal host firewall while the cPanel API access from the whitelisted runner IP is unresolved. Editing only the workflow file does not match the deploy's path filter, so merging this does not trigger a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)