### PR TITLE
ci: resume daily deploy schedule now that cPanel deploys work

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -7,12 +7,8 @@ on:
       - 'site/**'
       - 'scripts/deploy_site.py'
   workflow_dispatch:
-  # Daily schedule paused 2026-06-29: the cPanel upload from the whitelisted
-  # runner is blocked (cPHulk/Imunify on authenticated cPanel-API calls), so the
-  # scheduled run only fails daily and trips the host firewall. Re-enable once the
-  # cPanel API access / token is sorted. Push-to-main and manual dispatch remain.
-  # schedule:
-  #   - cron: '0 6 * * *'  # 06:00 UTC daily — catches any commits that skipped the push trigger
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily — catches any commits that skipped the push trigger
 
 permissions:
   contents: write


### PR DESCRIPTION
Reverts the #208 pause. Re-enables the 06:00 UTC daily safety-net deploy now that the cPanel path works (runner #205 + pacing #209 + verifier fix #210). Delta-based, runs on the self-hosted runner (zero hosted minutes), exits in seconds when nothing changed. Workflow-only change — does not trigger a deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)