### PR TITLE
site: migrate canonical GitHub URL to MnemeHQ (+ Mermaid sync, Omnigent accuracy fix)

### DIFF
--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -15,21 +15,23 @@ between coding agents and generated code.
 flowchart TD
   Dev[Developer]
   Agents["Claude Code / Cursor / Codex"]
-  Mneme["Mneme HQ<br/>Engineering Governance Layer"]
-  Decision{Governance decision}
-  Outcome["Allow / Reject / Guide"]
-  Code[Generated code]
+  Mneme["Mneme HQ<br/>Engineering Governance Layer for AI Coding Agents"]
+  Eval{Policy evaluation}
+  Code["Architecturally compliant code"]
+  Guidance[Guidance]
 
   Dev --> Agents --> Mneme
   Mneme --- ADRs[ADRs]
+  Mneme --- Standards[Standards]
   Mneme --- Rules[Engineering rules]
   Mneme --- Memory[Project memory]
-  Mneme --- Standards[Standards]
-  ADRs --> Decision
-  Rules --> Decision
-  Memory --> Decision
-  Standards --> Decision
-  Decision --> Outcome --> Code
+  ADRs --> Eval
+  Standards --> Eval
+  Rules --> Eval
+  Memory --> Eval
+  Eval -->|Allow| Code
+  Eval -->|Reject| Guidance
+  Guidance -->|retry| Agents
 ```
 
 ## 2. Generation flow

--- a/site/404.html
+++ b/site/404.html
@@ -168,7 +168,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -256,7 +256,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -279,7 +279,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/_snippets/footer.html
+++ b/site/_snippets/footer.html
@@ -48,7 +48,7 @@
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -71,7 +71,7 @@
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/_snippets/nav.html
+++ b/site/_snippets/nav.html
@@ -7,7 +7,7 @@
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -126,7 +126,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         "logo": "https://mnemehq.com/logo-v2.png",
         "description": "Architectural governance layer for AI-assisted development. Enforces architectural decisions on AI-generated code before review.",
         "sameAs": [
-          "https://github.com/TheoV823/mneme",
+          "https://github.com/MnemeHQ/mneme",
           "https://www.linkedin.com/company/mnemehq"
         ]
       },
@@ -658,7 +658,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -1270,7 +1270,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="links-grid">
       <div class="link-row">
         <span class="link-row-label">GitHub</span>
-        <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">github.com/TheoV823/mneme</a>
+        <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">github.com/MnemeHQ/mneme</a>
       </div>
       <div class="link-row">
         <span class="link-row-label">Founder</span>
@@ -1303,7 +1303,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="links-grid">
       <div class="link-row">
         <span class="link-row-label">GitHub</span>
-        <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">github.com/TheoV823/mneme</a>
+        <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">github.com/MnemeHQ/mneme</a>
       </div>
       <div class="link-row">
         <span class="link-row-label">Website</span>
@@ -1327,7 +1327,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <div class="cta-footer">
   <h2>Ready to enforce your architecture across every AI coding session?</h2>
   <div class="cta-group">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
     <a href="/use-cases/" class="btn-ghost">See use cases</a>
   </div>
 </div>
@@ -1384,7 +1384,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -1407,7 +1407,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/architecture/decision-memory-vs-documentation/index.html
+++ b/site/architecture/decision-memory-vs-documentation/index.html
@@ -376,7 +376,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -825,7 +825,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Add enforcement to the ADRs you already have</h3>
       <p>The ADR import integration adds a Constraints section to your existing ADRs and compiles them into the Mneme enforcement corpus. No rewrite, no new format.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -881,7 +881,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -904,7 +904,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/architecture/how-retrieval-works/index.html
+++ b/site/architecture/how-retrieval-works/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -741,7 +741,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Inspect the retriever source</h3>
       <p>DecisionRetriever, MemoryStore, ContextBuilder, and the full evaluation harness are open source under MIT license.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -797,7 +797,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -820,7 +820,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -293,7 +293,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -456,7 +456,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h2>Read the source</h2>
       <p>DecisionRetriever, MemoryStore, ContextBuilder, and the benchmark harness are all open source under MIT.</p>
     </div>
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
   </div>
 </div>
 </main>
@@ -511,7 +511,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -757,7 +757,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -772,7 +772,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- Layer 1 freeze status banner -->
 <div style="max-width:820px;margin:0 auto;padding:1.1rem 2rem;background:rgba(200,240,96,0.04);border-bottom:1px solid rgba(200,240,96,0.18);font-size:0.85rem;color:#88889a;line-height:1.7;">
   <strong style="color:#c8f060;font-family:'DM Mono',monospace;font-size:0.78rem;letter-spacing:0.08em;text-transform:uppercase;">Layer 1 freeze &middot; e73ff7d</strong><br>
-  This page is the methodology specification. The shipped Layer 1 suite is a pinned subset under the v1.1 methodology, anchored to the architectural freeze at commit <a href="https://github.com/TheoV823/mneme/commit/e73ff7d" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">e73ff7d</a>. recall@1 is reported but never optimized, and precision@K is treated as placeholder telemetry under the current shipped suite. Read the philosophy at <a href="/docs/benchmark-methodology/" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">/docs/benchmark-methodology/</a> or the full freeze artifact at <a href="https://github.com/TheoV823/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">docs/architecture/layer1-freeze-e73ff7d.md</a>.
+  This page is the methodology specification. The shipped Layer 1 suite is a pinned subset under the v1.1 methodology, anchored to the architectural freeze at commit <a href="https://github.com/MnemeHQ/mneme/commit/e73ff7d" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">e73ff7d</a>. recall@1 is reported but never optimized, and precision@K is treated as placeholder telemetry under the current shipped suite. Read the philosophy at <a href="/docs/benchmark-methodology/" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">/docs/benchmark-methodology/</a> or the full freeze artifact at <a href="https://github.com/MnemeHQ/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md" style="color:#8be0c8;text-decoration:none;border-bottom:1px solid rgba(139,224,200,0.4);">docs/architecture/layer1-freeze-e73ff7d.md</a>.
 </div>
 
 <!-- HERO -->
@@ -1082,7 +1082,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Methodology before metrics.</h2>
   <p>Full benchmark results publish after scenario suite validation. Methodology and harness are public now.</p>
   <div class="cta-group">
-    <a href="https://github.com/TheoV823/mneme/tree/main/mneme-project-memory/examples/benchmarks" class="btn-primary">View scenarios on GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme/tree/main/mneme-project-memory/examples/benchmarks" class="btn-primary">View scenarios on GitHub</a>
     <a href="/" class="btn-ghost">Back to home</a>
   </div>
   <p style="margin-top:2rem; font-size:0.85rem; color:var(--muted); line-height:1.8;">Related: the architectural argument behind the layer this benchmark measures is in <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" style="color:var(--accent);text-decoration:none;">architectural governance across heterogeneous AI coding agents</a>. The standards landscape this benchmark methodology is intended to be evaluable against is at <a href="/standards/" style="color:var(--accent);text-decoration:none;">/standards/</a>. The full set of governance use cases is at <a href="/use-cases/" style="color:var(--accent);text-decoration:none;">/use-cases/</a>.</p>
@@ -1150,7 +1150,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -1173,7 +1173,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/aider/index.html
+++ b/site/compare/aider/index.html
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -516,7 +516,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural enforcement underneath every coding agent</h3>
       <p>Mneme HQ hooks into Aider, Cursor, Claude Code, Copilot, and other AI coding agents at the Edit and Write boundary, matches your typed architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" class="cta-secondary">Read: Architectural governance across heterogeneous AI coding agents &rarr;</a>
     </div>
   </footer>
@@ -573,7 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -596,7 +596,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/claude-code-memory/index.html
+++ b/site/compare/claude-code-memory/index.html
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt engineering is not governance &rarr;</a>
     </div>
   </footer>
@@ -618,7 +618,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -641,7 +641,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/claude-md/index.html
+++ b/site/compare/claude-md/index.html
@@ -360,7 +360,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -583,7 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep your CLAUDE.md. Enforce the rules that matter.</h3>
       <p>Mneme HQ promotes the load-bearing rules out of your instructions file into typed decisions with a precedence engine and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/why-claude-md-stops-scaling/" class="cta-secondary">Read: Why CLAUDE.md Stops Scaling →</a>
       <a href="/integrations/claude-code/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Claude Code — integration guide →</a>
     </div>
@@ -641,7 +641,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -664,7 +664,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/coderabbit/index.html
+++ b/site/compare/coderabbit/index.html
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -568,7 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/ai-code-review-does-not-scale-linearly/" class="cta-secondary">Read: AI Code Review Does Not Scale Linearly →</a>
     </div>
   </footer>
@@ -625,7 +625,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -648,7 +648,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/continue-dev/index.html
+++ b/site/compare/continue-dev/index.html
@@ -324,7 +324,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -522,7 +522,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Precedence-aware governance underneath every coding agent</h3>
       <p>Mneme HQ enforces architectural decisions with explicit scope and a precedence engine. It runs at the Edit/Write hook for Continue, Cursor, Claude Code, Copilot, and any other AI coding agent. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-architectural-governance-needs-precedence-semantics/" class="cta-secondary">Read: Why architectural governance needs precedence semantics &rarr;</a>
     </div>
   </footer>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/cursor-rules/index.html
+++ b/site/compare/cursor-rules/index.html
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source, self-hosted, MIT licence.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub →</a>
       <a href="/insights/mneme-vs-cursor-rules/" class="cta-secondary">Read: Mneme vs Cursor Rules (editorial) →</a>
       <a href="/integrations/cursor/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Cursor — integration guide →</a>
     </div>
@@ -638,7 +638,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -661,7 +661,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/devin-vs-architectural-governance/index.html
+++ b/site/compare/devin-vs-architectural-governance/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -444,7 +444,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
       <a href="/works-with/devin/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Works with Devin &rarr;</a>
       <a href="/insights/devin-ai-software-engineer-governance/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Read the analysis</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -500,7 +500,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -523,7 +523,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/github-copilot/index.html
+++ b/site/compare/github-copilot/index.html
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -516,7 +516,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enforce architectural decisions across every coding agent</h3>
       <p>Mneme HQ hooks into AI coding agents &mdash; Copilot, Cursor, Claude Code, and others &mdash; at the Edit and Write boundary, matches your typed architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/github-copilot-space-framework/" class="cta-secondary">Read: What the SPACE framework reveals about Copilot &rarr;</a>
     </div>
   </footer>
@@ -573,7 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -596,7 +596,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/google-antigravity-vs-mneme/index.html
+++ b/site/compare/google-antigravity-vs-mneme/index.html
@@ -230,7 +230,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -327,7 +327,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
       <a href="/integrations/antigravity/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Works with Antigravity &rarr;</a>
       <a href="/insights/antigravity-solves-coordination-not-governance/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Read the analysis</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -383,7 +383,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -406,7 +406,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/index.html
+++ b/site/compare/index.html
@@ -392,7 +392,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -780,7 +780,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -803,7 +803,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/rag-coding-memory/index.html
+++ b/site/compare/rag-coding-memory/index.html
@@ -324,7 +324,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Decision memory that recalls every time</h3>
       <p>Mneme HQ hooks into your AI coding agent&rsquo;s Edit and Write operations, looks up architectural decisions by scope, and blocks violations deterministically. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-prompt-memory-fails-at-scale/" class="cta-secondary">Read: Why prompt memory fails at scale &rarr;</a>
     </div>
   </footer>
@@ -591,7 +591,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -614,7 +614,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/rag-vs-governance/index.html
+++ b/site/compare/rag-vs-governance/index.html
@@ -324,7 +324,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Deterministic enforcement, not better retrieval</h3>
       <p>Mneme HQ hooks into your AI coding agent&rsquo;s Edit and Write operations and blocks architectural violations before they reach the codebase. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-rag-fails-for-architectural-governance/" class="cta-secondary">Read: Why RAG fails for architectural governance &rarr;</a>
     </div>
   </footer>
@@ -591,7 +591,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -614,7 +614,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/sourcegraph-cody/index.html
+++ b/site/compare/sourcegraph-cody/index.html
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -514,7 +514,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enterprise governance that pairs with grounded retrieval</h3>
       <p>Mneme HQ enforces typed architectural decisions at the Edit/Write boundary &mdash; alongside Sourcegraph Cody&rsquo;s codebase retrieval, the IDE coding assistant of your choice, and your CI. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/why-rag-fails-for-architectural-governance/" class="cta-secondary">Read: Why RAG fails for architectural governance &rarr;</a>
     </div>
   </footer>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -594,7 +594,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/compare/windsurf/index.html
+++ b/site/compare/windsurf/index.html
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -514,7 +514,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance that holds across long autonomous runs</h3>
       <p>Mneme HQ fires on every Edit and Write Cascade (or any other coding agent) proposes &mdash; independent of how many planning steps preceded it. Typed decisions, explicit scope, precedence engine. Open source, self-hosted, model-agnostic.</p>
       <a href="/pilot/" class="btn-primary" style="margin-right:0.5rem;">Request a pilot &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub &rarr;</a>
       <a href="/insights/long-running-agents-need-governance/" class="cta-secondary">Read: Long-running agents need governance &rarr;</a>
     </div>
   </footer>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -594,7 +594,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/agent-verification/index.html
+++ b/site/concepts/agent-verification/index.html
@@ -296,7 +296,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -535,7 +535,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Verification you can run on every PR</h3>
       <p>Mneme compiles your team's architectural decisions into a verification contract that runs at pre-commit and in CI. Same contract, same change, same verdict &mdash; every time.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -591,7 +591,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -614,7 +614,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/agentic-development/index.html
+++ b/site/concepts/agentic-development/index.html
@@ -361,7 +361,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Govern your agentic workflow</h3>
       <p>Mneme provides the pre-generation enforcement infrastructure that agentic development requires — across agents, sessions, and tools, from a single version-controlled corpus.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -617,7 +617,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -640,7 +640,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/agentic-ide-governance/index.html
+++ b/site/concepts/agentic-ide-governance/index.html
@@ -241,7 +241,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -342,7 +342,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Architectural governance for agent-first IDEs</h3>
       <p>Mneme is the open-source layer for this discipline &mdash; deterministic ADR-derived constraints that travel with the repo and reach every agentic IDE on the team.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -398,7 +398,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -421,7 +421,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/ai-agent-drift/index.html
+++ b/site/concepts/ai-agent-drift/index.html
@@ -355,7 +355,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -708,7 +708,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -731,7 +731,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/ai-governance-infrastructure/index.html
+++ b/site/concepts/ai-governance-infrastructure/index.html
@@ -223,7 +223,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -310,7 +310,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>AI governance infrastructure, open source</h3>
       <p>Mneme compiles ADRs into deterministic verdicts that travel with the repo and reach every agent, tool, and CI surface &mdash; the open-source layer for this category.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -366,7 +366,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -389,7 +389,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/ai-native-sdlc/index.html
+++ b/site/concepts/ai-native-sdlc/index.html
@@ -370,7 +370,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -549,7 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Build governance infrastructure for your AI-native SDLC</h3>
       <p>Mneme is the governance layer for AI-native software delivery — decision memory, retrieval, injection, and enforcement as open-source infrastructure.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -605,7 +605,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -628,7 +628,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/ai-operating-layer/index.html
+++ b/site/concepts/ai-operating-layer/index.html
@@ -336,7 +336,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -523,7 +523,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Build the governance layer of your AI operating stack</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and enforces them across every agent and CI surface &mdash; the governance, provenance, and verification layers your AI operating layer is missing.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/antigravity-governance/index.html
+++ b/site/concepts/antigravity-governance/index.html
@@ -224,7 +224,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -323,7 +323,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Antigravity governance, repo-native</h3>
       <p>Mneme is the open-source layer for architectural governance across agent-first IDEs &mdash; including Google Antigravity.</p>
       <a href="/integrations/antigravity/" class="btn-primary" style="margin-right:0.5rem;">Works with Antigravity &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -379,7 +379,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -402,7 +402,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/architectural-compiler/index.html
+++ b/site/concepts/architectural-compiler/index.html
@@ -440,7 +440,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -785,7 +785,7 @@ PostgreSQL only.</span>
     <div class="cta-block">
       <h3>Try the ADR compiler</h3>
       <p>Run <code style="font-family:'DM Mono',monospace;font-size:0.82em;color:var(--teal)">mneme import-adr</code> against your existing ADR directory and see what compiles — and what surfaces as a validation error.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -841,7 +841,7 @@ PostgreSQL only.</span>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -864,7 +864,7 @@ PostgreSQL only.</span>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/architectural-drift/index.html
+++ b/site/concepts/architectural-drift/index.html
@@ -390,7 +390,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -683,7 +683,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -706,7 +706,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/architectural-governance/index.html
+++ b/site/concepts/architectural-governance/index.html
@@ -415,7 +415,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -748,7 +748,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -771,7 +771,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/artifact-provenance/index.html
+++ b/site/concepts/artifact-provenance/index.html
@@ -225,7 +225,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -308,7 +308,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Make governance verdicts a first-class agent artifact</h3>
       <p>Mneme attaches deterministic policy verdicts to every agent run &mdash; so reviewers see both the trail and the rule that applied.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -364,7 +364,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -387,7 +387,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/autonomous-software-engineering-governance/index.html
+++ b/site/concepts/autonomous-software-engineering-governance/index.html
@@ -289,7 +289,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -446,7 +446,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Autonomous software engineering, governed</h3>
       <p>Mneme is the open-source layer for this discipline &mdash; deterministic ADR-derived constraints that travel with the repo and reach every agent, tool, and CI surface.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -502,7 +502,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -525,7 +525,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/decision-continuity/index.html
+++ b/site/concepts/decision-continuity/index.html
@@ -361,7 +361,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -558,7 +558,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>See decision continuity in action</h3>
       <p>Mneme's governance corpus provides structural continuity across every agent session — without CLAUDE.md maintenance or per-session context injection.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -614,7 +614,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -637,7 +637,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/deterministic-enforcement/index.html
+++ b/site/concepts/deterministic-enforcement/index.html
@@ -434,7 +434,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -742,7 +742,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Inspect the deterministic evaluator</h3>
       <p>Mneme's evaluation layer — structured output checking against structured constraint records — is open source. Read the evaluator source to see how determinism is maintained across non-deterministic model inference.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -798,7 +798,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -821,7 +821,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/enforcement-provenance/index.html
+++ b/site/concepts/enforcement-provenance/index.html
@@ -350,7 +350,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -671,7 +671,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -694,7 +694,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/executable-architectural-intent/index.html
+++ b/site/concepts/executable-architectural-intent/index.html
@@ -335,7 +335,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -501,7 +501,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Promote the binding slice of your architecture</h3>
       <p>Mneme is the infrastructure layer for executable architectural intent: machine-evaluable constraints retrieved before agents generate, enforced at CI, traceable back to the source decision.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/execution-surfaces/index.html
+++ b/site/concepts/execution-surfaces/index.html
@@ -309,7 +309,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -553,7 +553,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Govern the surfaces, not just the source</h3>
       <p>Mneme's hooks attach to every execution surface an agent touches &mdash; pre-tool-use, pre-commit, pre-PR, CI &mdash; so the inventory and the governance map align by construction.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -609,7 +609,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -632,7 +632,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/governance-before-generation/index.html
+++ b/site/concepts/governance-before-generation/index.html
@@ -436,7 +436,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -853,7 +853,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -876,7 +876,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/governance-infrastructure/index.html
+++ b/site/concepts/governance-infrastructure/index.html
@@ -421,7 +421,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -850,7 +850,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Deploy governance infrastructure</h3>
       <p>Mneme is the governance infrastructure layer for AI-native software teams — encoding, distributing, versioning, and enforcing architectural decisions across every agent that touches your codebase.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -906,7 +906,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -929,7 +929,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/governance-propagation/index.html
+++ b/site/concepts/governance-propagation/index.html
@@ -353,7 +353,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -666,7 +666,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -689,7 +689,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/governance-provenance/index.html
+++ b/site/concepts/governance-provenance/index.html
@@ -295,7 +295,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -597,7 +597,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Rules with citable lineage</h3>
       <p>Mneme compiles your ADRs into a decision corpus where every rule carries its authoring ADR, supersession chain, propagation history, and originating context &mdash; queryable from CI, the dashboard, and the agent's verdict output.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -653,7 +653,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -676,7 +676,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/index.html
+++ b/site/concepts/index.html
@@ -341,7 +341,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -931,7 +931,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h2>See these concepts in practice</h2>
       <p>The benchmark, the demos, and the open-source codebase are all running versions of the governance infrastructure described here.</p>
     </div>
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
   </div>
 </div>
 </main>
@@ -986,7 +986,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -1009,7 +1009,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/intent-debt/index.html
+++ b/site/concepts/intent-debt/index.html
@@ -326,7 +326,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -565,7 +565,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -588,7 +588,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/model-independent-governance/index.html
+++ b/site/concepts/model-independent-governance/index.html
@@ -367,7 +367,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -536,7 +536,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Keep governance outside the model</h3>
       <p>Mneme is the model-independent governance layer for AI-assisted development: a repo-native control surface that returns the same verdict at every enforcement point, no matter which model or harness produced the change.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -592,7 +592,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -615,7 +615,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/multi-agent-architectural-drift/index.html
+++ b/site/concepts/multi-agent-architectural-drift/index.html
@@ -226,7 +226,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -302,7 +302,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Stop parallel agents from drifting in incompatible directions</h3>
       <p>Mneme is the open-source layer for deterministic architectural governance across multi-agent coding workflows.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -358,7 +358,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -381,7 +381,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/multi-agent-continuity/index.html
+++ b/site/concepts/multi-agent-continuity/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -679,7 +679,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -702,7 +702,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/objective-driven-development/index.html
+++ b/site/concepts/objective-driven-development/index.html
@@ -350,7 +350,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Govern your objective-driven loops</h3>
       <p>Mneme is the architectural constraint layer for governed objective loops: retrievable ADRs and dependency rules injected before agents generate, and enforced deterministically in CI after they run.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -593,7 +593,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -616,7 +616,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/precedence-semantics/index.html
+++ b/site/concepts/precedence-semantics/index.html
@@ -372,7 +372,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -681,7 +681,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -704,7 +704,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/reliable-delegation/index.html
+++ b/site/concepts/reliable-delegation/index.html
@@ -417,7 +417,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -590,7 +590,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     </details>
     <details>
       <summary>How does Mneme support reliable delegation?</summary>
-      <div class="faq-body">Mneme is the governance and verification layer for AI-assisted software development. It compiles a repository&rsquo;s architectural decisions into a deterministic constraint graph and enforces that graph at the boundaries where agents make consequential changes: session start, pre-tool-use, pre-commit, pre-PR, and CI. Governance packets inject constraints before generation. Verification contracts prove whether the agent&rsquo;s output preserved intent. Together they provide the two layers that convert agent capability into reliable delegation. See the <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
+      <div class="faq-body">Mneme is the governance and verification layer for AI-assisted software development. It compiles a repository&rsquo;s architectural decisions into a deterministic constraint graph and enforces that graph at the boundaries where agents make consequential changes: session start, pre-tool-use, pre-commit, pre-PR, and CI. Governance packets inject constraints before generation. Verification contracts prove whether the agent&rsquo;s output preserved intent. Together they provide the two layers that convert agent capability into reliable delegation. See the <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
     </details>
   </section>
 
@@ -628,7 +628,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>The governance and verification layer for AI-assisted development.</h3>
       <p>Mneme compiles your architectural decisions into a deterministic constraint graph and enforces it at the boundaries where agents act. Open source, MIT licensed.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -684,7 +684,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -707,7 +707,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/runtime-governance/index.html
+++ b/site/concepts/runtime-governance/index.html
@@ -315,7 +315,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -506,7 +506,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Runtime governance, repo-native</h3>
       <p>Mneme compiles ADRs and architectural constraints into deterministic verdicts that travel with the repo &mdash; reachable from every agent, every tool, every long-running execution surface. Open source.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -562,7 +562,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -585,7 +585,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/spec-driven-development/index.html
+++ b/site/concepts/spec-driven-development/index.html
@@ -241,7 +241,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -337,7 +337,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Architectural governance for spec-driven development</h3>
       <p>Mneme is the open-source layer for this discipline &mdash; deterministic ADR-derived constraints that keep agents inside architectural intent while they execute a spec.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -393,7 +393,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -416,7 +416,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/concepts/verification-contracts/index.html
+++ b/site/concepts/verification-contracts/index.html
@@ -412,7 +412,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -770,7 +770,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -793,7 +793,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -129,7 +129,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
           "name": "Mneme HQ",
           "url": "https://mnemehq.com",
           "sameAs": [
-            "https://github.com/TheoV823/mneme",
+            "https://github.com/MnemeHQ/mneme",
             "https://www.linkedin.com/company/mnemehq"
           ]
         }
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -582,24 +582,24 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <!-- CONTACT CHANNELS -->
   <div class="contact-grid">
 
-    <a href="https://github.com/TheoV823/mneme/issues" target="_blank" rel="noopener" class="contact-card">
+    <a href="https://github.com/MnemeHQ/mneme/issues" target="_blank" rel="noopener" class="contact-card">
       <div class="contact-card-icon icon-issues">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8be0c8" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       </div>
       <div class="contact-card-body">
         <div class="contact-card-label">GitHub Issues</div>
-        <div class="contact-card-value">github.com/TheoV823/mneme/issues</div>
+        <div class="contact-card-value">github.com/MnemeHQ/mneme/issues</div>
         <div class="contact-card-desc">Bug reports, feature requests, and integration questions. Preferred for anything technical.</div>
       </div>
     </a>
 
-    <a href="https://github.com/TheoV823/mneme/discussions" target="_blank" rel="noopener" class="contact-card">
+    <a href="https://github.com/MnemeHQ/mneme/discussions" target="_blank" rel="noopener" class="contact-card">
       <div class="contact-card-icon icon-github">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8be0c8" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
       </div>
       <div class="contact-card-body">
         <div class="contact-card-label">GitHub Discussions</div>
-        <div class="contact-card-value">github.com/TheoV823/mneme/discussions</div>
+        <div class="contact-card-value">github.com/MnemeHQ/mneme/discussions</div>
         <div class="contact-card-desc">Open questions, architecture ideas, community conversation.</div>
       </div>
     </a>
@@ -719,7 +719,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -742,7 +742,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/adr-compiler/index.html
+++ b/site/demo/adr-compiler/index.html
@@ -323,7 +323,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -476,7 +476,7 @@ These must never be conflated in code-bearing surfaces.
 
       <p>The repo ships a Python walkthrough that runs the compiler end-to-end against Mneme's own architectural decisions. No API key. No external services. Local Mneme pipeline:</p>
 
-      <pre><code>git clone https://github.com/TheoV823/mneme
+      <pre><code>git clone https://github.com/MnemeHQ/mneme
 cd mneme/mneme-project-memory
 pip install -e .
 python examples/demo-adr-import.py</code></pre>
@@ -623,7 +623,7 @@ Result: WARN</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -646,7 +646,7 @@ Result: WARN</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/agent-sdk-governance/index.html
+++ b/site/demo/agent-sdk-governance/index.html
@@ -320,7 +320,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -505,7 +505,7 @@ async def before_tool_call(tool_name: str, tool_input: dict) -> dict:
 
       <p>The repo ships a Python script that runs the full two-phase scenario against the real Mneme pipeline. The agent is simulated as a scripted diff producer &mdash; no live LLM call is required. The hook, corpus check, violation raise, remediation inject, and post-execution scan are the actual Mneme code paths.</p>
 
-      <pre><code>git clone https://github.com/TheoV823/mneme
+      <pre><code>git clone https://github.com/MnemeHQ/mneme
 cd mneme/examples/agent-sdk-governance
 python run.py</code></pre>
 
@@ -598,7 +598,7 @@ python run.py</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -621,7 +621,7 @@ python run.py</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/architectural-drift/index.html
+++ b/site/demo/architectural-drift/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -607,7 +607,7 @@ Agent halted before architectural drift.</code></pre>
 
       <p>The repo ships a Python walkthrough that simulates the timeline above against the Mneme pipeline. Three sequential "agents" produce diff hunks. The same Mneme conflict detector and enforcer that drive the editor hook and the CI gate evaluate each step:</p>
 
-      <pre><code>git clone https://github.com/TheoV823/mneme
+      <pre><code>git clone https://github.com/MnemeHQ/mneme
 cd mneme/examples/architectural-drift
 python run.py</code></pre>
 
@@ -718,7 +718,7 @@ python run.py</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -741,7 +741,7 @@ python run.py</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/dependency-policy/index.html
+++ b/site/demo/dependency-policy/index.html
@@ -378,7 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -555,7 +555,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -578,7 +578,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/governed-python-agent/index.html
+++ b/site/demo/governed-python-agent/index.html
@@ -292,7 +292,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -389,7 +389,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
       <h2>Run it yourself</h2>
 
-      <pre><code>git clone https://github.com/TheoV823/mneme
+      <pre><code>git clone https://github.com/MnemeHQ/mneme
 cd mneme/mneme-project-memory
 pip install -e .
 python examples/demo-adr-import.py</code></pre>
@@ -495,7 +495,7 @@ Result: WARN</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -518,7 +518,7 @@ Result: WARN</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -146,7 +146,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         "operatingSystem": "Linux, macOS, Windows",
         "description": "Open-source architectural governance layer for AI coding agents. Compiles project architectural decisions into enforceable, precedence-aware constraints that govern Claude Code, Cursor, GitHub Copilot, Windsurf, and custom SDK agents at the pre-generation stage.",
         "url": "https://mnemehq.com/",
-        "downloadUrl": "https://github.com/TheoV823/mneme",
+        "downloadUrl": "https://github.com/MnemeHQ/mneme",
         "license": "https://opensource.org/licenses/MIT",
         "softwareVersion": "0.4.0",
         "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
@@ -372,7 +372,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -706,7 +706,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -729,7 +729,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/multi-agent-governance/index.html
+++ b/site/demo/multi-agent-governance/index.html
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -491,7 +491,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
       <p>The repo ships a Python script that simulates the three-actor workflow against the real Mneme pipeline. The "actors" are scripted diff producers &mdash; the script does not call any LLM. The enforcement, retrieval, and conflict-detection steps are the actual Mneme code that drives the editor hook and CI gate.</p>
 
-      <pre><code>git clone https://github.com/TheoV823/mneme
+      <pre><code>git clone https://github.com/MnemeHQ/mneme
 cd mneme/examples/multi-agent-governance
 python run.py</code></pre>
 
@@ -599,7 +599,7 @@ python run.py</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -622,7 +622,7 @@ python run.py</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/repository-pattern/index.html
+++ b/site/demo/repository-pattern/index.html
@@ -379,7 +379,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -548,7 +548,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/demo/storage-decision/index.html
+++ b/site/demo/storage-decision/index.html
@@ -373,7 +373,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -567,7 +567,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -590,7 +590,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/benchmark-methodology/index.html
+++ b/site/docs/benchmark-methodology/index.html
@@ -522,7 +522,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -646,7 +646,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     Mneme is currently in Layer 1 — local-repo, single-developer, project-scoped architectural governance. The mechanism is frozen at <em>e73ff7d</em>. The validation phase tests the mechanism in real repos with real users; it does not extend the mechanism. Layer 2 territory (multi-repo, team sync, org policy distribution) opens only after Layer 1 exit criteria are met.
   </p>
   <p>
-    This page is a public summary of the philosophy. The full architectural freeze artifact lives in the repo at <a href="https://github.com/TheoV823/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md">docs/architecture/layer1-freeze-e73ff7d.md</a>. The full methodology specification with metric definitions, suite composition, verdict thresholds, and reproducibility protocol lives at <a href="/benchmark/">/benchmark/</a>.
+    This page is a public summary of the philosophy. The full architectural freeze artifact lives in the repo at <a href="https://github.com/MnemeHQ/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md">docs/architecture/layer1-freeze-e73ff7d.md</a>. The full methodology specification with metric definitions, suite composition, verdict thresholds, and reproducibility protocol lives at <a href="/benchmark/">/benchmark/</a>.
   </p>
 
   <h2 id="differentiation">What this means for evaluators</h2>
@@ -668,7 +668,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Read the full freeze artifact.</h2>
   <p>The repo-level freeze captures shipped capabilities, charter discipline, deferred work, and the bright line between "deferred" and "not Mneme."</p>
   <div class="cta-group">
-    <a href="https://github.com/TheoV823/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md" class="btn-primary">Layer 1 freeze artifact</a>
+    <a href="https://github.com/MnemeHQ/mneme/blob/main/docs/architecture/layer1-freeze-e73ff7d.md" class="btn-primary">Layer 1 freeze artifact</a>
     <a href="/benchmark/" class="btn-ghost">Full methodology spec</a>
   </div>
 </section>
@@ -725,7 +725,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -748,7 +748,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/cli/index.html
+++ b/site/docs/cli/index.html
@@ -336,7 +336,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -382,7 +382,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cmd-card">
 <pre><span class="cp">$</span> pip install mneme-hq</pre>
       <p class="cdesc">Installs the <code>mneme</code> entry point on your PATH. Every subcommand requires <code>--memory</code> pointing at a <code>project_memory.json</code> file. An example corpus ships at <code>examples/project_memory.json</code>.</p>
-      <p class="cdesc" style="margin-bottom:0;">From source (contributors): <code>git clone https://github.com/TheoV823/mneme &amp;&amp; cd mneme/mneme-project-memory &amp;&amp; pip install -e .</code></p>
+      <p class="cdesc" style="margin-bottom:0;">From source (contributors): <code>git clone https://github.com/MnemeHQ/mneme &amp;&amp; cd mneme/mneme-project-memory &amp;&amp; pip install -e .</code></p>
     </div>
   </section>
 
@@ -684,7 +684,7 @@ jobs:
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -707,7 +707,7 @@ jobs:
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/governance-violations/index.html
+++ b/site/docs/governance-violations/index.html
@@ -329,7 +329,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -697,7 +697,7 @@ def create_app():
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -720,7 +720,7 @@ def create_app():
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/how-enforcement-works/index.html
+++ b/site/docs/how-enforcement-works/index.html
@@ -236,7 +236,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -312,7 +312,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p>Enforcement that varies between runs is not governance &mdash; it is suggestion. Mneme is built around the principle that the same decision, the same task, and the same memory must produce the same verdict, every time, in every environment.</p>
     <p>This determinism is what makes governance auditable. When a CI step fails or an agent is blocked, the verdict is reconstructible: the rule that matched is recorded, the term that triggered it is recorded, and the score that surfaced that rule is recorded. There is nothing probabilistic to investigate.</p>
     <p>It also makes regressions visible. Any change to the enforcement layer that would alter a verdict is detectable against the frozen benchmark suite &mdash; nothing can drift silently.</p>
-    <p>For deeper detail on the retrieval mechanics, the benchmark methodology, and the Layer 1 charter, see the <a href="https://github.com/TheoV823/mneme/blob/main/docs/architecture/governance-representation.md" target="_blank" rel="noopener">architecture doc in the source repository</a>.</p>
+    <p>For deeper detail on the retrieval mechanics, the benchmark methodology, and the Layer 1 charter, see the <a href="https://github.com/MnemeHQ/mneme/blob/main/docs/architecture/governance-representation.md" target="_blank" rel="noopener">architecture doc in the source repository</a>.</p>
   </div>
 
   <div class="cross-links">
@@ -386,7 +386,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -409,7 +409,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -218,7 +218,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -281,7 +281,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2 style="font-family:'DM Mono',monospace;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);margin:3.5rem 0 1.25rem;">How to read these docs</h2>
   <p style="font-size:0.9rem;color:var(--muted);line-height:1.85;max-width:780px;margin:0 0 1.25rem;">The CLI reference is the operational entrypoint: every governance action — listing decisions, adding them, running a check, generating Cursor rules, executing the benchmark — flows through one of the documented commands. Pair it with the governance violations doc to understand <em>what</em> the <code style="font-family:'DM Mono',monospace;font-size:0.85em;background:var(--surface2);padding:0.05rem 0.4rem;border-radius:4px;border:1px solid var(--border);">check</code> command is actually surfacing in practice.</p>
   <p style="font-size:0.9rem;color:var(--muted);line-height:1.85;max-width:780px;margin:0 0 1.25rem;">The supported languages page is the canonical coverage matrix — Tier 1 (Python, TypeScript, JavaScript) gets native depth; Tier 2 (Go, Java, C#, Rust) gets repository-level governance through architectural and dependency rules. Mneme is language-agnostic by design; that page documents where the depth lives today and what is on the roadmap.</p>
-  <p style="font-size:0.9rem;color:var(--muted);line-height:1.85;max-width:780px;margin:0;">The benchmark methodology page is the methodology specification, not a results dashboard. It describes layered retrieval and enforcement scoring, structured-output verification, pre-registered thresholds, and the anti-gaming protocol — methodology before metrics. Cross-link: see the <a href="/insights/" style="color:var(--accent);text-decoration:none;">Insights</a> hub for essays on the underlying architectural-governance category, and the <a href="https://github.com/TheoV823/mneme" style="color:var(--accent);text-decoration:none;">source repository</a> for everything the docs do not cover.</p>
+  <p style="font-size:0.9rem;color:var(--muted);line-height:1.85;max-width:780px;margin:0;">The benchmark methodology page is the methodology specification, not a results dashboard. It describes layered retrieval and enforcement scoring, structured-output verification, pre-registered thresholds, and the anti-gaming protocol — methodology before metrics. Cross-link: see the <a href="/insights/" style="color:var(--accent);text-decoration:none;">Insights</a> hub for essays on the underlying architectural-governance category, and the <a href="https://github.com/MnemeHQ/mneme" style="color:var(--accent);text-decoration:none;">source repository</a> for everything the docs do not cover.</p>
 </div>
 
 </main>
@@ -336,7 +336,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -359,7 +359,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/docs/supported-languages/index.html
+++ b/site/docs/supported-languages/index.html
@@ -249,7 +249,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -569,7 +569,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -592,7 +592,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/for/cto/index.html
+++ b/site/for/cto/index.html
@@ -405,7 +405,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -627,7 +627,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -650,7 +650,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/for/index.html
+++ b/site/for/index.html
@@ -360,7 +360,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -465,7 +465,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <div class="for-cta-links">
         <a href="/use-cases/">See use cases &rarr;</a>
         <a href="/benchmark/">View benchmark &rarr;</a>
-        <a href="https://github.com/TheoV823/mneme">GitHub &rarr;</a>
+        <a href="https://github.com/MnemeHQ/mneme">GitHub &rarr;</a>
       </div>
     </div>
 
@@ -588,7 +588,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -611,7 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/for/platform/index.html
+++ b/site/for/platform/index.html
@@ -374,7 +374,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -400,7 +400,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <time datetime="2026-05-10">Updated May 2026</time>
     </p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
       <a href="/use-cases/" class="btn-ghost">See all use cases</a>
     </div>
   </div>
@@ -511,7 +511,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>One corpus. All agents. All tools.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
       <a href="/use-cases/" class="btn-ghost">See all use cases</a>
     </div>
   </div>
@@ -567,7 +567,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -590,7 +590,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/for/principal-engineer/index.html
+++ b/site/for/principal-engineer/index.html
@@ -386,7 +386,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -524,7 +524,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Stop reviewing the same violations twice.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
       <a href="/insights/why-code-review-cannot-scale-with-ai-output/" class="link-ghost">Read: Why Code Review Cannot Scale &rarr;</a>
     </div>
   </div>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -603,7 +603,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/founder/index.html
+++ b/site/founder/index.html
@@ -600,7 +600,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -741,7 +741,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <div class="cta-footer">
   <h2>Ready to enforce your architecture across every AI coding session?</h2>
   <div class="cta-group">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
     <a href="/use-cases/" class="btn-ghost">See use cases</a>
   </div>
 </div>
@@ -798,7 +798,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -821,7 +821,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/index.html
+++ b/site/index.html
@@ -975,7 +975,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       "operatingSystem": "Linux, macOS, Windows",
       "description": "Mneme HQ is the architectural governance layer for AI-assisted development. It compiles architectural intent into enforceable constraints that govern AI coding agents before code is generated, preventing architectural drift at the source rather than catching it in review.",
       "url": "https://mnemehq.com/",
-      "downloadUrl": "https://github.com/TheoV823/mneme",
+      "downloadUrl": "https://github.com/MnemeHQ/mneme",
       "isAccessibleForFree": true,
       "featureList": [
         "Pre-generation architectural governance for AI coding agents",
@@ -990,7 +990,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         { "@type": "Thing", "name": "Architectural governance" },
         { "@type": "Thing", "name": "AI coding assistants" },
         { "@type": "Thing", "name": "Architectural Decision Records" },
-        { "@type": "Thing", "name": "AI code review bottleneck" }
+        { "@type": "Thing", "name": "AI code review capacity" }
       ],
       "mentions": [
         { "@type": "Thing", "name": "Cursor Rules" },
@@ -1013,7 +1013,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       "logo": "https://mnemehq.com/logo-v2.png",
       "description": "Mneme HQ builds the architectural governance layer for AI-assisted development. We help engineering teams govern AI coding agents at the pre-generation stage, before architectural drift reaches review.",
       "sameAs": [
-        "https://github.com/TheoV823/mneme"
+        "https://github.com/MnemeHQ/mneme"
       ]
     },
     {
@@ -1095,7 +1095,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -1121,7 +1121,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-group">
       <a href="/pilot/" class="btn-primary">Request pilot access</a>
       <a href="/demo/" class="btn-ghost">Walk the flagship demos</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View on GitHub</a>
     </div>
   </div>
 
@@ -1163,7 +1163,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <div style="background:var(--surface2);border-top:1px solid var(--border2);border-bottom:1px solid var(--border2);">
   <div class="section-wrap" id="problem" style="border-top:none;padding-top:4.25rem;padding-bottom:4.25rem;">
-    <div class="section-eyebrow">The bottleneck</div>
+    <div class="section-eyebrow">The mismatch</div>
     <h2 class="section-title" style="margin-bottom:0.5rem;">AI increased code output.<br><span style="color:#ff7070;">Review capacity did not.</span></h2>
     <p style="max-width:620px;margin-bottom:2rem;color:var(--muted);font-size:1.05rem;line-height:1.55;">
       Coding assistants generate code faster than teams can review it.<br>
@@ -1587,7 +1587,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="code-blocks">
       <div class="code-block" data-copy-block>
         <div class="code-block-label">install<button class="copy-btn" type="button" data-command="install" aria-label="Copy install commands">Copy</button></div>
-        <pre><span class="cp">$</span> git clone https://github.com/TheoV823/mneme
+        <pre><span class="cp">$</span> git clone https://github.com/MnemeHQ/mneme
 <span class="cp">$</span> cd mneme
 <span class="cp">$</span> pip install -e .</pre>
       </div>
@@ -1607,7 +1607,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       &nbsp;&nbsp;&middot;&nbsp;&nbsp;
       <a href="/benchmark/" style="color:var(--accent);text-decoration:none;">Run the benchmark &rarr;</a>
       &nbsp;&nbsp;&middot;&nbsp;&nbsp;
-      <a href="https://github.com/TheoV823/mneme#python-api" style="color:var(--accent);text-decoration:none;">Python API &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme#python-api" style="color:var(--accent);text-decoration:none;">Python API &rarr;</a>
     </p>
   </div>
 
@@ -1682,7 +1682,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h2>Ready to govern your AI coding agents?</h2>
     <div class="cta-group">
       <a href="/pilot/" class="btn-primary">Request pilot access</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View on GitHub</a>
       <a href="/demo/" class="btn-ghost">Walk the flagship demos</a>
     </div>
   </div>
@@ -1817,7 +1817,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -1840,7 +1840,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/index.html
+++ b/site/index.html
@@ -990,7 +990,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
         { "@type": "Thing", "name": "Architectural governance" },
         { "@type": "Thing", "name": "AI coding assistants" },
         { "@type": "Thing", "name": "Architectural Decision Records" },
-        { "@type": "Thing", "name": "AI code review capacity" }
+        { "@type": "Thing", "name": "AI code review bottleneck" }
       ],
       "mentions": [
         { "@type": "Thing", "name": "Cursor Rules" },
@@ -1163,7 +1163,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <div style="background:var(--surface2);border-top:1px solid var(--border2);border-bottom:1px solid var(--border2);">
   <div class="section-wrap" id="problem" style="border-top:none;padding-top:4.25rem;padding-bottom:4.25rem;">
-    <div class="section-eyebrow">The mismatch</div>
+    <div class="section-eyebrow">The bottleneck</div>
     <h2 class="section-title" style="margin-bottom:0.5rem;">AI increased code output.<br><span style="color:#ff7070;">Review capacity did not.</span></h2>
     <p style="max-width:620px;margin-bottom:2rem;color:var(--muted);font-size:1.05rem;line-height:1.55;">
       Coding assistants generate code faster than teams can review it.<br>

--- a/site/insights/acceleration-whiplash-governance-gap/index.html
+++ b/site/insights/acceleration-whiplash-governance-gap/index.html
@@ -316,7 +316,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Move enforcement to the point of authorship</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook, enforcing architectural constraints before code is written. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &#x2192;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &#x2192;</a>
     </div>
   </footer>
 </article>
@@ -589,7 +589,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -612,7 +612,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-first-ides-need-architectural-invariants/index.html
+++ b/site/insights/agent-first-ides-need-architectural-invariants/index.html
@@ -222,7 +222,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -311,7 +311,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Encode the invariants. Retrieve them. Enforce them.</h3>
       <p>Mneme is the open-source layer that turns ADRs into deterministic governance for agent-first development &mdash; including Google Antigravity, Cursor, Claude Code, and Copilot.</p>
       <a href="/integrations/antigravity/" class="btn-primary" style="margin-right:0.5rem;">Works with Antigravity &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -367,7 +367,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -390,7 +390,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-formation-engineering-performance-metrics/index.html
+++ b/site/insights/agent-formation-engineering-performance-metrics/index.html
@@ -355,7 +355,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -506,7 +506,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Measure whether your agents are building one system</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time &mdash; the layer that turns agentic engineering metrics into live readings. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -562,7 +562,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -585,7 +585,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-governance-in-the-sdlc/index.html
+++ b/site/insights/agent-governance-in-the-sdlc/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -469,7 +469,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep architecture coherent across every agent</h3>
       <p>Mneme propagates the same architectural decisions to every agent, hook, and CI surface in an orchestrated workflow &mdash; so parallel work does not mean parallel drift. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -525,7 +525,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -548,7 +548,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-manager-control-plane-governance/index.html
+++ b/site/insights/agent-manager-control-plane-governance/index.html
@@ -222,7 +222,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -300,7 +300,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add policy to your agent control plane</h3>
       <p>Mneme is the open-source governance layer for multi-agent coding workflows &mdash; deterministic verdicts that travel alongside the manager view.</p>
       <a href="/integrations/antigravity/" class="btn-primary" style="margin-right:0.5rem;">Works with Antigravity &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -356,7 +356,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -379,7 +379,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-runtime-governance/index.html
+++ b/site/insights/agent-runtime-governance/index.html
@@ -319,7 +319,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -510,7 +510,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Runtime governance for autonomous workflows</h3>
       <p>The next generation of AI infrastructure will not just execute agents. It will constrain, verify, and govern them across long-running workflows. Mneme is the open-source layer for that job.</p>
       <a href="/concepts/runtime-governance/" class="btn-primary" style="margin-right:0.5rem;">Read the concept &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
     </div>
   </footer>
 </article>
@@ -566,7 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -589,7 +589,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agent-skills-vs-architectural-governance/index.html
+++ b/site/insights/agent-skills-vs-architectural-governance/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add governance to your agent stack</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and enforces them at the hook level &mdash; so governance travels with the workflow instead of living only in review. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -590,7 +590,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -613,7 +613,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agentic-convergence-trap-architectural-governance/index.html
+++ b/site/insights/agentic-convergence-trap-architectural-governance/index.html
@@ -397,7 +397,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -588,7 +588,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. The layer that keeps your architecture yours. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -644,7 +644,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -667,7 +667,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agentic-infrastructure-attack-surface/index.html
+++ b/site/insights/agentic-infrastructure-attack-surface/index.html
@@ -378,7 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -727,7 +727,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -750,7 +750,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agentic-resource-discovery-agent-governance/index.html
+++ b/site/insights/agentic-resource-discovery-agent-governance/index.html
@@ -374,7 +374,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -518,7 +518,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what discovered tools are allowed to change</h3>
       <p>ARD helps agents find and verify capabilities. Mneme evaluates the change each capability produces against your architectural decisions and engineering rules, and returns an auditable verdict before the change is accepted. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -574,7 +574,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -597,7 +597,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agentic-workforce-visibility-crisis/index.html
+++ b/site/insights/agentic-workforce-visibility-crisis/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -476,7 +476,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>See what your agentic workforce is actually doing</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and checks every agent-generated change against them at generation time &mdash; producing an auditable record of what agents did and whether it aligned with intent. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -532,7 +532,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -555,7 +555,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/agents-of-chaos-and-the-governance-gap/index.html
+++ b/site/insights/agents-of-chaos-and-the-governance-gap/index.html
@@ -336,7 +336,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance before generation</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time, via Claude Code&rsquo;s PreToolUse hook. Constraints that hold structurally, not conversationally. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -593,7 +593,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -616,7 +616,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
+++ b/site/insights/ai-adoption-maturity-model-engineering-analysis/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -489,7 +489,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Turn maturity-model governance into enforced decisions</h3>
       <p>Mneme enforces your architectural decisions for coding agents &mdash; recorded decisions retrieved at generation time and verified before changes land. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -545,7 +545,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -568,7 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-agent-governance-two-markets/index.html
+++ b/site/insights/ai-agent-governance-two-markets/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -562,7 +562,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural governance for autonomous systems</h3>
       <p>Runtime controls protect the action. Mneme protects the architecture. It is the open-source layer that compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and in CI, so autonomous iteration cannot quietly drift away from engineering intent.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -618,7 +618,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -641,7 +641,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-agents-are-not-employees-governance/index.html
+++ b/site/insights/ai-agents-are-not-employees-governance/index.html
@@ -397,7 +397,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -606,7 +606,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Constrain the agent; keep the accountability. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -662,7 +662,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -685,7 +685,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-code-review-does-not-scale-linearly/index.html
+++ b/site/insights/ai-code-review-does-not-scale-linearly/index.html
@@ -343,7 +343,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -545,7 +545,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Move governance before generation</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file, not after the PR is opened. Open source, hook-level integration with Claude Code.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/compare/coderabbit/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs CodeRabbit — full comparison &rarr;</a>
     </div>
   </footer>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -625,7 +625,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-coding-agent-verification-tax/index.html
+++ b/site/insights/ai-coding-agent-verification-tax/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -482,7 +482,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop paying the verification tax by hand.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; before drift reaches the pull request. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -538,7 +538,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
+++ b/site/insights/ai-coding-agents-financial-services-audit-trail/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -463,7 +463,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Give every AI-made change an audit trail, not just a commit message.</h3>
       <p>Mneme turns your architectural decisions and ADRs into executable constraints that agents retrieve at generation time and CI verifies deterministically &mdash; with every verdict logged as evidence. For banking, insurance, and fintech teams, that is the difference between hoping you were in control and proving it. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -519,7 +519,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -542,7 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-coding-agents-life-sciences-governance/index.html
+++ b/site/insights/ai-coding-agents-life-sciences-governance/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -459,7 +459,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make every agent change auditable before you make it autonomous.</h3>
       <p>Mneme turns your architectural and regulatory decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; producing the traceable, defensible record a GxP audit expects. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -515,7 +515,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -538,7 +538,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-coding-governance-should-be-reviewable/index.html
+++ b/site/insights/ai-coding-governance-should-be-reviewable/index.html
@@ -359,7 +359,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -613,7 +613,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -636,7 +636,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-coding-productivity-gains-rework/index.html
+++ b/site/insights/ai-coding-productivity-gains-rework/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -474,7 +474,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Turn AI throughput back into progress.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; catching the violations that drive rework and churn before they merge. Open source, or <a href="/demo/">see it enforce a decision in the live demo</a>.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -530,7 +530,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -553,7 +553,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-governance-for-regulated-industries/index.html
+++ b/site/insights/ai-governance-for-regulated-industries/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -481,7 +481,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Prove every AI-generated change followed approved patterns.</h3>
       <p>Mneme turns your architectural decisions and ADRs into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; producing the decision provenance, validation history, and audit trail regulated environments require. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -560,7 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-infrastructure-governance-category/index.html
+++ b/site/insights/ai-infrastructure-governance-category/index.html
@@ -230,7 +230,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The next AI infrastructure layer is governance</h3>
       <p>Mneme is the open-source layer for architectural governance across AI-assisted development &mdash; ADR-derived constraints, deterministic verdicts, propagation across every agent and CI surface.</p>
       <a href="/concepts/ai-governance-infrastructure/" class="btn-primary" style="margin-right:0.5rem;">Read the concept &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -407,7 +407,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -430,7 +430,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
+++ b/site/insights/ai-is-becoming-the-operating-layer-for-software-execution/index.html
@@ -333,7 +333,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -596,7 +596,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Build the governance layer of your AI operating stack</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints, retrieves them before agents generate, and enforces them deterministically in CI &mdash; the governance, provenance, and verification layers of the AI operating stack. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -652,7 +652,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -675,7 +675,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-native-engineering-intent-debt/index.html
+++ b/site/insights/ai-native-engineering-intent-debt/index.html
@@ -372,7 +372,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -591,7 +591,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what the AI generates</h3>
       <p>Mneme is an open-source architectural governance layer for AI-assisted development. It turns architectural decisions into enforceable constraints before agents generate code — via Claude Code's PreToolUse hook and other generation-time surfaces.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -647,7 +647,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -670,7 +670,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-peer-review-context-loss-governance/index.html
+++ b/site/insights/ai-peer-review-context-loss-governance/index.html
@@ -378,7 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -544,7 +544,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Verify high-confidence AI outputs before they become operational decisions</h3>
       <p>Mneme treats architectural decisions as durable, source-tracked constraints &mdash; so AI-generated criticism and code can be checked against what the repo has already decided. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -600,7 +600,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -623,7 +623,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
+++ b/site/insights/ai-race-wont-be-won-on-infrastructure-alone/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -473,7 +473,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Win the layer that infrastructure spend can't buy.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so the intelligence you can access is intelligence you can actually deploy. Governance infrastructure, open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
+++ b/site/insights/ai-roi-problem-is-about-systems-not-models/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -501,7 +501,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make verification scale with generation</h3>
       <p>Mneme compiles architectural and operational decisions into deterministic constraints that fire across every surface where work happens. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ai-stack-determinism-probabilistic-models/index.html
+++ b/site/insights/ai-stack-determinism-probabilistic-models/index.html
@@ -328,7 +328,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -513,7 +513,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The deterministic layer your probabilistic stack already needs</h3>
       <p>Mneme compiles ADRs and architectural decisions into machine-evaluable constraints &mdash; the same verdict, every run, across every model and agent. The deterministic layer underneath the probabilistic one. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -569,7 +569,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -592,7 +592,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/all/index.html
+++ b/site/insights/all/index.html
@@ -491,7 +491,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -2066,7 +2066,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -2089,7 +2089,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
+++ b/site/insights/anthropic-claude-marketplace-ai-engineering-control-plane/index.html
@@ -327,7 +327,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -494,7 +494,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural governance for Claude-powered workflows</h3>
       <p>Mneme is the open-source governance layer for AI-assisted development &mdash; deterministic ADR-derived constraints, invariant preservation across agents and tools, verification contracts instead of probabilistic memory.</p>
       <a href="/works-with/claude-marketplace/" class="btn-primary" style="margin-right:0.5rem;">Works with Claude &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
     </div>
   </footer>
 </article>
@@ -550,7 +550,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -573,7 +573,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/anthropic-recursive-self-improvement-engineering-governance/index.html
+++ b/site/insights/anthropic-recursive-self-improvement-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -480,7 +480,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep architecture intact as AI writes more of your code</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -536,7 +536,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -559,7 +559,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/anthropic-research-system-coordination-infrastructure/index.html
+++ b/site/insights/anthropic-research-system-coordination-infrastructure/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -510,7 +510,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make agent coordination architecturally stable</h3>
       <p>Mneme provides the deterministic constraint layer that propagates architectural intent across orchestrators, subagents, and CI &mdash; so multi-agent systems can scale without fragmenting. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -566,7 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -589,7 +589,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/antigravity-solves-coordination-not-governance/index.html
+++ b/site/insights/antigravity-solves-coordination-not-governance/index.html
@@ -229,7 +229,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -321,7 +321,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural governance for agent-first IDEs</h3>
       <p>Mneme is the open-source layer for governance across agentic IDEs &mdash; Antigravity, Cursor, Claude Code, Copilot &mdash; the same compiled ADR-derived constraints across every surface.</p>
       <a href="/integrations/antigravity/" class="btn-primary" style="margin-right:0.5rem;">Works with Antigravity &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -400,7 +400,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
+++ b/site/insights/architectural-governance-across-heterogeneous-ai-coding-agents/index.html
@@ -418,7 +418,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -819,7 +819,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>One governance layer. Every agent.</h3>
       <p>Mneme HQ is the tool-agnostic decision store and enforcement hook for codebases that are governed by architecture, not by which assistant happened to write the line. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -875,7 +875,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -898,7 +898,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/artifacts-are-not-governance/index.html
+++ b/site/insights/artifacts-are-not-governance/index.html
@@ -210,7 +210,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -301,7 +301,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add deterministic governance to your agent artifact stream</h3>
       <p>Mneme compiles ADRs into machine-evaluable verdicts that travel alongside agent artifacts &mdash; so reviewers see both what happened and whether it was allowed.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -357,7 +357,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -380,7 +380,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
+++ b/site/insights/autonomous-code-remediation-requires-architectural-governance/index.html
@@ -333,7 +333,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -559,7 +559,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop architectural drift at the generation layer</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook — enforcing architectural constraints before code is written, not after it enters the review queue. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &#x2192;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &#x2192;</a>
     </div>
   </footer>
 </article>
@@ -615,7 +615,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -638,7 +638,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/bain-ai-development-lifecycle-governance/index.html
+++ b/site/insights/bain-ai-development-lifecycle-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -477,7 +477,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make risk a first-class constraint in your agent workflow</h3>
       <p>Mneme compiles your team&rsquo;s architectural decisions into enforceable, auditable constraints that reach every stage of the AI development lifecycle &mdash; before commit, in the PR, and in CI. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -237,7 +237,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -354,7 +354,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enforceable architectural boundaries for the AI coding era</h3>
       <p>Mneme is the open-source layer for architectural governance across AI-assisted development &mdash; deterministic constraints, repo-native enforcement, the same compiled rules across every agent and CI surface.</p>
       <a href="/concepts/ai-governance-infrastructure/" class="btn-primary" style="margin-right:0.5rem;">Read the concept &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -410,7 +410,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -433,7 +433,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/bcg-ai-era-operating-models-governance/index.html
+++ b/site/insights/bcg-ai-era-operating-models-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -492,7 +492,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Give autonomous teams enforced architectural boundaries</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -548,7 +548,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/beyond-security-by-design-governance-by-design/index.html
+++ b/site/insights/beyond-security-by-design-governance-by-design/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -478,7 +478,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Design governance in, don't bolt it on</h3>
       <p>Mneme compiles architectural decisions into constraints that are enforced before an agent acts &mdash; governance designed into the workflow, not reviewed after the fact. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/block-builderbot-coordination-governance/index.html
+++ b/site/insights/block-builderbot-coordination-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -461,7 +461,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Coordinate agents without losing your architecture</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -517,7 +517,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -540,7 +540,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/claude-code-skills-organizational-knowledge/index.html
+++ b/site/insights/claude-code-skills-organizational-knowledge/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -477,7 +477,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Your skills encode decisions. Govern the decisions.</h3>
       <p>Mneme records architectural decisions as structured, retrievable constraints and enforces them when agents make changes &mdash; so executable knowledge stays consistent with the decisions it depends on. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/cloud-agents-need-architectural-governance/index.html
+++ b/site/insights/cloud-agents-need-architectural-governance/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -463,7 +463,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Durable execution keeps agents running. Keep the architecture intact.</h3>
       <p>Mneme enforces architectural decisions across long-running, multi-repo agent execution &mdash; before changes land, regardless of which environment produced them. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -519,7 +519,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -542,7 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
+++ b/site/insights/constraint-decay-coding-agents-architectural-governance/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop letting constraint decay reach the PR queue</h3>
       <p>Mneme compiles ADRs and project constraints into deterministic checks that run before generation and in CI &mdash; the same rules, across every agent and tool. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -635,7 +635,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -658,7 +658,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/coordination-governance-multi-agent-systems/index.html
+++ b/site/insights/coordination-governance-multi-agent-systems/index.html
@@ -318,7 +318,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -501,7 +501,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Coordination governance for multi-agent workflows</h3>
       <p>Mneme is the open-source layer for governance propagation across autonomous coding systems &mdash; deterministic architectural memory, verification contracts, and provenance that hold across every subagent in the workflow.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
+++ b/site/insights/cursor-developer-habits-report-governance-infrastructure/index.html
@@ -385,7 +385,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -597,7 +597,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme compiles your architectural decisions and ADRs into machine-evaluable constraints and enforces them deterministically at hooks and in CI &mdash; before and around AI code generation, regardless of which model or agent did the work. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -653,7 +653,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -676,7 +676,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/databricks-omnigent-agent-infrastructure-governance/index.html
+++ b/site/insights/databricks-omnigent-agent-infrastructure-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -473,7 +473,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep architecture intact as work passes across agents</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/databricks-omnigent-agent-infrastructure-governance/index.html
+++ b/site/insights/databricks-omnigent-agent-infrastructure-governance/index.html
@@ -7,7 +7,7 @@
   <link rel="preload" href="/assets/fonts/InstrumentSerif-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/Inter-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/fonts.css">
-  <meta name="description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Cursor. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
+  <meta name="description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Pi. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0c0c0d" />
   <link rel="canonical" href="https://mnemehq.com/insights/databricks-omnigent-agent-infrastructure-governance/" />
@@ -15,12 +15,12 @@
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Mneme HQ" />
   <meta property="og:title" content="Databricks Omnigent Builds the Layer Above Coding Agents. Engineering Governance Is the One After." />
-  <meta property="og:description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Cursor. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
+  <meta property="og:description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Pi. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
   <meta property="og:url" content="https://mnemehq.com/insights/databricks-omnigent-agent-infrastructure-governance/" />
   <meta property="og:image" content="https://mnemehq.com/insights/databricks-omnigent-agent-infrastructure-governance/og.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Databricks Omnigent Builds the Layer Above Coding Agents. Engineering Governance Is the One After." />
-  <meta name="twitter:description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Cursor. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
+  <meta name="twitter:description" content="Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Pi. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer." />
   <meta name="twitter:image" content="https://mnemehq.com/insights/databricks-omnigent-agent-infrastructure-governance/og.png" />
   <meta name="author" content="Theo Valmis" />
   <meta property="article:published_time" content="2026-06-30T00:00:00Z" />
@@ -132,7 +132,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       {
         "@type": "TechArticle",
         "headline": "Databricks Omnigent Builds the Layer Above Coding Agents. Engineering Governance Is the One After.",
-        "description": "Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Cursor. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer.",
+        "description": "Databricks open-sourced Omnigent, a meta-harness that composes, controls, and shares agents across Claude Code, Codex, and Pi. It validates the agent infrastructure layer. It does not preserve architectural intent. That is the next layer.",
         "url": "https://mnemehq.com/insights/databricks-omnigent-agent-infrastructure-governance/",
         "datePublished": "2026-06-30",
         "author": {"@type": "Person", "name": "Theo Valmis", "url": "https://mnemehq.com/founder/"},
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <span class="eyebrow-meta">8 min read</span>
     </div>
     <h1>Databricks Omnigent Builds the Layer Above Coding Agents. Engineering Governance Is the One After.</h1>
-    <p class="article-lede">At its 2026 Data + AI Summit, Databricks open-sourced Omnigent, a meta-harness that sits above individual coding agents &mdash; Claude Code, Codex, Cursor, Pi &mdash; and lets teams compose, control, and collaborate on them through one interface. Databricks puts it directly: to combine agents, govern them, and work on them with other people, you need a layer above the harness, and Omnigent is that layer. It is real validation that agent infrastructure is becoming its own category. It also raises the question orchestration does not answer: as work passes across many agents, what keeps the architecture intact?</p>
+    <p class="article-lede">In June 2026, Databricks open-sourced Omnigent, a meta-harness that sits above individual coding agents &mdash; Claude Code, Codex, Pi, and custom agents &mdash; and lets teams compose, control, and collaborate on them through one interface. Databricks puts it directly: to combine agents, govern them, and work on them with other people, you need a layer above the harness, and Omnigent is that layer. It is real validation that agent infrastructure is becoming its own category. It also raises the question orchestration does not answer: as work passes across many agents, what keeps the architecture intact?</p>
     <p class="byline">By <a href="/founder/">Theo Valmis</a><span class="sep">&middot;</span><time datetime="2026-06-30">June 2026</time></p>
   </header>
 
@@ -379,7 +379,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
 
     <h2>What Databricks Announced</h2>
-    <p><a href="https://www.databricks.com/blog/introducing-omnigent-meta-harness-combine-control-and-share-your-agents" target="_blank" rel="noopener">Omnigent</a> is an open-source meta-harness, released under Apache 2.0 with a managed beta on the Databricks platform. It sits above individual agent harnesses &mdash; Claude Code, Codex, Cursor, Pi, and custom agents &mdash; and treats each as an interchangeable worker under one orchestrator, exposing a common interface to combine, control, and share them.</p>
+    <p><a href="https://www.databricks.com/blog/introducing-omnigent-meta-harness-combine-control-and-share-your-agents" target="_blank" rel="noopener">Omnigent</a> is an open-source meta-harness, released under Apache 2.0 and in alpha at launch. It sits above individual agent harnesses &mdash; Claude Code, Codex, Pi, and custom agents &mdash; and treats each as an interchangeable worker under one orchestrator, exposing a common interface to combine, control, and share them.</p>
     <p>Databricks frames the product around three capabilities. <strong>Composition</strong> lets teams combine models, harnesses, and techniques without rewriting, switching between agents with one-line changes. <strong>Control</strong> applies stateful, contextual policies that track agent actions and enforce guardrails such as cost budgets and permissions at the meta-harness layer rather than through prompts. <strong>Collaboration</strong> shares a live agent session by URL so teammates can review files, comment, and steer in real time. Underneath sits sandboxed execution with operating-system access controls. The thesis is stated plainly: to combine agents, govern them, and work on them with other people, you need a layer above the harness, and Omnigent is that layer.</p>
     <p>Omnigent&rsquo;s control plane is genuinely governance-flavored &mdash; budgets, permissions, action tracking. But it governs agent <em>execution</em>: which agent runs, what it may spend, what it may access. That is a different object from the architecture of the code those agents change.</p>
 
@@ -424,7 +424,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h2 id="faq-heading" style="margin-bottom:1.5rem;">Frequently asked questions</h2>
     <details style="border:1px solid var(--border);border-radius:8px;margin-bottom:0.75rem;overflow:hidden;">
       <summary style="padding:1rem 1.25rem;cursor:pointer;font-weight:500;color:var(--text);list-style:none;display:flex;justify-content:space-between;align-items:center;">What is Databricks Omnigent?<span style="color:var(--accent);font-size:1.2rem;flex-shrink:0;margin-left:1rem;">+</span></summary>
-      <div style="padding:0 1.25rem 1.25rem;color:var(--muted);font-size:0.88rem;line-height:1.8;">Omnigent is an open-source meta-harness from Databricks, announced at the 2026 Data + AI Summit. It sits above individual coding-agent harnesses such as Claude Code, Codex, Cursor, and Pi, treating each as an interchangeable worker, and provides composition, control, and collaboration through one interface plus sandboxed execution. It is released under Apache 2.0 with a managed beta on Databricks.</div>
+      <div style="padding:0 1.25rem 1.25rem;color:var(--muted);font-size:0.88rem;line-height:1.8;">Omnigent is an open-source meta-harness from Databricks, open-sourced in June 2026. It sits above individual coding-agent harnesses such as Claude Code, Codex, and Pi (plus custom agents), treating each as an interchangeable worker, and provides composition, control, and collaboration through one interface plus sandboxed execution. It is released under Apache 2.0 in alpha.</div>
     </details>
     <details style="border:1px solid var(--border);border-radius:8px;margin-bottom:0.75rem;overflow:hidden;">
       <summary style="padding:1rem 1.25rem;cursor:pointer;font-weight:500;color:var(--text);list-style:none;display:flex;justify-content:space-between;align-items:center;">What is a meta-harness?<span style="color:var(--accent);font-size:1.2rem;flex-shrink:0;margin-left:1rem;">+</span></summary>

--- a/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
+++ b/site/insights/datadog-state-of-ai-engineering-governance-crisis/index.html
@@ -396,7 +396,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -675,7 +675,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -731,7 +731,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -754,7 +754,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/deployment-quality-will-define-the-ai-era/index.html
+++ b/site/insights/deployment-quality-will-define-the-ai-era/index.html
@@ -360,7 +360,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -546,7 +546,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Build governance infrastructure for AI-assisted engineering</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file. Open source, hook-level integration with Claude Code.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -625,7 +625,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/devin-ai-software-engineer-governance/index.html
+++ b/site/insights/devin-ai-software-engineer-governance/index.html
@@ -322,7 +322,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -475,7 +475,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <p>Mneme is the open-source layer for architectural governance across AI-assisted development &mdash; Devin, Claude Code, Cursor, Copilot, and CI, all enforcing the same compiled architectural decisions.</p>
       <a href="/works-with/devin/" class="btn-primary" style="margin-right:0.5rem;">Works with Devin &rarr;</a>
       <a href="/compare/devin-vs-architectural-governance/" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);margin-right:0.5rem;">Compare</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">GitHub</a>
     </div>
   </footer>
 </article>
@@ -531,7 +531,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -554,7 +554,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
+++ b/site/insights/dora-metrics-insufficient-for-agentic-development/index.html
@@ -381,7 +381,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -580,7 +580,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Measure whether your system stayed who you decided it would be</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -636,7 +636,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -659,7 +659,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/emerging-ai-agent-infrastructure-stack/index.html
+++ b/site/insights/emerging-ai-agent-infrastructure-stack/index.html
@@ -376,7 +376,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -654,7 +654,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
       <details class="faq-item">
         <summary>Where does Mneme fit in this stack?</summary>
-        <div class="faq-body">Mneme is the governance and verification layer for AI-assisted software development. It compiles a repository's architectural decisions into a deterministic decision graph and enforces it at the boundaries where agents make consequential changes: session start, pre-tool-use, pre-commit, pre-PR, and CI. Mneme runs beside harnesses, memory systems, and observability tools, not instead of them. See the <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
+        <div class="faq-body">Mneme is the governance and verification layer for AI-assisted software development. It compiles a repository's architectural decisions into a deterministic decision graph and enforces it at the boundaries where agents make consequential changes: session start, pre-tool-use, pre-commit, pre-PR, and CI. Mneme runs beside harnesses, memory systems, and observability tools, not instead of them. See the <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
       </details>
     </div>
 
@@ -701,7 +701,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The governance and verification layer for AI-assisted software development.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent stack. Harnesses keep agents acting. Memory keeps them oriented. Observability records what they did. Mneme keeps them inside their architectural boundaries. Open source, MIT licensed.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -757,7 +757,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -780,7 +780,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
+++ b/site/insights/enforce-engineering-standards-across-ai-assisted-teams/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -500,7 +500,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enforce your engineering standards on every AI-generated change</h3>
       <p>Mneme stores your architectural decisions, patterns, and team conventions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/future-of-software-engineering-after-vibe-coding/index.html
+++ b/site/insights/future-of-software-engineering-after-vibe-coding/index.html
@@ -356,7 +356,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -478,7 +478,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep your architectural decisions alive after the loop thins out</h3>
       <p>Mneme is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which agent or engineer produced it. It is the governing layer for a world where coding is automated and accountability is not.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/gartner-ai-governance-engineering-governance/index.html
+++ b/site/insights/gartner-ai-governance-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -481,7 +481,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern the architecture your AI coding agents are changing</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -560,7 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/generative-ai-software-engineering-stack/index.html
+++ b/site/insights/generative-ai-software-engineering-stack/index.html
@@ -413,7 +413,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -727,7 +727,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ is layer 5</h3>
       <p>Open-source decision corpus and pre-generation enforcement for AI-assisted engineering. Tool-agnostic, MIT-licensed, designed to sit above whichever combination of layers 1&ndash;4 your team picks.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -783,7 +783,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -806,7 +806,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
+++ b/site/insights/github-agent-pull-requests-review-wrong-layer/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -477,7 +477,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enforce architectural invariants before the PR exists.</h3>
       <p>Mneme loads your architectural decisions into the agent&rsquo;s context and verifies every change against them deterministically &mdash; so duplicated utilities and weakened CI thresholds never reach your reviewers. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/github-ai-agent-validation-trust-layer/index.html
+++ b/site/insights/github-ai-agent-validation-trust-layer/index.html
@@ -378,7 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -525,7 +525,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Validate the diff, not just the run</h3>
       <p>GitHub grades whether your agent behaved. Mneme decides whether what it changed still conforms to your architecture. It is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which agent produced it.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -581,7 +581,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -604,7 +604,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/github-copilot-space-framework/index.html
+++ b/site/insights/github-copilot-space-framework/index.html
@@ -343,7 +343,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -584,7 +584,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/github-copilot-usage-based-billing-review-economics/index.html
+++ b/site/insights/github-copilot-usage-based-billing-review-economics/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -450,7 +450,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Stop paying to review code that should never have been generated.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that coding agents retrieve at generation time and CI verifies deterministically &mdash; rejecting non-compliant changes before they reach a metered review. Open source, or <a href="/demo/">see it enforce a decision in the live demo</a>.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -506,7 +506,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/goal-driven-agents-architectural-governance/index.html
+++ b/site/insights/goal-driven-agents-architectural-governance/index.html
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -695,7 +695,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern your goal-driven agent loops</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and retrieves them before agents generate &mdash; so the loop optimizes inside your architecture, not around it. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -751,7 +751,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -774,7 +774,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
+++ b/site/insights/google-cloud-agent-registry-agent-fleet-governance/index.html
@@ -378,7 +378,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -527,7 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural governance for your agent fleet</h3>
       <p>A registry controls which agents run. Mneme controls whether their output stays aligned with your architecture. It is the open-source layer that compiles your architectural decisions and project rules into deterministic, machine-evaluable constraints and enforces them at hooks and in CI &mdash; the same verdict on every change, no matter which registered agent produced it.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -583,7 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -606,7 +606,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/google-gemini-deep-research-agent-governance/index.html
+++ b/site/insights/google-gemini-deep-research-agent-governance/index.html
@@ -392,7 +392,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -613,7 +613,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern the agent, not just the artifact</h3>
       <p>A managed runtime decides how an agent runs. Mneme governs what it is allowed to do: it compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -669,7 +669,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -692,7 +692,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/governance-control-plane-after-agent-frameworks/index.html
+++ b/site/insights/governance-control-plane-after-agent-frameworks/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -492,7 +492,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Give your agent fleet a governance control plane, not just runtime guardrails.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so the question is no longer just whether an agent <em>can</em> act, but whether the change it ships is allowed to. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -548,7 +548,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/governance-layers-for-ai-coding-assistants/index.html
+++ b/site/insights/governance-layers-for-ai-coding-assistants/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -476,7 +476,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Put a governance layer under your AI coding agents.</h3>
       <p>Mneme turns your architecture standards and ADRs into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; with an audit trail showing which rule applied to which change. Policy, memory, enforcement, and auditability, in one open-source layer.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -532,7 +532,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -555,7 +555,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
+++ b/site/insights/governance-perimeter-is-moving-to-the-endpoint/index.html
@@ -298,7 +298,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance that survives the endpoint</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints that travel with the repository &mdash; across local agents, IDEs, CI, and runtime surfaces. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -589,7 +589,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -612,7 +612,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/harness-engineering-still-needs-governance/index.html
+++ b/site/insights/harness-engineering-still-needs-governance/index.html
@@ -402,7 +402,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -720,7 +720,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
 
       <details class="faq-item">
         <summary>Where does Mneme fit relative to a harness?</summary>
-        <div class="faq-body">Mneme runs beside the harness, not instead of it. The harness coordinates execution; Mneme enforces architectural decisions. At session start, <code>mneme check --mode warn</code> loads active ADRs and surfaces existing violations. Before commit or PR, <code>mneme check --mode strict</code> blocks output that violates the active decision graph. In CI, the same check is the team-level backstop. Mneme does not replace tool use, retries, or memory; it enforces the constraints those layers cannot enforce. See the <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
+        <div class="faq-body">Mneme runs beside the harness, not instead of it. The harness coordinates execution; Mneme enforces architectural decisions. At session start, <code>mneme check --mode warn</code> loads active ADRs and surfaces existing violations. Before commit or PR, <code>mneme check --mode strict</code> blocks output that violates the active decision graph. In CI, the same check is the team-level backstop. Mneme does not replace tool use, retries, or memory; it enforces the constraints those layers cannot enforce. See the <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
       </details>
 
       <details class="faq-item">
@@ -766,7 +766,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
       <h3>The governance layer your agent harness is missing.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent workflow. Harnesses keep agents acting. Mneme keeps them inside their architectural boundaries. Open source, MIT licensed.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -822,7 +822,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -845,7 +845,7 @@ Verification     &mdash; tests, builds, deploy-time checks</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/harness-engineering-verification-layer/index.html
+++ b/site/insights/harness-engineering-verification-layer/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -527,7 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make execution verifiable, not just successful</h3>
       <p>Mneme compiles your architecture decision records into machine-evaluable constraints and enforces them deterministically at agent hooks and in CI. Same input, same verdict, every run &mdash; with each result traceable to the decision behind it. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -583,7 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -606,7 +606,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/html-is-not-the-point-structure-is/index.html
+++ b/site/insights/html-is-not-the-point-structure-is/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance for the machine-operable era</h3>
       <p>Mneme treats architectural decisions as machine-evaluable constraints that follow the artifact across generation, review, and runtime. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -593,7 +593,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -616,7 +616,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
+++ b/site/insights/ibm-2026-tech-leader-study-agent-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -480,7 +480,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Turn governance documents into executable controls</h3>
       <p>Mneme converts the architectural decisions buried in wikis and rule files into structured, retrievable constraints that coding agents are verified against before changes land. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -536,7 +536,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -559,7 +559,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -380,7 +380,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -702,7 +702,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -725,7 +725,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/latent-space-agent-communication-governance/index.html
+++ b/site/insights/latent-space-agent-communication-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -463,7 +463,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what agents do, not just what they say</h3>
       <p>Mneme enforces architectural decisions against the changes agents make &mdash; a verification surface that does not depend on agents narrating their reasoning in readable text. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -519,7 +519,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -542,7 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/llm-wiki-library-not-law/index.html
+++ b/site/insights/llm-wiki-library-not-law/index.html
@@ -311,7 +311,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -493,7 +493,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Promote your binding decisions out of the wiki</h3>
       <p>Mneme takes the subset of your architectural intent that has to bind agent behavior and makes it explicit, retrievable, enforceable, and auditable &mdash; on top of the docs and ADRs you already have. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -549,7 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -572,7 +572,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/long-context-windows-governance-infrastructure/index.html
+++ b/site/insights/long-context-windows-governance-infrastructure/index.html
@@ -373,7 +373,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -520,7 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Bigger context, smaller blind spots</h3>
       <p>Mneme makes architectural decisions deterministically retrievable and machine-enforceable &mdash; so what the agent attended to is no longer the only thing constraining the change. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -576,7 +576,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -599,7 +599,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/long-running-agents-need-governance/index.html
+++ b/site/insights/long-running-agents-need-governance/index.html
@@ -382,7 +382,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -810,7 +810,7 @@ mneme check --mode warn</code></pre>
 
       <details class="faq-item">
         <summary>Where exactly does Mneme fit in this workflow?</summary>
-        <div class="faq-body">Mneme is the governance layer that runs alongside the harness. At session start, <code>mneme check --mode warn</code> tells the incoming agent which architectural constraints apply and whether any are already violated. Before commit or PR, <code>mneme check --mode strict</code> enforces them. Mneme does not replace the progress log, git, or tests. It enforces the constraints those artifacts cannot enforce. See the <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
+        <div class="faq-body">Mneme is the governance layer that runs alongside the harness. At session start, <code>mneme check --mode warn</code> tells the incoming agent which architectural constraints apply and whether any are already violated. Before commit or PR, <code>mneme check --mode strict</code> enforces them. Mneme does not replace the progress log, git, or tests. It enforces the constraints those artifacts cannot enforce. See the <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">open-source repository</a> for setup details.</div>
       </details>
 
       <details class="faq-item">
@@ -845,7 +845,7 @@ mneme check --mode warn</code></pre>
       <h3>The governance layer your agent harness is missing.</h3>
       <p>Mneme HQ is the deterministic precedence engine and enforcement hook that runs beside your agent workflow. Progress logs tell the agent what happened. Mneme tells it what must remain true. Open source, MIT licensed.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -901,7 +901,7 @@ mneme check --mode warn</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -924,7 +924,7 @@ mneme check --mode warn</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/loop-engineering-is-not-new/index.html
+++ b/site/insights/loop-engineering-is-not-new/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -464,7 +464,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Build the loop. Then govern what it commits.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that an autonomous loop retrieves at generation time and CI verifies deterministically &mdash; so the probabilistic generator inside the loop cannot quietly drift the system. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -520,7 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -543,7 +543,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/machine-readable-pull-requests-agentic-development/index.html
+++ b/site/insights/machine-readable-pull-requests-agentic-development/index.html
@@ -379,7 +379,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -595,7 +595,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make architectural intent visible to the systems reviewing your code</h3>
       <p>Mneme compiles ADRs and constraints into machine-evaluable verdicts &mdash; the contract behind every change, attachable to every PR. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -651,7 +651,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -674,7 +674,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/mckinsey-agentic-software-delivery-governance/index.html
+++ b/site/insights/mckinsey-agentic-software-delivery-governance/index.html
@@ -365,7 +365,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -483,7 +483,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The enforcement layer the rewiring needs</h3>
       <p>Rewire the operating model &mdash; then give your architects&rsquo; decisions a way to reach the agent. Mneme is the open-source layer that compiles your architectural decisions into deterministic, machine-evaluable constraints and enforces them at hooks and in CI, returning the same verdict on every change at the agent&rsquo;s latency, not the org chart&rsquo;s.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -539,7 +539,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -562,7 +562,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
+++ b/site/insights/mckinsey-ai-table-stakes-to-advantage/index.html
@@ -397,7 +397,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -618,7 +618,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. The moat the model can&rsquo;t rent you. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -674,7 +674,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -697,7 +697,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/memory-is-not-governance/index.html
+++ b/site/insights/memory-is-not-governance/index.html
@@ -427,7 +427,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -856,7 +856,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Memory feeds it. Governance picks the rule.</h3>
       <p>Mneme HQ is the layer above the memory store: a deterministic precedence engine and enforcement hook for codebases governed by architecture, not by whichever rule ranked highest in this morning's embedding. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -912,7 +912,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -935,7 +935,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
+++ b/site/insights/microsoft-agent-forge-enterprise-ai-infrastructure/index.html
@@ -371,7 +371,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -520,7 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Architectural governance for autonomous workflows</h3>
       <p>Mneme operates above the agent runtime as a deterministic governance and verification layer &mdash; the same constraints across Agent Forge, Claude Code, Copilot, and CI. Open source.</p>
       <a href="/integrations/microsoft-agent-forge/" class="btn-primary" style="margin-right:0.5rem;">Microsoft Agent Forge &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
     </div>
   </footer>
 </article>
@@ -576,7 +576,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -599,7 +599,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/microsoft-agent-platform-governance-layer/index.html
+++ b/site/insights/microsoft-agent-platform-governance-layer/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -471,7 +471,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Your platform governs its agents. Who governs your architecture?</h3>
       <p>Mneme records your architectural decisions once and enforces them across every agent platform your team uses &mdash; GitHub, Cursor, Claude Code, and whatever ships next. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -527,7 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -550,7 +550,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
+++ b/site/insights/microsoft-agentic-transformation-playbook-ai-agent-governance/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -528,7 +528,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Give your coding agents an enforceable operating model</h3>
       <p>Mneme compiles architectural decisions into machine-evaluable constraints and enforces them at the hook and CI layer &mdash; the same rules, across every agent and tool. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -584,7 +584,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -607,7 +607,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
+++ b/site/insights/microsoft-execution-containers-ai-agent-runtime-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -471,7 +471,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Runtime isolation is one layer. Add the architectural one.</h3>
       <p>Mneme enforces the architectural decisions that runtime containment cannot see &mdash; which patterns, invariants, and policies must hold as agents work across environments. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -527,7 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -550,7 +550,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/microsoft-project-solara-post-app-governance/index.html
+++ b/site/insights/microsoft-project-solara-post-app-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -479,7 +479,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The agent moves. Your governance should move with it.</h3>
       <p>Mneme encodes architectural decisions as repo-native, deterministic policy and enforces them across the execution surfaces where agents act &mdash; IDE, CI, cloud, and whatever ships next. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -535,7 +535,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -558,7 +558,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
+++ b/site/insights/mistral-vibe-ai-coding-enterprise-infrastructure/index.html
@@ -315,7 +315,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -446,7 +446,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>One governance layer across every coding agent</h3>
       <p>Mneme compiles architectural decisions into deterministic verdicts that reach terminal agents, IDE extensions, async workflows, and CI &mdash; the same rules across Mistral Vibe, Claude Code, Copilot, Cursor, and the agents you have not adopted yet. Open source.</p>
       <a href="/works-with/" class="btn-primary" style="margin-right:0.5rem;">Works with &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
     </div>
   </footer>
 </article>
@@ -502,7 +502,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -525,7 +525,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/mneme-vs-cursor-rules/index.html
+++ b/site/insights/mneme-vs-cursor-rules/index.html
@@ -381,7 +381,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -568,7 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
       <a href="/compare/cursor-rules/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs Cursor Rules — full comparison →</a>
       <a href="/integrations/cursor/" style="display:block;margin-top:0.5rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme + Cursor — integration guide →</a>
     </div>
@@ -626,7 +626,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -649,7 +649,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/models-are-temporary-architectural-intent-is-not/index.html
+++ b/site/insights/models-are-temporary-architectural-intent-is-not/index.html
@@ -293,7 +293,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -486,7 +486,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Keep your governance outside the model</h3>
       <p>Mneme is the model-independent governance layer for AI-assisted development: a repo-native control surface that returns the same verdict at every enforcement point, regardless of which model or harness produced the change. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -542,7 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -565,7 +565,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/morph-reflexes-agent-observability-engineering-governance/index.html
+++ b/site/insights/morph-reflexes-agent-observability-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -473,7 +473,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what your agents build, not just how they behave</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/nvidia-nemo-agent-toolkit-engineering-governance/index.html
+++ b/site/insights/nvidia-nemo-agent-toolkit-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -477,7 +477,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add the governance layer your agent workflows are missing</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/open-knowledge-format-vs-governance/index.html
+++ b/site/insights/open-knowledge-format-vs-governance/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -490,7 +490,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>OKF makes your decisions findable. Mneme makes them binding.</h3>
       <p>Mneme turns your architectural decisions and ADRs into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so a decision an agent reads is also a decision it cannot ship past. Pairs naturally with any knowledge format, including OKF. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -546,7 +546,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -569,7 +569,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
+++ b/site/insights/openai-compatible-apis-are-commoditizing-models/index.html
@@ -369,7 +369,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -567,7 +567,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The layer that survives the model swap</h3>
       <p>Mneme HQ is the open-source decision corpus and pre-generation enforcement layer. Tool-agnostic, model-agnostic, framework-independent &mdash; built for codebases that change models without changing architecture.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -623,7 +623,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -646,7 +646,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
+++ b/site/insights/openclaw-and-the-limits-of-autonomous-coding/index.html
@@ -334,7 +334,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -532,7 +532,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance before generation</h3>
       <p>Mneme HQ enforces architectural constraints at generation time via Claude Code&rsquo;s PreToolUse hook. Execution boundaries, verification contracts, and auditability — built into the workflow, not retrofitted after the fact. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -588,7 +588,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -611,7 +611,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/palantir-agentic-governance-engineering-governance/index.html
+++ b/site/insights/palantir-agentic-governance-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -473,7 +473,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what coding agents build, not just what they can access</h3>
       <p>Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/pr-review-is-becoming-incident-response/index.html
+++ b/site/insights/pr-review-is-becoming-incident-response/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -541,7 +541,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Move governance upstream of the PR queue</h3>
       <p>Mneme compiles architecture decisions into deterministic constraints that fire before generation and continue firing across commit, PR, and CI. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -597,7 +597,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -620,7 +620,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/productivity-paradox-perception-vs-measurement/index.html
+++ b/site/insights/productivity-paradox-perception-vs-measurement/index.html
@@ -343,7 +343,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -522,7 +522,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Move governance before generation</h3>
       <p>Mneme HQ enforces architectural decisions at generation time — before the AI agent writes the file, not after the PR is opened. Open source, hook-level integration with Claude Code.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/compare/coderabbit/" style="display:block;margin-top:0.75rem;font-size:0.82rem;color:var(--muted);text-decoration:none;">Mneme HQ vs CodeRabbit — full comparison &rarr;</a>
     </div>
   </footer>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/prompt-engineering-is-not-governance/index.html
+++ b/site/insights/prompt-engineering-is-not-governance/index.html
@@ -424,7 +424,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -623,7 +623,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop relying on prompts to enforce architecture</h3>
       <p>Mneme HQ enforces architectural decisions with structured constraints, a precedence engine, and hook-level blocking — not system prompt suggestions. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -679,7 +679,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -702,7 +702,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/prompt-engineering-vs-harness-engineering/index.html
+++ b/site/insights/prompt-engineering-vs-harness-engineering/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -564,7 +564,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make the architecture a constraint, not a suggestion</h3>
       <p>A reliable harness runs the agent. It does not hold the agent to your architecture. Mneme compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and in CI &mdash; before drift is ever written. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -620,7 +620,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -643,7 +643,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/rag-is-not-memory/index.html
+++ b/site/insights/rag-is-not-memory/index.html
@@ -387,7 +387,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -661,7 +661,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -684,7 +684,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/recursive-self-improvement-orchestration-problem/index.html
+++ b/site/insights/recursive-self-improvement-orchestration-problem/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -491,7 +491,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Let your agents improve themselves &mdash; without improving away from your intent.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so a self-optimizing system keeps optimizing toward the objectives you actually set. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -547,7 +547,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -570,7 +570,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/review-is-not-governance/index.html
+++ b/site/insights/review-is-not-governance/index.html
@@ -351,7 +351,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -482,7 +482,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what the AI generates</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time, via Claude Code's PreToolUse hook. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -538,7 +538,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/rise-of-agentic-engineering-education/index.html
+++ b/site/insights/rise-of-agentic-engineering-education/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -656,7 +656,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>The governance layer the curriculum is missing</h3>
       <p>Mneme HQ is the open-source decision corpus and pre-generation enforcement layer that operates above whichever AI coding tool a team picks. Tool-agnostic, MIT-licensed, framework-independent.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -712,7 +712,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -735,7 +735,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/rule-files-vs-retrieval-memory/index.html
+++ b/site/insights/rule-files-vs-retrieval-memory/index.html
@@ -348,7 +348,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -487,7 +487,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop pasting your architecture into every prompt</h3>
       <p>Mneme retrieves the architectural decisions relevant to the current change and enforces them at the hook level &mdash; not as a static preamble the model can dilute. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -543,7 +543,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -566,7 +566,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/runtime-harnesses-for-ai-agents/index.html
+++ b/site/insights/runtime-harnesses-for-ai-agents/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -468,7 +468,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make architectural intent part of the harness</h3>
       <p>Mneme adds the governance layer to the agent harness &mdash; enforceable architectural invariants checked before tool execution, before commit, before PR, and in CI. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -524,7 +524,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -547,7 +547,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/runtime-verification-is-not-architectural-verification/index.html
+++ b/site/insights/runtime-verification-is-not-architectural-verification/index.html
@@ -297,7 +297,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -505,7 +505,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add architectural verification to your stack</h3>
       <p>Mneme compiles architecture decision records into deterministic constraints that fire across agent harnesses, commits, PRs, and CI. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -584,7 +584,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/search-as-code-agent-execution-surface/index.html
+++ b/site/insights/search-as-code-agent-execution-surface/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -464,7 +464,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern what the agent runs, not just what it calls</h3>
       <p>Mneme enforces architectural and policy decisions against the code agents execute &mdash; not just the tools they were given. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -520,7 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -543,7 +543,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/shared-memory-is-not-shared-intent/index.html
+++ b/site/insights/shared-memory-is-not-shared-intent/index.html
@@ -350,7 +350,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -489,7 +489,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Give your AI coding team shared intent, not just shared memory.</h3>
       <p>Mneme turns your architectural decisions into executable constraints that every agent retrieves at generation time and CI verifies deterministically &mdash; so a decision the team agreed to is enforced across all of them, not just remembered. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -545,7 +545,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -568,7 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
+++ b/site/insights/snowflake-ai-data-engineering-governance-infrastructure/index.html
@@ -340,7 +340,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -516,7 +516,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for autonomous AI systems</h3>
       <p>Mneme is the open-source layer for layer 5: deterministic architectural memory, verification contracts, and provenance that hold across every agent and execution surface in the enterprise AI stack.</p>
       <a href="/demo/" class="btn-primary" style="margin-right:0.5rem;">See the demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary" style="background:transparent;border:1px solid var(--accent);color:var(--accent);">View on GitHub</a>
     </div>
   </footer>
 </article>
@@ -572,7 +572,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -595,7 +595,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/spec-driven-development-still-needs-governance/index.html
+++ b/site/insights/spec-driven-development-still-needs-governance/index.html
@@ -398,7 +398,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -549,7 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Add governance to your spec-driven workflow</h3>
       <p>Mneme is the open-source architectural governance layer &mdash; deterministic, ADR-derived constraints injected before generation and verified after. It plugs into spec-driven development without replacing it.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -605,7 +605,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -628,7 +628,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/stanford-ai-index-2026-engineering-governance/index.html
+++ b/site/insights/stanford-ai-index-2026-engineering-governance/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -477,7 +477,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Make your architectural decisions enforceable</h3>
       <p>If code generation is becoming solved, engineering governance is the layer left to build. Mneme stores your architectural decisions as structured, machine-readable constraints and verifies every agent-generated change against them at generation time. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -533,7 +533,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/topics/agent-infrastructure/index.html
+++ b/site/insights/topics/agent-infrastructure/index.html
@@ -398,7 +398,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -796,7 +796,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -819,7 +819,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/topics/ai-coding-agents/index.html
+++ b/site/insights/topics/ai-coding-agents/index.html
@@ -388,7 +388,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -695,7 +695,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -718,7 +718,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/topics/architectural-governance/index.html
+++ b/site/insights/topics/architectural-governance/index.html
@@ -388,7 +388,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -718,7 +718,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -741,7 +741,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/topics/engineering-performance/index.html
+++ b/site/insights/topics/engineering-performance/index.html
@@ -384,7 +384,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -651,7 +651,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -674,7 +674,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/what-is-harness-engineering/index.html
+++ b/site/insights/what-is-harness-engineering/index.html
@@ -377,7 +377,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -597,7 +597,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Build the harness. Then build the layer above it.</h3>
       <p>Mneme compiles your architectural decisions into machine-evaluable constraints and enforces them deterministically at hooks and CI, before and around AI generation &mdash; the governance layer that sits above the harness. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -653,7 +653,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -676,7 +676,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/what-is-the-ai-sdlc/index.html
+++ b/site/insights/what-is-the-ai-sdlc/index.html
@@ -298,7 +298,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -524,7 +524,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -547,7 +547,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/when-agents-launch-the-database/index.html
+++ b/site/insights/when-agents-launch-the-database/index.html
@@ -352,7 +352,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -470,7 +470,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Govern the action, not just the commit</h3>
       <p>Mneme enforces architectural decisions at the surfaces where agents act &mdash; before a change reaches the repo, and across the tools agents use beyond it. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -526,7 +526,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -549,7 +549,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
+++ b/site/insights/why-architectural-governance-needs-precedence-semantics/index.html
@@ -389,7 +389,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -795,7 +795,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>One precedence engine. Every agent.</h3>
       <p>Mneme HQ is the structured decision store and precedence engine for codebases governed by architecture, not by whichever assistant happened to read the file first. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -851,7 +851,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -874,7 +874,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-claude-md-stops-scaling/index.html
+++ b/site/insights/why-claude-md-stops-scaling/index.html
@@ -440,7 +440,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -694,7 +694,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <p>The teams that have hit it recognize the symptoms: a CLAUDE.md that has grown into a maintenance burden, rules that conflict without resolution, enforcement that depends on reviewer attention, architectural violations that accumulate slowly and then become structural. Autonomous agents that followed architectural constraints in session 1 and drifted by session 50.</p>
 
-    <p>The solution is not a more organized CLAUDE.md. It is governance infrastructure: structured decision records with scope and precedence, deterministic retrieval based on what is being generated, and hook-level enforcement that operates before output reaches the codebase. That infrastructure is what <a href="https://github.com/TheoV823/mneme" style="color:var(--accent);text-decoration:none;">Mneme</a> is designed to provide &mdash; an architectural compiler layer that sits above the context window, not inside it.</p>
+    <p>The solution is not a more organized CLAUDE.md. It is governance infrastructure: structured decision records with scope and precedence, deterministic retrieval based on what is being generated, and hook-level enforcement that operates before output reaches the codebase. That infrastructure is what <a href="https://github.com/MnemeHQ/mneme" style="color:var(--accent);text-decoration:none;">Mneme</a> is designed to provide &mdash; an architectural compiler layer that sits above the context window, not inside it.</p>
 
     <div class="callout">
       <p><strong>CLAUDE.md keeps your context aligned. Mneme keeps your architecture enforced.</strong> The two layers are complements, not competitors. What changes is the expectation of which one is responsible for enforcement &mdash; and the infrastructure needed to deliver on that responsibility.</p>
@@ -747,7 +747,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Governance infrastructure for AI-native codebases</h3>
       <p>Mneme HQ adds a deterministic enforcement layer above your context window &mdash; typed architectural decisions, a precedence engine, and hook-level blocking before violations reach the codebase. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -803,7 +803,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -826,7 +826,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
+++ b/site/insights/why-code-review-cannot-scale-with-ai-output/index.html
@@ -423,7 +423,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -674,7 +674,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Enforce architectural decisions before code is written</h3>
       <p>Mneme HQ integrates with Claude Code's PreToolUse hook — blocking architectural violations at generation time, not in review. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -730,7 +730,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -753,7 +753,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
+++ b/site/insights/why-context-alone-doesnt-prevent-architectural-drift/index.html
@@ -369,7 +369,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -608,7 +608,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Stop relying on context to enforce architecture</h3>
       <p>Mneme encodes architectural decisions as machine-evaluable constraints and enforces them at the hook level &mdash; not in the prompt window. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -664,7 +664,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -687,7 +687,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-observability-is-not-governance/index.html
+++ b/site/insights/why-observability-is-not-governance/index.html
@@ -365,7 +365,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -607,7 +607,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Put governance upstream of your dashboards</h3>
       <p>Mneme HQ enforces your architectural decisions at generation time — pre-tool-use hook in the agent, gate in CI. The drift you can finally stop measuring is the drift you stopped shipping.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -663,7 +663,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -686,7 +686,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-prompt-memory-fails-at-scale/index.html
+++ b/site/insights/why-prompt-memory-fails-at-scale/index.html
@@ -340,7 +340,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -515,7 +515,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Structured governance memory for AI coding</h3>
       <p>Mneme HQ replaces context injection with a precedence-aware decision engine that enforces architectural constraints before generation. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -571,7 +571,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -594,7 +594,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/why-rag-fails-for-architectural-governance/index.html
+++ b/site/insights/why-rag-fails-for-architectural-governance/index.html
@@ -411,7 +411,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -685,7 +685,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Mneme HQ enforces architectural decisions at the source</h3>
       <p>Structured decision schema, deterministic precedence engine, and hook-level enforcement for Claude Code. Open source.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub →</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub →</a>
     </div>
   </footer>
 </article>
@@ -741,7 +741,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -764,7 +764,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
+++ b/site/insights/zero-trust-for-ai-agents-architectural-governance/index.html
@@ -363,7 +363,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -481,7 +481,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <h3>Verify the diff, not just the agent</h3>
       <p>Secure what your agents are allowed to do &mdash; then verify that what they build preserves your architecture. Mneme is the open-source layer that compiles your architectural decisions into deterministic, machine-evaluable constraints and enforces them at hooks and in CI, returning the same verdict on every change no matter which agent produced it. It is the part of zero trust that inspects the code.</p>
       <a href="/demo/" style="display:inline-block;margin-right:1.25rem;color:#c8f060;font-family:'DM Mono',monospace;font-size:0.85rem;text-decoration:none;">See the live demo &rarr;</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -537,7 +537,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -560,7 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/adr-import/index.html
+++ b/site/integrations/adr-import/index.html
@@ -355,7 +355,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -528,7 +528,7 @@ Result: WARN</code></pre>
     <div class="cta-block">
       <h3>Turn your existing ADRs into enforceable guardrails</h3>
       <p>Open source, self-hosted. The runnable demo requires no API key.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/integrations/claude-code/" class="cta-secondary">Read: governing Claude Code workflows &rarr;</a>
     </div>
   </footer>
@@ -585,7 +585,7 @@ Result: WARN</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -608,7 +608,7 @@ Result: WARN</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/antigravity/index.html
+++ b/site/integrations/antigravity/index.html
@@ -224,7 +224,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -243,7 +243,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h1>Architectural Governance for Google Antigravity</h1>
   <p class="hero-sub">Google Antigravity lets coding agents plan, execute, and verify work across editor, terminal, and browser. Mneme adds deterministic architectural governance so autonomous agent workflows stay aligned with ADRs, constraints, and repository invariants.</p>
   <div class="hero-ctas">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/compare/google-antigravity-vs-mneme/" class="btn-secondary">Side-by-side comparison</a>
   </div>
 </section>
@@ -320,7 +320,7 @@ CI records the governance result</pre>
   <h2>Use Mneme to add architectural governance to agent-first development workflows</h2>
   <p>Open-source. Repo-native. Works alongside Google Antigravity and every other agent-first IDE &mdash; the same compiled architectural decisions enforced at hook, commit, PR, and CI.</p>
   <div class="cta-band-buttons">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/concepts/agentic-ide-governance/" class="btn-secondary">Read the concept</a>
     <a href="/insights/antigravity-solves-coordination-not-governance/" class="btn-secondary">Read the analysis</a>
   </div>
@@ -378,7 +378,7 @@ CI records the governance result</pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -401,7 +401,7 @@ CI records the governance result</pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/claude-agent-sdk/index.html
+++ b/site/integrations/claude-agent-sdk/index.html
@@ -342,7 +342,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -688,7 +688,7 @@ jobs:
     <div class="cta-block">
       <h3>Start enforcing architectural decisions in Agent SDK workflows</h3>
       <p>Open source, self-hosted. The governance corpus is a JSON file in your repo. Install takes under five minutes.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt Engineering Is Not Governance &rarr;</a>
     </div>
   </footer>
@@ -745,7 +745,7 @@ jobs:
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -768,7 +768,7 @@ jobs:
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/claude-code/index.html
+++ b/site/integrations/claude-code/index.html
@@ -373,7 +373,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -609,7 +609,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Start enforcing architectural decisions in Claude Code</h3>
       <p>Open source, self-hosted. Install takes under five minutes.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/prompt-engineering-is-not-governance/" class="cta-secondary">Read: Prompt Engineering Is Not Governance &rarr;</a>
     </div>
   </footer>
@@ -666,7 +666,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -689,7 +689,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/copilot/index.html
+++ b/site/integrations/copilot/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -464,7 +464,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>One corpus, every AI coding tool in your stack</h3>
       <p>Mneme HQ is the architectural constraint layer that outlasts any single vendor's surface &mdash; readable by humans, parseable by every coding tool, enforceable at CI.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" class="cta-secondary">Read: Architectural Governance Across Heterogeneous AI Coding Agents &rarr;</a>
     </div>
   </footer>
@@ -521,7 +521,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -544,7 +544,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/cursor/index.html
+++ b/site/integrations/cursor/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -474,7 +474,7 @@ mneme cursor generate --memory .mneme/project_memory.json --query "service bound
     <div class="cta-block">
       <h3>One corpus. Every AI editor.</h3>
       <p>Maintain decisions in Mneme HQ. Export to Cursor Rules, enforce via Claude Code hooks — same source of truth, no duplication.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/compare/cursor-rules/" class="cta-secondary">See full comparison: Mneme HQ vs Cursor Rules &rarr;</a>
     </div>
   </footer>
@@ -531,7 +531,7 @@ mneme cursor generate --memory .mneme/project_memory.json --query "service bound
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -554,7 +554,7 @@ mneme cursor generate --memory .mneme/project_memory.json --query "service bound
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/github-actions/index.html
+++ b/site/integrations/github-actions/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -488,7 +488,7 @@ jobs:
     <div class="cta-block">
       <h3>Add architectural governance to your CI pipeline</h3>
       <p>Mneme check runs anywhere Python runs. The reference workflow is three steps.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/ai-code-review-does-not-scale-linearly/" class="cta-secondary">Read: AI Code Review Does Not Scale Linearly &rarr;</a>
     </div>
   </footer>
@@ -545,7 +545,7 @@ jobs:
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -568,7 +568,7 @@ jobs:
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/gitlab/index.html
+++ b/site/integrations/gitlab/index.html
@@ -349,7 +349,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -476,7 +476,7 @@ mneme-governance:
     <div class="cta-block">
       <h3>Add architectural governance to your GitLab pipelines</h3>
       <p>Mneme check runs anywhere Python runs. The reference job is three lines.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/ai-code-review-does-not-scale-linearly/" class="cta-secondary">Read: AI Code Review Does Not Scale Linearly &rarr;</a>
     </div>
   </footer>
@@ -533,7 +533,7 @@ mneme-governance:
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -556,7 +556,7 @@ mneme-governance:
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -306,7 +306,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -579,7 +579,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -602,7 +602,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/jetbrains/index.html
+++ b/site/integrations/jetbrains/index.html
@@ -373,7 +373,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -552,7 +552,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>One corpus. Every JetBrains IDE. Enforced in CI.</h3>
       <p>Open source, self-hosted. The same decision corpus feeds JetBrains AI Assistant, Claude Code, Cursor, and your CI gate &mdash; no per-tool duplication.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" class="cta-secondary">Read: Architectural Governance Across Heterogeneous AI Coding Agents &rarr;</a>
     </div>
   </footer>
@@ -609,7 +609,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -632,7 +632,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/microsoft-agent-forge/index.html
+++ b/site/integrations/microsoft-agent-forge/index.html
@@ -312,7 +312,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -332,7 +332,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <p class="hero-sub">Microsoft Agent Forge helps enterprises operationalize autonomous AI agents with managed orchestration, tool calling, and runtime infrastructure. Mneme adds deterministic architectural governance and verification before autonomous workflows modify production systems.</p>
   <div class="hero-ctas">
     <a href="/benchmark/" class="btn-primary">View Governance Benchmarks</a>
-    <a href="https://github.com/TheoV823/mneme" class="btn-secondary">GitHub Repository</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-secondary">GitHub Repository</a>
   </div>
 </section>
 
@@ -448,7 +448,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Explore deterministic governance for AI-assisted development</h2>
   <p>Open-source. Repo-native. Works across Microsoft Agent Forge, Claude Code, Cursor, Copilot, and CI &mdash; the same compiled constraints, everywhere the codebase is touched.</p>
   <div class="cta-band-buttons">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/benchmark/" class="btn-secondary">Governance Benchmarks</a>
     <a href="/#how-it-works" class="btn-secondary">How Mneme Works</a>
   </div>
@@ -506,7 +506,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -529,7 +529,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/opencode/index.html
+++ b/site/integrations/opencode/index.html
@@ -355,7 +355,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -463,7 +463,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Govern OpenCode across every surface</h3>
       <p>Mneme enforces your architectural decisions through OpenCode's plugin hooks &mdash; advisory while editing, blocking before commit. Open source.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
     </div>
   </footer>
 </article>
@@ -519,7 +519,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -542,7 +542,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/perplexity/index.html
+++ b/site/integrations/perplexity/index.html
@@ -263,7 +263,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -389,7 +389,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Record your next architectural decision</h3>
       <p>The fastest way to move from research to enforcement: run <code>mneme init</code>, add your first decision with <code>mneme add_decision</code>, and wire a hook. The research rationale lives in the corpus; the constraint is live from the first <code>mneme check</code>.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Get started on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Get started on GitHub</a>
       <a href="/demo/adr-compiler/" class="cta-secondary">See the ADR compiler — how existing docs become live enforcement →</a>
     </div>
   </div>
@@ -446,7 +446,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -469,7 +469,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/vscode/index.html
+++ b/site/integrations/vscode/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -527,7 +527,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div class="cta-block">
       <h3>Govern Claude Code inside VS Code in under five minutes</h3>
       <p>Open source, self-hosted. Same install as the Claude Code integration &mdash; the editor is just the host.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/insights/architectural-governance-across-heterogeneous-ai-coding-agents/" class="cta-secondary">Read: Architectural Governance Across Heterogeneous AI Coding Agents &rarr;</a>
     </div>
   </footer>
@@ -584,7 +584,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -607,7 +607,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/integrations/warp/index.html
+++ b/site/integrations/warp/index.html
@@ -306,7 +306,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -427,7 +427,7 @@ mneme check --mode warn   # try locally first</code></pre>
     <div class="cta-block">
       <h3>One corpus. Every agent Warp runs.</h3>
       <p>Architectural decisions stay enforceable underneath whatever Warp orchestrates &mdash; Agent Mode, parallel Claude Code panes, autonomous workflows.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/works-with/" class="cta-secondary">See the full ecosystem &rarr;</a>
     </div>
   </footer>
@@ -484,7 +484,7 @@ mneme check --mode warn   # try locally first</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -507,7 +507,7 @@ mneme check --mode warn   # try locally first</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -129,5 +129,5 @@ Mneme alignment is honest: tracking, design-aligned, planning to engage with fut
 - JavaScript governance (Tier 1, operationally supported): https://mnemehq.com/supported-languages/javascript-governance/
 - Supported languages canonical docs (coverage matrix, limitations, roadmap): https://mnemehq.com/docs/supported-languages/
 - Roadmap: https://mnemehq.com/roadmap/
-- Source: https://github.com/TheoV823/mneme
-- Benchmarks: https://github.com/TheoV823/mneme/tree/main/examples/benchmarks
+- Source: https://github.com/MnemeHQ/mneme
+- Benchmarks: https://github.com/MnemeHQ/mneme/tree/main/examples/benchmarks

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -152,8 +152,8 @@ Marketing/SEO pages framed as "architectural governance for AI-assisted X develo
 
 ## Source and benchmarks
 
-- [GitHub repository](https://github.com/TheoV823/mneme)
-- [Benchmark scenarios](https://github.com/TheoV823/mneme/tree/main/examples/benchmarks)
+- [GitHub repository](https://github.com/MnemeHQ/mneme)
+- [Benchmark scenarios](https://github.com/MnemeHQ/mneme/tree/main/examples/benchmarks)
 
 ## Reported benchmark
 

--- a/site/pilot/index.html
+++ b/site/pilot/index.html
@@ -584,7 +584,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -758,7 +758,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -781,7 +781,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/platforms/index.html
+++ b/site/platforms/index.html
@@ -259,7 +259,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -398,7 +398,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <h2 class="group-title">Get started</h2>
   <div class="cta-grid">
-    <a class="cta-card" href="https://github.com/TheoV823/mneme">
+    <a class="cta-card" href="https://github.com/MnemeHQ/mneme">
       <span class="cta-label">Source</span>
       <span class="cta-title">GitHub &rarr;</span>
       <span class="cta-sub">MIT-licensed. Works on every platform listed above.</span>
@@ -478,7 +478,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -501,7 +501,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -408,7 +408,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -534,7 +534,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -557,7 +557,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/qa-glossary/index.html
+++ b/site/qa-glossary/index.html
@@ -234,7 +234,7 @@
           {"@type": "Question", "name": "How does Mneme HQ relate to AI safety?", "acceptedAnswer": {"@type": "Answer", "text": "It's a narrow slice of AI safety: governance of AI-generated code at the project level. It's not AI alignment, not model safety, not RLHF. It's the boring, auditable, deterministic kind of safety that matters when AI is actually shipping code into production. The relevant safety claim is reproducibility: every verdict is reconstructable, no black box, no model in the verdict loop."}},
           {"@type": "Question", "name": "Can I use Mneme HQ for non-code governance (docs, configs, prompts)?", "acceptedAnswer": {"@type": "Answer", "text": "The mechanism is general — Decisions and ADRs are not code-specific. In practice, the v0.x integrations and benchmark focus on code. Governance of generated docs, configs, or prompts is a plausible extension but is not currently in scope."}},
           {"@type": "Question", "name": "How do I contribute to Mneme HQ?", "acceptedAnswer": {"@type": "Answer", "text": "The repository governs itself with Mneme. Read CLAUDE.md and the freeze artifact (docs/architecture/layer1-freeze-e73ff7d.md) before opening a PR. Changes to decision_retriever.py, enforcer.py, benchmark.py, or any benchmark fixture are charter-level changes requiring the freeze doc's amendment procedure. Docs, tooling, integrations, the site, and examples proceed normally with [memory] prefix discipline for project_memory.json edits."}},
-          {"@type": "Question", "name": "Is Mneme HQ open source?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, MIT licensed. The repository is at github.com/TheoV823/mneme. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open."}}
+          {"@type": "Question", "name": "Is Mneme HQ open source?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, MIT licensed. The repository is at github.com/MnemeHQ/mneme. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open."}}
         ]
       },
       {
@@ -389,7 +389,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -432,7 +432,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
       <span class="sep">&middot;</span>
       <time datetime="2026-05-22">Published May 2026</time>
       <span class="sep">&middot;</span>
-      <a href="https://github.com/TheoV823/mneme">github.com/TheoV823/mneme</a>
+      <a href="https://github.com/MnemeHQ/mneme">github.com/MnemeHQ/mneme</a>
       <span class="sep">&middot;</span>
       MIT License
     </p>
@@ -489,7 +489,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
         <li class="qa-item"><h3 class="qa-question" id="q-contribute">How do I contribute to Mneme HQ?</h3><div class="qa-answer"><p>The repository governs itself with Mneme. Read <code>CLAUDE.md</code> and the freeze artifact (<code>docs/architecture/layer1-freeze-e73ff7d.md</code>) before opening a PR. Changes to <code>decision_retriever.py</code>, <code>enforcer.py</code>, <code>benchmark.py</code>, or any benchmark fixture are charter-level changes requiring the freeze doc's amendment procedure. Docs, tooling, integrations, the site, and examples proceed normally with <code>[memory]</code> prefix discipline for <code>project_memory.json</code> edits.</p></div></li>
 
-        <li class="qa-item"><h3 class="qa-question" id="q-open-source">Is Mneme HQ open source?</h3><div class="qa-answer"><p>Yes, MIT licensed. The repository is at <a href="https://github.com/TheoV823/mneme">github.com/TheoV823/mneme</a>. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open.</p></div></li>
+        <li class="qa-item"><h3 class="qa-question" id="q-open-source">Is Mneme HQ open source?</h3><div class="qa-answer"><p>Yes, MIT licensed. The repository is at <a href="https://github.com/MnemeHQ/mneme">github.com/MnemeHQ/mneme</a>. The mechanism, the benchmark methodology, the freeze artifact, the ADR compiler, and all integrations are open. Commercial offerings (managed governance, hosted policy packs, enterprise audit log) are planned for Layer 2 but the core stays open.</p></div></li>
 
         </ol>
       </section>
@@ -791,7 +791,7 @@ Body markdown follows.</code></pre>
       <h2 class="section-title">How to cite</h2>
       <div class="cite-block">
         <div class="cite-label">Canonical citation</div>
-        <p>Mneme HQ. <em>Q&amp;A and Glossary</em>. mnemehq.com. 2026. Available at: <a href="https://mnemehq.com/qa-glossary/">https://mnemehq.com/qa-glossary/</a> and <a href="https://github.com/TheoV823/mneme">https://github.com/TheoV823/mneme</a>.</p>
+        <p>Mneme HQ. <em>Q&amp;A and Glossary</em>. mnemehq.com. 2026. Available at: <a href="https://mnemehq.com/qa-glossary/">https://mnemehq.com/qa-glossary/</a> and <a href="https://github.com/MnemeHQ/mneme">https://github.com/MnemeHQ/mneme</a>.</p>
         <p>MIT License. Reproduction and citation encouraged.</p>
       </div>
     </section>
@@ -849,7 +849,7 @@ Body markdown follows.</code></pre>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -872,7 +872,7 @@ Body markdown follows.</code></pre>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -359,7 +359,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -372,7 +372,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Building the Governance Layer<br>for AI-Assisted Development</h1>
     <p class="hero-sub">Mneme is evolving from local governance tooling into the governance infrastructure layer for AI-assisted software development. As AI coding workflows mature, engineering teams will need more than prompt files to maintain architectural consistency at scale.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub</a>
       <a href="/contact/" class="btn-ghost">Talk to us</a>
     </div>
   </div>
@@ -502,7 +502,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <p>We're speaking with engineering leaders and early adopters exploring governance for AI-assisted development.</p>
     <div class="cta-group">
       <a href="/contact/" class="btn-primary">Talk to us</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View on GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View on GitHub</a>
     </div>
   </div>
 
@@ -560,7 +560,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -583,7 +583,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/standards/index.html
+++ b/site/standards/index.html
@@ -322,7 +322,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -460,7 +460,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <h3>Done</h3>
   <ul>
-    <li><strong>Open source under MIT license.</strong> The decision-store schema, the precedence engine, and the Claude Code hook integration are public on <a class="ext" href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener">GitHub</a>. Anyone evaluating an emerging standard can read, fork, and reference the design.</li>
+    <li><strong>Open source under MIT license.</strong> The decision-store schema, the precedence engine, and the Claude Code hook integration are public on <a class="ext" href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener">GitHub</a>. Anyone evaluating an emerging standard can read, fork, and reference the design.</li>
     <li><strong>Structured project memory format.</strong> Mneme's <code>project_memory.json</code> schema is documented and stable; it is the artifact a future cross-tool format would either consume or be compared against.</li>
     <li><strong>Public benchmark methodology.</strong> The Mneme governance benchmark is published with reproducible methodology, intended as a citable reference for evaluating governance-layer behavior.</li>
   </ul>
@@ -545,7 +545,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -568,7 +568,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/fastapi-governance/index.html
+++ b/site/supported-languages/fastapi-governance/index.html
@@ -263,7 +263,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -492,7 +492,7 @@ router = APIRouter(prefix=<span class="kw">"/admin"</span>)  <span class="cm"># 
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -515,7 +515,7 @@ router = APIRouter(prefix=<span class="kw">"/admin"</span>)  <span class="cm"># 
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/index.html
+++ b/site/supported-languages/index.html
@@ -237,7 +237,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -345,7 +345,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
   <h2 class="group-title">Get started</h2>
   <div class="cta-grid">
-    <a class="cta-card" href="https://github.com/TheoV823/mneme">
+    <a class="cta-card" href="https://github.com/MnemeHQ/mneme">
       <span class="cta-label">Source</span>
       <span class="cta-title">GitHub &rarr;</span>
       <span class="cta-sub">MIT-licensed. Works on any language repository.</span>
@@ -415,7 +415,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -438,7 +438,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/javascript-governance/index.html
+++ b/site/supported-languages/javascript-governance/index.html
@@ -252,7 +252,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -436,7 +436,7 @@ cron.schedule(<span class="kw">"0 3 * * *"</span>, <span class="kw">async</span>
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -459,7 +459,7 @@ cron.schedule(<span class="kw">"0 3 * * *"</span>, <span class="kw">async</span>
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/python-governance/index.html
+++ b/site/supported-languages/python-governance/index.html
@@ -253,7 +253,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -461,7 +461,7 @@ app = Celery(<span class="kw">'tasks'</span>, broker=<span class="kw">'redis://l
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -484,7 +484,7 @@ app = Celery(<span class="kw">'tasks'</span>, broker=<span class="kw">'redis://l
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/spring-boot-governance/index.html
+++ b/site/supported-languages/spring-boot-governance/index.html
@@ -263,7 +263,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -491,7 +491,7 @@ http.csrf(csrf -&gt; csrf.disable())
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -514,7 +514,7 @@ http.csrf(csrf -&gt; csrf.disable())
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/terraform-governance/index.html
+++ b/site/supported-languages/terraform-governance/index.html
@@ -263,7 +263,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -503,7 +503,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -526,7 +526,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/supported-languages/typescript-governance/index.html
+++ b/site/supported-languages/typescript-governance/index.html
@@ -252,7 +252,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -451,7 +451,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -474,7 +474,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/ci-governance-for-ai-generated-code/index.html
+++ b/site/use-cases/ci-governance-for-ai-generated-code/index.html
@@ -305,7 +305,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -467,7 +467,7 @@ mneme-check:
     <div class="cta-block">
       <h3>Make AI-generated code answer to the corpus.</h3>
       <p>Architectural decisions stay enforceable through CI &mdash; whichever agent produced the diff, whichever pipeline ran it.</p>
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">View on GitHub &rarr;</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">View on GitHub &rarr;</a>
       <a href="/integrations/github-actions/" class="cta-secondary">See the GitHub Actions setup &rarr;</a>
     </div>
   </footer>
@@ -524,7 +524,7 @@ mneme-check:
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -547,7 +547,7 @@ mneme-check:
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/coding-assistant-governance/index.html
+++ b/site/use-cases/coding-assistant-governance/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -383,8 +383,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>How Mneme HQ Prevents Coding Assistants from Violating Architecture Rules</h1>
     <p class="hero-sub">Stop Cursor, Claude Code, and Copilot from ignoring your ADRs, service boundaries, and team conventions — session after session.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -615,7 +615,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <details>
       <summary>How long does it take to set up?</summary>
-      <div class="faq-body">Under 5 minutes for a project with existing documentation. <code>pip install mneme-hq</code>, add your first decision to <code>.mneme/project_memory.json</code>, and run <code>mneme check</code>. See the <a href="https://github.com/TheoV823/mneme" style="color:var(--accent)">README</a> for the quickstart.</div>
+      <div class="faq-body">Under 5 minutes for a project with existing documentation. <code>pip install mneme-hq</code>, add your first decision to <code>.mneme/project_memory.json</code>, and run <code>mneme check</code>. See the <a href="https://github.com/MnemeHQ/mneme" style="color:var(--accent)">README</a> for the quickstart.</div>
     </details>
 
     <details>
@@ -636,7 +636,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Add decision memory to your AI workflow in 5 minutes.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -692,7 +692,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -715,7 +715,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/data-platform-governance/index.html
+++ b/site/use-cases/data-platform-governance/index.html
@@ -357,7 +357,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -376,8 +376,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Keeping AI Assistants Aligned with Data Platform Architecture</h1>
     <p class="hero-sub">Enforce warehouse standards, naming conventions, and pipeline constraints — before an AI assistant writes a single query that breaks your data contracts.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Protect your data platform from AI-generated drift.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -617,7 +617,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -640,7 +640,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/design-system-governance/index.html
+++ b/site/use-cases/design-system-governance/index.html
@@ -357,7 +357,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -376,8 +376,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Using Mneme HQ to Preserve Design System Decisions for AI Builders</h1>
     <p class="hero-sub">Stop AI assistants from inventing colors, breaking component hierarchy, and ignoring accessibility rules every time they generate a UI.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -561,7 +561,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Keep AI-generated UI consistent with your design system.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -617,7 +617,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -640,7 +640,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/index.html
+++ b/site/use-cases/index.html
@@ -431,7 +431,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -778,7 +778,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -801,7 +801,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/legacy-codebase-memory/index.html
+++ b/site/use-cases/legacy-codebase-memory/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -383,8 +383,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Using Mneme HQ to Preserve Tribal Knowledge in Legacy Codebases</h1>
     <p class="hero-sub">The senior engineer bottleneck, solved. Give every coding assistant access to the undocumented rules that only your longest-tenured engineers know.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -643,7 +643,7 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
   <div class="cta-footer">
     <h2>Stop losing institutional knowledge when engineers leave.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -699,7 +699,7 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -722,7 +722,7 @@ legacy-mailer-wrapper.yml  <span class="cc"># 6 decisions captured in one sessio
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/multi-agent-workflow-governance/index.html
+++ b/site/use-cases/multi-agent-workflow-governance/index.html
@@ -363,7 +363,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -382,8 +382,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Governing Multi-Step AI Development Workflows with Mneme HQ</h1>
     <p class="hero-sub">Give every agent in your pipeline — planner, coder, reviewer, deployer — a shared memory of your architectural decisions. One decision store. Every stage enforced.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -598,7 +598,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Give every agent in your pipeline a shared decision memory.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -654,7 +654,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -677,7 +677,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/use-cases/security-compliance-guardrails/index.html
+++ b/site/use-cases/security-compliance-guardrails/index.html
@@ -362,7 +362,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -383,8 +383,8 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <h1>Preventing LLMs from Introducing Security and Compliance Violations</h1>
     <p class="hero-sub">Enforce encryption standards, auth requirements, PII handling rules, and secrets policies — before the LLM generates a single line of non-compliant code.</p>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
-      <a href="https://github.com/TheoV823/mneme" class="btn-ghost">View GitHub</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-ghost">View GitHub</a>
     </div>
   </div>
 
@@ -647,7 +647,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div class="cta-footer">
     <h2>Enforce compliance rules before the LLM writes a line.</h2>
     <div class="cta-group">
-      <a href="https://github.com/TheoV823/mneme" class="btn-primary">Install Mneme HQ</a>
+      <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">Install Mneme HQ</a>
       <a href="/use-cases/" class="btn-ghost">More use cases</a>
     </div>
   </div>
@@ -703,7 +703,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -726,7 +726,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/works-with/antigravity/index.html
+++ b/site/works-with/antigravity/index.html
@@ -211,7 +211,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -231,7 +231,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <p class="hero-sub">Antigravity coordinates autonomous coding agents across editor, terminal, and browser. Mneme works alongside agent-first development environments by providing repo-native architectural governance, ADR retrieval, and deterministic checks &mdash; the same compiled rules across every agent on the codebase.</p>
   <div class="hero-ctas">
     <a href="/integrations/antigravity/" class="btn-primary">Integration page &rarr;</a>
-    <a href="https://github.com/TheoV823/mneme" class="btn-secondary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-secondary">GitHub</a>
   </div>
 </section>
 
@@ -266,7 +266,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Architectural governance for agent-first development workflows</h2>
   <p>Open-source. Repo-native. Works alongside Google Antigravity and every other agentic IDE on the codebase &mdash; same compiled ADR-derived constraints, enforced at hook, commit, PR, and CI.</p>
   <div class="cta-band-buttons">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/integrations/antigravity/" class="btn-secondary">Integration page</a>
   </div>
 </div>
@@ -323,7 +323,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -346,7 +346,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/works-with/claude-marketplace/index.html
+++ b/site/works-with/claude-marketplace/index.html
@@ -301,7 +301,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -320,7 +320,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h1>Architectural Governance for Claude-Powered Development Workflows</h1>
   <p class="hero-sub">Mneme works alongside Claude Code, the partner products in the Claude Marketplace, CI systems, and AI-assisted developer tooling &mdash; to preserve architectural decisions across autonomous development workflows. The marketplace covers generation, memory, orchestration, and review. Mneme covers the governance layer that runs before any of them.</p>
   <div class="hero-ctas">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/integrations/claude-code/" class="btn-secondary">Claude Code integration</a>
   </div>
 </section>
@@ -417,7 +417,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Protect architectural decisions before drift reaches production</h2>
   <p>Open-source. Repo-native. Works alongside Claude Code, marketplace partners, CI, and any other Claude-powered surface that touches the codebase.</p>
   <div class="cta-band-buttons">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/works-with/" class="btn-secondary">All works-with</a>
     <a href="/insights/anthropic-claude-marketplace-ai-engineering-control-plane/" class="btn-secondary">Read the analysis</a>
   </div>
@@ -475,7 +475,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -498,7 +498,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/works-with/devin/index.html
+++ b/site/works-with/devin/index.html
@@ -300,7 +300,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -319,7 +319,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h1>Mneme Works Alongside Devin</h1>
   <p class="hero-sub">Devin executes. Mneme preserves architectural intent across that execution. The governance layer that sits above Devin and every other autonomous coding agent on the codebase &mdash; ADR-derived constraints, deterministic retrieval, hook and CI enforcement, the same compiled rules across every surface.</p>
   <div class="hero-ctas">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/compare/devin-vs-architectural-governance/" class="btn-secondary">Side-by-side comparison</a>
   </div>
 </section>
@@ -462,7 +462,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2>Architectural governance for autonomous coding workflows</h2>
   <p>Open-source. Repo-native. Works alongside Devin and every other AI coding agent on the codebase &mdash; the same compiled architectural decisions enforced at hook, commit, PR, and CI.</p>
   <div class="cta-band-buttons">
-    <a href="https://github.com/TheoV823/mneme" class="btn-primary">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme" class="btn-primary">GitHub</a>
     <a href="/insights/devin-ai-software-engineer-governance/" class="btn-secondary">Read the analysis</a>
     <a href="/compare/devin-vs-architectural-governance/" class="btn-secondary">Side-by-side comparison</a>
   </div>
@@ -520,7 +520,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -543,7 +543,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">

--- a/site/works-with/index.html
+++ b/site/works-with/index.html
@@ -331,7 +331,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <a href="/concepts/">Concepts</a>
     <a href="/insights/">Insights</a>
     <a href="/docs/">Docs</a>
-    <a href="https://github.com/TheoV823/mneme">GitHub</a>
+    <a href="https://github.com/MnemeHQ/mneme">GitHub</a>
     <a href="/pilot/" class="btn-nav-cta">Request a pilot</a>
   </div>
 </nav>
@@ -728,7 +728,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <h2 class="group-title">Get started</h2>
 
   <div class="cta-grid">
-    <a class="cta-card" href="https://github.com/TheoV823/mneme">
+    <a class="cta-card" href="https://github.com/MnemeHQ/mneme">
       <span class="cta-label">Source</span>
       <span class="cta-title">GitHub &rarr;</span>
       <span class="cta-sub">MIT-licensed. Read the implementation, file an issue, contribute.</span>
@@ -802,7 +802,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
     <div>
       <div style="font-family: 'DM Mono', monospace; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.9rem;">Connect</div>
       <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.82rem;">
-        <li><a href="https://github.com/TheoV823/mneme">GitHub</a></li>
+        <li><a href="https://github.com/MnemeHQ/mneme">GitHub</a></li>
         <li><a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener">LinkedIn</a></li>
         <li><a href="https://dev.to/mnemehq" target="_blank" rel="noopener">DEV.to</a></li>
         <li><a href="https://www.youtube.com/@MnemeHQ" target="_blank" rel="noopener">YouTube</a></li>
@@ -825,7 +825,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
   <div style="max-width: 1080px; margin: 1.25rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--muted); font-family: 'DM Mono', monospace; letter-spacing: 0.03em;">
     <span style="display:inline-flex;align-items:center;gap:0.75rem;"><a href="/" aria-label="Mneme HQ home" style="display:inline-flex;opacity:0.75;"><img src="/favicon.png" alt="Mneme HQ" height="22" style="display:block;"></a><span>Mneme HQ&trade; &middot; Open source &middot; MIT License</span></span>
     <nav aria-label="Social media" style="display: flex; align-items: center; gap: 1rem;">
-      <a href="https://github.com/TheoV823/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
+      <a href="https://github.com/MnemeHQ/mneme" target="_blank" rel="noopener" aria-label="GitHub" style="color: var(--muted); display: inline-flex;">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.16c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.17 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.12 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.35.78 1.05.78 2.12v3.15c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
       </a>
       <a href="https://www.linkedin.com/company/mnemehq" target="_blank" rel="noopener" aria-label="LinkedIn" style="color: var(--muted); display: inline-flex;">


### PR DESCRIPTION
## What

- **Canonical GitHub URL migration:** replace all `github.com/TheoV823/mneme` with `github.com/MnemeHQ/mneme` across the site (nav, footer, CTAs, JSON-LD, clone command) — 980 occurrences across 245 files, uniform replace including `_snippets/` so `check_nav_footer` still matches.
- **Sync Mermaid diagram #1** in `docs/architecture-diagrams.md` to match the production homepage SVG: "Policy evaluation", "Architecturally compliant code", and the explicit reject → guidance → retry loop.

## Not included

The homepage "bottleneck" copy is intentionally left as-is (reverted in a follow-up commit).

## Checks

`check_nav_footer`, `check_sticky_nav`, `check_encoding`, `check_insights` all pass. 0 `TheoV823/mneme` references remain in `site/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)