### PR TITLE
ci: batch Cloudflare cache purge to 30 URLs per request

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -60,27 +60,34 @@ def purge_cf_cache(urls=None):
     if not CF_TOKEN or not CF_ZONE_ID:
         print('[SKIP] Cloudflare cache purge - CF_API_TOKEN or CF_ZONE_ID not set')
         return
+    def _post(payload, desc):
+        req = urllib.request.Request(
+            f'https://api.cloudflare.com/client/v4/zones/{CF_ZONE_ID}/purge_cache',
+            data=payload,
+            headers={'Authorization': f'Bearer {CF_TOKEN}', 'Content-Type': 'application/json'},
+            method='POST',
+        )
+        try:
+            with urllib.request.urlopen(req) as r:
+                result = json.loads(r.read())
+            if result.get('success'):
+                print(f'[OK] Cloudflare cache purged ({desc})')
+            else:
+                print(f'[WARN] Cloudflare purge failed: {result.get("errors")}')
+        except Exception as e:
+            print(f'[WARN] Cloudflare purge error (deploy succeeded): {e}')
+
     if urls:
-        payload = json.dumps({'files': urls}).encode()
-        desc = f'{len(urls)} URL(s): {", ".join(urls)}'
+        # Cloudflare purge-by-URL accepts at most 30 files per request; batch them
+        # so large deploys (e.g. a sitewide change touching every page's footer)
+        # don't get rejected with HTTP 400 and leave stale content served.
+        BATCH = 30
+        for i in range(0, len(urls), BATCH):
+            batch = urls[i:i + BATCH]
+            _post(json.dumps({'files': batch}).encode(),
+                  f'{len(batch)} URL(s), batch {i // BATCH + 1} of {(len(urls) + BATCH - 1) // BATCH}')
     else:
-        payload = json.dumps({'purge_everything': True}).encode()
-        desc = 'everything'
-    req = urllib.request.Request(
-        f'https://api.cloudflare.com/client/v4/zones/{CF_ZONE_ID}/purge_cache',
-        data=payload,
-        headers={'Authorization': f'Bearer {CF_TOKEN}', 'Content-Type': 'application/json'},
-        method='POST',
-    )
-    try:
-        with urllib.request.urlopen(req) as r:
-            result = json.loads(r.read())
-        if result.get('success'):
-            print(f'[OK] Cloudflare cache purged ({desc})')
-        else:
-            print(f'[WARN] Cloudflare purge failed: {result.get("errors")}')
-    except Exception as e:
-        print(f'[WARN] Cloudflare purge error (deploy succeeded): {e}')
+        _post(json.dumps({'purge_everything': True}).encode(), 'everything')
 
 # ── cPanel credentials ────────────────────────────────────────────────────────
 # Endpoint is overridable via env (set CPANEL_HOST/CPANEL_PORT as repo Variables


### PR DESCRIPTION
## Problem

The #214 canonical-URL migration changed every page's footer -> 245 changed URLs. The deploy uploaded all 245 files to the origin successfully, but the Cloudflare purge sent all 245 URLs in **one** `purge_cache` request. Cloudflare's purge-by-URL API caps at **30 files per request**, so it returned **HTTP 400**, the cache was never purged, and post-deploy strict verification failed with `stale 200 (served content does not match uploaded file)` for many URLs.

(Earlier deploys purged fine because they changed <30 URLs: 26 for the insights batch, 2 for the diagrams.)

## Fix

Batch the files purge into chunks of 30 per request. `purge_everything` (full deploy) is unaffected; no signature change.

## Self-heal

The failed run exited at verification (before `tag_deployed()`), so the `site-deployed` tag is still at the last successful deploy. Merging this triggers a delta re-deploy of the same 245 files, and the batched purge will now succeed and clear the stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)