### PR TITLE
feat: add architecture diagrams (Mermaid docs + brand SVG on homepage & architecture)

### DIFF
--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -1,0 +1,131 @@
+# Mneme HQ architecture diagrams
+
+Mermaid sources for the Mneme HQ architecture set. GitHub renders these inline,
+they version with the code, and they export to SVG for the site, decks, and
+analyst briefings. The on-site (mnemehq.com) versions are hand-authored inline
+SVG using the brand `.diag-*` primitives; these Mermaid sources are the
+developer-facing, diff-able source of truth for the same diagrams.
+
+## 1. Where Mneme sits
+
+The single most important diagram: where the engineering governance layer fits
+between coding agents and generated code.
+
+```mermaid
+flowchart TD
+  Dev[Developer]
+  Agents["Claude Code / Cursor / Codex"]
+  Mneme["Mneme HQ<br/>Engineering Governance Layer"]
+  Decision{Governance decision}
+  Outcome["Allow / Reject / Guide"]
+  Code[Generated code]
+
+  Dev --> Agents --> Mneme
+  Mneme --- ADRs[ADRs]
+  Mneme --- Rules[Engineering rules]
+  Mneme --- Memory[Project memory]
+  Mneme --- Standards[Standards]
+  ADRs --> Decision
+  Rules --> Decision
+  Memory --> Decision
+  Standards --> Decision
+  Decision --> Outcome --> Code
+```
+
+## 2. Generation flow
+
+What happens at runtime when an agent generates code under governance.
+
+```mermaid
+flowchart TD
+  Prompt[Prompt] --> Agent[Agent] --> Ctx[Load context]
+  Ctx --> ADRs[ADRs]
+  Ctx --> Rules[Engineering rules]
+  Ctx --> Memory[Project memory]
+  Ctx --> Standards[Standards]
+  ADRs --> Gen[Generate]
+  Rules --> Gen
+  Memory --> Gen
+  Standards --> Gen
+  Gen --> Check{Governance check}
+  Check -->|Pass| Merge[Merge]
+  Check -->|Reject| Explain[Explain violation] --> Regen[Regenerate] --> Gen
+```
+
+## 3. Engineering governance model
+
+How heterogeneous sources of engineering intent unify into governance the
+engine can enforce.
+
+```mermaid
+flowchart TD
+  Specs[Specifications] --> SG[Structured governance]
+  AD[Architecture decisions] --> SG
+  CS[Coding standards] --> SG
+  PM[Project memory] --> SG
+  BP[Best practices] --> SG
+  CR[Compliance rules] --> SG
+  SG --> Engine[Mneme engine] --> Agents[AI coding agents]
+```
+
+## 4. Multi-agent governance
+
+One set of rules, applied identically across every agent a team uses.
+
+```mermaid
+flowchart TD
+  Cursor[Cursor] --> Mneme[Mneme]
+  Claude[Claude Code] --> Mneme
+  Codex[Codex] --> Mneme
+  OpenHands[OpenHands] --> Mneme
+  Goose[Goose] --> Mneme
+  Continue[Continue] --> Mneme
+  Mneme --> R[Same rules]
+  Mneme --> A[Same architecture]
+  Mneme --> S[Same standards]
+```
+
+## 5. Decision lifecycle
+
+From an architectural decision to enforcement against agent-generated change.
+
+```mermaid
+flowchart LR
+  W[ADR written] --> Rev[Review] --> Ap[Approve] --> Idx[Mneme indexes]
+  Idx --> Req[Agent requests context] --> Enf[Rule enforced] --> Vio[Violation detected]
+```
+
+## 6. With vs without Mneme
+
+The comparison that lands fastest in a sales or analyst conversation.
+
+```mermaid
+flowchart TD
+  subgraph Without["Without governance"]
+    direction TB
+    P1[Prompt] --> AG[Agent guesses] --> Drift[Architecture drifts] --> RC[Review catches some] --> Prod1[Production]
+  end
+  subgraph With["With Mneme"]
+    direction TB
+    P2[Prompt] --> ML[Mneme loads intent] --> AF[Agent follows architecture] --> RV[Review verifies] --> Prod2[Production]
+  end
+```
+
+## 7. Position in the AI engineering stack
+
+Where engineering governance sits as a layer, alongside CI/CD, testing, and
+code review rather than replacing them.
+
+```mermaid
+flowchart TD
+  App[Applications] --> AICA[AI coding agents]
+  AICA --> Mneme["Mneme HQ — Engineering governance layer"]
+  Mneme --> PK["Project knowledge: ADRs - Standards - Memory"]
+  PK --> Infra["Git - CI/CD - Tests - Infrastructure"]
+```
+
+---
+
+**Maintenance:** keep these in sync with the on-site SVG versions. When a
+diagram changes, update the Mermaid source here first (it is the diff-able
+source of truth), then regenerate or hand-edit the brand SVG on the site.

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -313,6 +313,32 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p class="hero-desc">Technical deep dives into the pipeline — retrieval mechanics, scoring, decision memory, and the deliberate architectural choices behind deterministic governance. No embeddings, no ML, no approximations in the enforcement path.</p>
   </header>
 
+  <figure class="arch-figure" style="margin:0 0 2.5rem;">
+    <figcaption style="margin:0 0 0.9rem;font-size:0.82rem;color:#a8a8b8;line-height:1.6;">The big picture: engineering governance is a layer of the AI engineering stack, alongside CI/CD and testing. The runtime stack below breaks the governance layer down in technical detail.</figcaption>
+    <svg viewBox="0 0 720 580" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="aes-t aes-d" style="width:100%;height:auto;display:block;max-width:720px;margin:0 auto;" font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+      <title id="aes-t">Position in the AI engineering stack</title>
+      <desc id="aes-d">A vertical stack of layers: Applications at the top, then AI coding agents, then the Mneme HQ engineering governance layer (emphasized), then architectural knowledge (ADRs, standards, project memory), then infrastructure (Git, CI/CD, tests). Engineering governance sits as its own layer alongside the others rather than replacing them.</desc>
+      <rect x="0" y="0" width="720" height="580" rx="14" fill="#0c0c0d" stroke="#222226"/>
+      <text x="34" y="40" fill="#c8f060" font-family="'DM Mono', ui-monospace, monospace" font-size="11" letter-spacing="1.5">POSITION IN THE AI ENGINEERING STACK</text>
+      <rect x="110" y="64" width="500" height="58" rx="9" fill="#141416" stroke="#2e2e34"/>
+      <text x="360" y="98" fill="#e8e8ec" font-size="14.5" text-anchor="middle">Applications</text>
+      <rect x="110" y="132" width="500" height="64" rx="9" fill="#10141b" stroke="#6ea8d8" stroke-width="1.3"/>
+      <text x="360" y="160" fill="#e8e8ec" font-size="14.5" text-anchor="middle">AI coding agents</text>
+      <text x="360" y="180" fill="#9cc4ea" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5" text-anchor="middle">Claude Code &#183; Cursor &#183; Codex &#183; OpenHands</text>
+      <rect x="92" y="206" width="536" height="84" rx="11" fill="#16170c" stroke="#c8f060" stroke-width="1.9"/>
+      <text x="360" y="240" fill="#c8f060" font-size="17" font-weight="700" text-anchor="middle">Mneme HQ</text>
+      <text x="360" y="263" fill="#dfe3cf" font-size="12.5" text-anchor="middle">Engineering Governance Layer</text>
+      <text x="360" y="281" fill="#a8a8b8" font-family="'DM Mono', ui-monospace, monospace" font-size="10" text-anchor="middle">enforce &#183; before generation &#183; across every agent</text>
+      <rect x="110" y="300" width="500" height="64" rx="9" fill="#141416" stroke="#8be0c8" stroke-width="1.3"/>
+      <text x="360" y="328" fill="#e8e8ec" font-size="14" text-anchor="middle">Architectural knowledge</text>
+      <text x="360" y="348" fill="#86c9b6" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5" text-anchor="middle">ADRs &#183; Standards &#183; Project memory</text>
+      <rect x="110" y="374" width="500" height="64" rx="9" fill="#141416" stroke="#2e2e34"/>
+      <text x="360" y="402" fill="#e8e8ec" font-size="14" text-anchor="middle">Infrastructure</text>
+      <text x="360" y="422" fill="#a8a8b8" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5" text-anchor="middle">Git &#183; CI/CD &#183; Tests</text>
+      <text x="360" y="476" fill="#a8a8b8" font-size="12" text-anchor="middle">A layer alongside CI/CD, testing, and review &#8212; not a replacement for them.</text>
+    </svg>
+  </figure>
+
   <section class="stack-section" aria-labelledby="runtime-stack-heading">
     <div class="section-label" id="runtime-stack-heading" style="margin-top:0;">Runtime stack &middot; where Mneme sits</div>
     <p class="stack-lede">An autonomous agent system is not one layer. <strong>Models</strong> produce candidate output. <strong>Harnesses</strong> coordinate execution, retries, and tool use. <strong>Execution systems</strong> maintain long-running loops, sessions, and memory. <strong>Governance infrastructure</strong> defines and enforces the architectural constraints the output must satisfy. <strong>Verification</strong> confirms the resulting system still passes its objective checks. Mneme is the governance layer &mdash; a separate layer that runs side by side with harnesses and execution systems, not inside them.</p>

--- a/site/index.html
+++ b/site/index.html
@@ -1229,6 +1229,57 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p style="max-width:620px;margin-bottom:1rem;color:var(--muted);font-size:1.05rem;line-height:1.6;">
       Mneme is not a memory tool, not a rules file, and not a RAG system. Each of those exists for a reason. None of them govern implementation.
     </p>
+    <figure class="arch-figure" style="margin:1.75rem 0 2.25rem;">
+      <svg viewBox="0 0 820 660" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="wms-t wms-d" style="width:100%;height:auto;display:block;max-width:820px;margin:0 auto;" font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+        <title id="wms-t">Where Mneme sits</title>
+        <desc id="wms-d">A developer prompts AI coding agents (Claude Code, Cursor, Codex). The Mneme HQ engineering governance layer for AI coding agents draws on ADRs, standards, engineering rules and project memory to run a policy evaluation. An allow verdict yields architecturally compliant code; a reject verdict produces guidance that is fed back to the agents to retry.</desc>
+        <defs>
+          <marker id="wms-al" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#c8f060"/></marker>
+          <marker id="wms-ag" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#33333a"/></marker>
+          <marker id="wms-ab" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#6ea8d8"/></marker>
+        </defs>
+        <rect x="0" y="0" width="820" height="660" rx="14" fill="#0c0c0d" stroke="#222226"/>
+        <text x="34" y="40" fill="#c8f060" font-family="'DM Mono', ui-monospace, monospace" font-size="11" letter-spacing="1.5">WHERE MNEME SITS</text>
+        <line x1="440" y1="92" x2="440" y2="114" stroke="#c8f060" stroke-width="1.6" marker-end="url(#wms-al)"/>
+        <line x1="440" y1="170" x2="440" y2="194" stroke="#c8f060" stroke-width="1.6" marker-end="url(#wms-al)"/>
+        <line x1="440" y1="392" x2="440" y2="390" stroke="#c8f060" stroke-width="1.6"/>
+        <path d="M440 262 V286 H185 V300" fill="none" stroke="#2e2e34" stroke-width="1" marker-end="url(#wms-ag)"/>
+        <path d="M440 262 V286 H355 V300" fill="none" stroke="#2e2e34" stroke-width="1" marker-end="url(#wms-ag)"/>
+        <path d="M440 262 V286 H525 V300" fill="none" stroke="#2e2e34" stroke-width="1" marker-end="url(#wms-ag)"/>
+        <path d="M440 262 V286 H695 V300" fill="none" stroke="#2e2e34" stroke-width="1" marker-end="url(#wms-ag)"/>
+        <path d="M185 348 V368 H440 V392" fill="none" stroke="#2e2e34" stroke-width="1"/>
+        <path d="M355 348 V368 H440" fill="none" stroke="#2e2e34" stroke-width="1"/>
+        <path d="M525 348 V368 H440" fill="none" stroke="#2e2e34" stroke-width="1"/>
+        <path d="M695 348 V368 H440 V392" fill="none" stroke="#2e2e34" stroke-width="1"/>
+        <path d="M500 440 V470 H610 V498" fill="none" stroke="#c8f060" stroke-width="1.5" marker-end="url(#wms-al)"/>
+        <path d="M380 440 V470 H225 V498" fill="none" stroke="#5c5c66" stroke-width="1.4" marker-end="url(#wms-ag)"/>
+        <text x="618" y="464" fill="#c8f060" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5">ALLOW</text>
+        <text x="150" y="464" fill="#a8a8b8" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5">REJECT</text>
+        <path d="M150 521 H44 V140 H316" fill="none" stroke="#6ea8d8" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#wms-ab)"/>
+        <text x="52" y="330" fill="#9cc4ea" font-family="'DM Mono', ui-monospace, monospace" font-size="10" transform="rotate(-90 52 330)">retry with guidance</text>
+        <rect x="370" y="50" width="140" height="42" rx="8" fill="#141416" stroke="#2e2e34"/>
+        <text x="440" y="76" fill="#e8e8ec" font-size="14" text-anchor="middle">Developer</text>
+        <rect x="316" y="116" width="248" height="54" rx="9" fill="#10141b" stroke="#6ea8d8" stroke-width="1.3"/>
+        <text x="440" y="139" fill="#e8e8ec" font-size="13.5" text-anchor="middle">AI coding agents</text>
+        <text x="440" y="158" fill="#9cc4ea" font-family="'DM Mono', ui-monospace, monospace" font-size="10.5" text-anchor="middle">Claude Code &#183; Cursor &#183; Codex</text>
+        <rect x="230" y="196" width="420" height="66" rx="11" fill="#16170c" stroke="#c8f060" stroke-width="1.8"/>
+        <text x="440" y="223" fill="#c8f060" font-size="17" font-weight="700" text-anchor="middle">Mneme HQ</text>
+        <text x="440" y="246" fill="#dfe3cf" font-size="12.5" text-anchor="middle">Engineering Governance Layer for AI Coding Agents</text>
+        <g font-size="12.5" text-anchor="middle">
+          <rect x="110" y="300" width="150" height="48" rx="8" fill="#141416" stroke="#8be0c8" stroke-width="1.2"/><text x="185" y="329" fill="#e8e8ec">ADRs</text>
+          <rect x="280" y="300" width="150" height="48" rx="8" fill="#141416" stroke="#8be0c8" stroke-width="1.2"/><text x="355" y="329" fill="#e8e8ec">Standards</text>
+          <rect x="450" y="300" width="150" height="48" rx="8" fill="#141416" stroke="#8be0c8" stroke-width="1.2"/><text x="525" y="329" fill="#e8e8ec">Engineering rules</text>
+          <rect x="620" y="300" width="150" height="48" rx="8" fill="#141416" stroke="#8be0c8" stroke-width="1.2"/><text x="695" y="329" fill="#e8e8ec">Project memory</text>
+        </g>
+        <rect x="330" y="392" width="220" height="48" rx="8" fill="#141416" stroke="#2e2e34"/>
+        <text x="440" y="421" fill="#e8e8ec" font-size="13.5" text-anchor="middle">Policy evaluation</text>
+        <rect x="150" y="498" width="150" height="46" rx="8" fill="#16170c" stroke="#c8f060" stroke-width="1.3"/>
+        <text x="225" y="526" fill="#c8f060" font-size="13" text-anchor="middle">Guidance</text>
+        <rect x="486" y="498" width="252" height="46" rx="8" fill="#16170c" stroke="#c8f060" stroke-width="1.4"/>
+        <text x="612" y="526" fill="#e8e8ec" font-size="13" text-anchor="middle">Architecturally compliant code</text>
+      </svg>
+      <figcaption style="margin-top:0.7rem;font-size:0.82rem;color:#a8a8b8;text-align:center;line-height:1.6;">Mneme governs the moment between intent and generated code &mdash; one set of rules, applied to every agent, before the change lands.</figcaption>
+    </figure>
     <div class="category-grid">
       <div class="category-card">
         <div class="cat-other">Rules files document standards.</div>


### PR DESCRIPTION
## What

Architecture diagrams for Mneme HQ, in **both** formats (per the scope discussion):

**Developer docs — Mermaid (`docs/architecture-diagrams.md`)**
All 7 diagrams as GitHub-rendered Mermaid: where Mneme sits, generation flow, engineering governance model, multi-agent governance, decision lifecycle, with/without comparison, and position in the AI engineering stack. Version-controlled, diff-able, the source of truth.

**Marketing/site — branded inline SVG**
The two highest-value diagrams, hand-authored in the house palette (lime = governance, teal = intent, blue = agents, grey = infra), self-contained (no JS, no new dependency, responsive via `viewBox`):

1. **"Where Mneme sits"** → homepage `#positioning` section. Developer → agents → the enlarged "Engineering Governance Layer for AI Coding Agents" box → ADRs/standards/rules/memory → **policy evaluation** → allow (architecturally compliant code) / reject (**guidance → retry loop** back to the agents).
2. **"Position in the AI engineering stack"** → top of `/architecture/` as the big-picture overview above the existing detailed runtime stack.

## Why this split

The two site diagrams are the category-defining, reusable visuals (homepage, deck, analyst briefings). The other five are explanatory flows that read fine as Mermaid in developer docs.

## Checks

`check_nav_footer`, `check_sticky_nav`, `check_encoding` all pass; CRLF preserved. Both site diagrams verified rendering in-context via headless screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
