### PR TITLE
ci: make post-deploy verification robust to Cloudflare email obfuscation

### DIFF
--- a/scripts/deploy_verify.py
+++ b/scripts/deploy_verify.py
@@ -6,13 +6,42 @@ these into its retry/HTTP loop.
 """
 from __future__ import annotations
 
+import re
+
+# Cloudflare "Email Address Obfuscation" (Scrape Shield, on by default) rewrites
+# every mailto: link and visible email in the SERVED html: the address becomes a
+# /cdn-cgi/l/email-protection href and/or a <span class="__cf_email__"> token,
+# plus an injected email-decode script. The uploaded file still has the raw
+# address, so a byte-substring needle false-fails every page that lists an email
+# (contact / founder / privacy / pilot ...) even though the deploy is fresh.
+# Neutralize both representations to a common placeholder so the comparison
+# ignores Cloudflare's rewriting. Applied to both sides (it runs inside norm()),
+# so it can never mask a genuinely stale page.
+_CF_EMAIL_SCRIPT = re.compile(rb'<script[^>]*/email-decode\.min\.js[^>]*>.*?</script>', re.I | re.S)
+_CF_EMAIL_SPAN = re.compile(rb'<span[^>]*\bclass=["\']__cf_email__["\'][^>]*>.*?</span>', re.I | re.S)
+_CF_EMAIL_HREF = re.compile(rb'href=["\']/cdn-cgi/l/email-protection[^"\']*["\']', re.I)
+_MAILTO = re.compile(rb'mailto:[^"\'>\s]+', re.I)
+_RAW_EMAIL = re.compile(rb'[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}')
+
+
+def _neutralize_email_obfuscation(b: bytes) -> bytes:
+    b = _CF_EMAIL_SCRIPT.sub(b'', b)                 # Cloudflare email-decode script (served only)
+    b = _CF_EMAIL_SPAN.sub(b'EMAIL', b)              # obfuscated visible token -> EMAIL
+    b = _CF_EMAIL_HREF.sub(b'href="mailto:EMAIL"', b)  # obfuscated href -> canonical mailto
+    b = _MAILTO.sub(b'mailto:EMAIL', b)              # raw mailto (uploaded side) -> canonical
+    b = _RAW_EMAIL.sub(b'EMAIL', b)                  # any remaining raw address -> EMAIL
+    return b
+
 
 def norm(b: bytes) -> bytes:
-    """Normalize newlines and per-line trailing whitespace.
+    """Normalize newlines, per-line trailing whitespace, and Cloudflare email
+    obfuscation.
 
     Lets us compare a local file against the served response without benign
-    encoding differences (CRLF vs LF, trailing spaces) registering as changes.
+    differences (CRLF vs LF, trailing spaces, Cloudflare's serve-time email
+    rewriting) registering as changes.
     """
+    b = _neutralize_email_obfuscation(b)
     return b"\n".join(line.rstrip() for line in b.replace(b"\r\n", b"\n").split(b"\n")).strip()
 
 

--- a/scripts/test_deploy_verify.py
+++ b/scripts/test_deploy_verify.py
@@ -46,6 +46,47 @@ def test_stale_200_is_fail():
     assert "stale" in detail
 
 
+# A page that lists an email — uploaded with a raw mailto + visible address.
+PAGE_EMAIL = (
+    b"<!DOCTYPE html>\n<html>\n<head><title>X</title></head>\n<body>\n"
+    b'<p>fresh content. Contact <a href="mailto:theo@mnemehq.com">theo@mnemehq.com</a>.</p>\n'
+    b"</body>\n</html>\n"
+)
+# What Cloudflare's Email Address Obfuscation actually serves: the mailto href
+# becomes /cdn-cgi/l/email-protection, the visible address becomes a
+# __cf_email__ span, and an email-decode script is injected before </body>.
+LIVE_EMAIL_OBFUSCATED = (
+    b"<!DOCTYPE html>\n<html>\n<head><title>X</title></head>\n<body>\n"
+    b'<p>fresh content. Contact <a href="/cdn-cgi/l/email-protection#0d61646c...">'
+    b'<span class="__cf_email__" data-cfemail="0d61646c...">[email&#160;protected]</span></a>.</p>\n'
+    b'<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>\n'
+    b'<script defer src="https://static.cloudflareinsights.com/beacon.min.js"></script>\n'
+    b"</body>\n</html>\n"
+)
+# Same Cloudflare obfuscation, but the page body is genuinely OLD content.
+LIVE_EMAIL_STALE = (
+    b"<!DOCTYPE html>\n<html>\n<head><title>X</title></head>\n<body>\n"
+    b'<p>OLD content. Contact <a href="/cdn-cgi/l/email-protection#0d61">'
+    b'<span class="__cf_email__" data-cfemail="0d61">[email&#160;protected]</span></a>.</p>\n'
+    b"</body>\n</html>\n"
+)
+
+
+def test_cloudflare_email_obfuscation_is_ok():
+    # The fresh page is served with Cloudflare email obfuscation; it must still
+    # verify OK (this is what was false-failing contact/founder/pilot/privacy).
+    needle = content_needle(PAGE_EMAIL)
+    assert classify(200, LIVE_EMAIL_OBFUSCATED, needle) == ("ok", "")
+
+
+def test_email_obfuscation_does_not_mask_stale():
+    # Email normalization must not let a genuinely stale page pass.
+    needle = content_needle(PAGE_EMAIL)
+    verdict, detail = classify(200, LIVE_EMAIL_STALE, needle)
+    assert verdict == "fail"
+    assert "stale" in detail
+
+
 def test_404_is_fail():
     assert classify(404, b"", content_needle(PAGE))[0] == "fail"
 


### PR DESCRIPTION
## Why
The last deploy uploaded all 238 files successfully (the pacing fix worked), but then **failed verification** on 4 URLs — `/contact/`, `/founder/`, `/pilot/`, `/privacy/` — as "stale 200". Root cause: those are exactly the pages with `mailto:` addresses, and **Cloudflare Email Address Obfuscation** rewrites them at serve time (`/cdn-cgi/l/email-protection` href, `__cf_email__` span, injected email-decode script). The verifier's exact-substring needle then can't match, false-fails, exits non-zero, and **skips IndexNow** — even though the content is live and correct.

## Fix
`norm()` now neutralizes email obfuscation on **both** sides (raw `mailto:`/address uploaded; Cloudflare's obfuscated markup served) to a common `EMAIL` placeholder before the substring check. Symmetric, so it can't mask a genuinely stale page.

## Validation
- 10/10 `test_deploy_verify.py` pass, incl. 2 new cases (obfuscated-fresh = ok; obfuscated-stale = fail).
- Ran the neutralizer over the **live served markup** of all 4 pages: cf email artifacts 3/3/9/3 → **0**.

## Note
Editing `scripts/deploy_verify.py` does not match the deploy path filter, so merging this does **not** auto-deploy; the next manual/push deploy picks it up. Expected result: those 4 pages verify OK → deploy goes green → IndexNow finally fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)