### PR TITLE
docs: align mneme-hq package to v0.5.0 release

### DIFF
--- a/mneme-project-memory/CHANGELOG.md
+++ b/mneme-project-memory/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+_Nothing yet._
+
+---
+
+## v0.5.0 — 2026-07-03
+
+**Installable Claude Code plugin, `mneme init`, and PyPI metadata realignment**
+
+First minor release since v0.4.0. It ships new backwards-compatible,
+user-facing capabilities — a project scaffolder and a distributable Claude Code
+plugin — and folds in the v0.4.1 / v0.4.2 hook-reliability fixes that were
+tagged on GitHub but never reflected in the published PyPI package metadata
+(PyPI still serves `0.4.0`). No `DecisionRetriever`, `ConflictDetector`,
+retrieval, or enforcement semantics change.
+
 ### Added
 
 - `mneme init` subcommand — scaffolds a valid, empty, neutral
@@ -11,12 +26,75 @@
   nothing to enforce. No seeded decisions (every decision is enforceable, so
   sample content would create phantom rules). Refuses to overwrite an existing
   file unless `--force` is given; `--path` overrides the output location.
+- Installable Claude Code plugin under `integrations/claude-code-plugin/` —
+  bundles the enforcement hook, the `mneme` skill, and four namespaced slash
+  commands (`/mneme:context`, `/mneme:check`, `/mneme:record`,
+  `/mneme:review`) into a single distributable unit. The plugin manifest
+  (`.claude-plugin/plugin.json`) declares manifest version `0.1.0` (independent
+  of the `mneme-hq` package version) and a `mode` userConfig option
+  (`strict` | `warn`, default `strict`).
+- Direct exec-form invocation of `mneme-hook` in the plugin hook config
+  (`{ "type": "command", "command": "mneme-hook", "args": [] }`) — no shell
+  string, no wrapper script, no interpreter probing. Claude Code resolves
+  `mneme-hook` on `PATH` and spawns it directly, so the hook is
+  platform-independent by construction.
+- Enforcement-mode resolution for the Claude Code adapter (`resolve_mode()`
+  in `mneme/integrations/claude_code/hook.py`) with precedence
+  `MNEME_HOOK_MODE` > `CLAUDE_PLUGIN_OPTION_MODE` > `strict`. The plugin's
+  `mode` userConfig value reaches the hook subprocess as
+  `CLAUDE_PLUGIN_OPTION_MODE`; an explicit `MNEME_HOOK_MODE` overrides it.
+  Mode resolution stays inside the Claude Code adapter.
+- Strict fallback for invalid mode values — an unrecognized value in either
+  variable resolves to `strict`, so a typo can never silently disable
+  enforcement. A set-but-invalid explicit override does not fall through to the
+  plugin option; values are case- and whitespace-tolerant.
+
+### Fixed
+
+- Realigned the published package with the v0.4.1 / v0.4.2 hook-reliability
+  fixes. Both were tagged on GitHub, but the fixes never reached the PyPI
+  package metadata — PyPI still serves `0.4.0`, which has the exit-code
+  propagation bug (a failed check could exit `0` and let a violating edit
+  through in strict mode). Publishing `0.5.0` makes `pip install mneme-hq`
+  deliver the reliable hook for the first time. The underlying fixes:
+  - `mneme/__main__.py` so `python -m mneme` dispatches and
+    `sys.exit(main())` propagates CLI exit codes (v0.4.2).
+  - Hook subprocess uses `[sys.executable, "-m", "mneme", ...]` instead of a
+    bare `mneme`, so a missing Scripts directory on `PATH` (Windows Microsoft
+    Store Python) no longer makes the hook fail open silently (v0.4.1).
+
+### Changed
+
+- `pyproject.toml` version `0.4.0` → `0.5.0`.
 
 ### Tests
 
-- `tests/test_cli_init.py` — 6 tests (fresh create, MemoryStore round-trip,
+- `tests/test_cli_init.py` — 6 tests (fresh create, `MemoryStore` round-trip,
   refuse-existing, `--force` overwrite, custom `--path`, clean `mneme check`).
-- Full suite: 354 passed, 52 warnings.
+- `tests/integrations/claude_code/test_plugin_contract.py` — deterministic,
+  shell-free plugin contract tests: manifest is valid and declares the `mode`
+  option, manifest declares a valid semver version, the hook uses exec-form
+  direct invocation, the hook command carries no shell dependency, no wrapper
+  script remains, all four slash commands are present, the skill is present.
+- `tests/integrations/claude_code/test_hook_mode.py` — mode-precedence and
+  strict-fallback coverage.
+- `tests/integrations/claude_code/test_hook_e2e.py` — end-to-end against the
+  real `mneme check` binary via the hook shim: a compliant Write is allowed
+  (exit `0`) and a violating Write is blocked (exit `2`) in strict mode, plus
+  the equivalent Edit cases. (Skipped when `mneme` is not on `PATH`.)
+- `tests/test_packaging_contract.py` — deterministic packaging contract:
+  asserts `[project.scripts]` declares both console scripts
+  (`mneme = mneme.cli:main` and
+  `mneme-hook = mneme.integrations.claude_code.hook:cli_main`), and verifies
+  the same two entry points inside the built wheel when a `dist/` artifact is
+  present.
+
+### Release
+
+- Manual PyPI publication procedure and the post-merge checklist:
+  `docs/releases/RELEASING.md`. This PR does **not** publish, tag a release,
+  or advertise the new version in the plugin README — those steps run only
+  after `mneme-hq >= 0.5.0` is live on PyPI.
 
 ---
 

--- a/mneme-project-memory/CHANGELOG.md
+++ b/mneme-project-memory/CHANGELOG.md
@@ -14,8 +14,8 @@ First minor release since v0.4.0. It ships new backwards-compatible,
 user-facing capabilities — a project scaffolder and a directory-ready Claude
 Code plugin — and folds in the v0.4.1 / v0.4.2 hook-reliability fixes that were
 tagged on GitHub but never reflected in the published PyPI package metadata
-(PyPI still serves `0.4.0`). No `DecisionRetriever`, `ConflictDetector`,
-retrieval, or enforcement semantics change.
+(before v0.5.0, PyPI served only `0.4.0`). No `DecisionRetriever`,
+`ConflictDetector`, retrieval, or enforcement semantics change.
 
 The two artifacts are separate. The `mneme-hq` **PyPI package** provides the
 `mneme` and `mneme-hook` runtime console commands. The **Claude Code plugin**
@@ -65,9 +65,9 @@ enable the plugin, and vice versa — the plugin is loaded by Claude Code (via
 
 - Realigned the published package with the v0.4.1 / v0.4.2 hook-reliability
   fixes. Both were tagged on GitHub, but the fixes never reached the PyPI
-  package metadata — PyPI still serves `0.4.0`, which has the exit-code
-  propagation bug (a failed check could exit `0` and let a violating edit
-  through in strict mode). Publishing `0.5.0` makes `pip install mneme-hq`
+  package metadata — before v0.5.0, PyPI served only `0.4.0`, which has the
+  exit-code propagation bug (a failed check could exit `0` and let a violating
+  edit through in strict mode). Publishing `0.5.0` makes `pip install mneme-hq`
   deliver the reliable hook for the first time. The underlying fixes:
   - `mneme/__main__.py` so `python -m mneme` dispatches and
     `sys.exit(main())` propagates CLI exit codes (v0.4.2).

--- a/mneme-project-memory/CHANGELOG.md
+++ b/mneme-project-memory/CHANGELOG.md
@@ -8,14 +8,22 @@ _Nothing yet._
 
 ## v0.5.0 — 2026-07-03
 
-**Installable Claude Code plugin, `mneme init`, and PyPI metadata realignment**
+**Directory-ready Claude Code plugin, `mneme init`, and PyPI metadata realignment**
 
 First minor release since v0.4.0. It ships new backwards-compatible,
-user-facing capabilities — a project scaffolder and a distributable Claude Code
-plugin — and folds in the v0.4.1 / v0.4.2 hook-reliability fixes that were
+user-facing capabilities — a project scaffolder and a directory-ready Claude
+Code plugin — and folds in the v0.4.1 / v0.4.2 hook-reliability fixes that were
 tagged on GitHub but never reflected in the published PyPI package metadata
 (PyPI still serves `0.4.0`). No `DecisionRetriever`, `ConflictDetector`,
 retrieval, or enforcement semantics change.
+
+The two artifacts are separate. The `mneme-hq` **PyPI package** provides the
+`mneme` and `mneme-hook` runtime console commands. The **Claude Code plugin**
+under `integrations/claude-code-plugin/` is a directory of plugin files that
+*drives* those commands. Installing the PyPI package does **not** install or
+enable the plugin, and vice versa — the plugin is loaded by Claude Code (via
+`--plugin-dir` or a marketplace) and expects `mneme` / `mneme-hook` already on
+`PATH`.
 
 ### Added
 
@@ -26,13 +34,17 @@ retrieval, or enforcement semantics change.
   nothing to enforce. No seeded decisions (every decision is enforceable, so
   sample content would create phantom rules). Refuses to overwrite an existing
   file unless `--force` is given; `--path` overrides the output location.
-- Installable Claude Code plugin under `integrations/claude-code-plugin/` —
+- Directory-ready Claude Code plugin under `integrations/claude-code-plugin/` —
   bundles the enforcement hook, the `mneme` skill, and four namespaced slash
   commands (`/mneme:context`, `/mneme:check`, `/mneme:record`,
-  `/mneme:review`) into a single distributable unit. The plugin manifest
-  (`.claude-plugin/plugin.json`) declares manifest version `0.1.0` (independent
-  of the `mneme-hq` package version) and a `mode` userConfig option
-  (`strict` | `warn`, default `strict`).
+  `/mneme:review`) into a single directory that Claude Code can load with
+  `--plugin-dir` (or via a marketplace). It depends on the `mneme` /
+  `mneme-hook` commands from the `mneme-hq` package being on `PATH`; installing
+  the package does not install the plugin. The plugin manifest
+  (`.claude-plugin/plugin.json`) declares manifest version `0.1.0` — correct for
+  its first directory release, and versioned independently of the `mneme-hq`
+  package version — and a `mode` userConfig option (`strict` | `warn`, default
+  `strict`). The plugin has not yet been publicly submitted to a marketplace.
 - Direct exec-form invocation of `mneme-hook` in the plugin hook config
   (`{ "type": "command", "command": "mneme-hook", "args": [] }`) — no shell
   string, no wrapper script, no interpreter probing. Claude Code resolves

--- a/mneme-project-memory/docs/releases/RELEASING.md
+++ b/mneme-project-memory/docs/releases/RELEASING.md
@@ -175,39 +175,121 @@ revoke it in the PyPI project settings and issue a new one.
 
 ## 14. Validate the public package from a clean `pipx` environment
 
-Verify what PyPI actually serves — from a *fresh* environment, not the build
-venv (which already has the local package installed).
+Verify what PyPI actually serves — from a *fresh*, isolated environment, not the
+build venv (which already has the local source package installed). Uninstall
+first so you cannot accidentally validate a stale install, then pin the exact
+published version.
 
 ```powershell
 deactivate
+pipx uninstall mneme-hq
 pipx install "mneme-hq==0.5.0"
+
+Get-Command mneme
+Get-Command mneme-hook
 mneme --help
-mneme-hook --help          # both console scripts resolve on PATH
 ```
 
-`pipx` installs into an isolated environment, so this proves the published
-wheel — not your local checkout — provides both entry points.
+Notes:
 
-## 15. Repeat Claude Code plugin strict validation
+- It is fine if `pipx uninstall` reports the package was not installed — the
+  point is to guarantee a clean starting state.
+- Confirm both console scripts resolve with `Get-Command` (they must point into
+  the `pipx` environment, not your source checkout).
+- Only `mneme` has a `--help`. **Do not run `mneme-hook --help`** — `mneme-hook`
+  is the Claude Code hook entrypoint: it reads a hook event from **stdin**, so
+  invoking it interactively (with or without `--help`) blocks waiting for EOF.
+  Its real validation is the Claude Code smoke test in steps 15–16.
+
+> The pytest end-to-end tests in
+> `tests/integrations/claude_code/test_hook_e2e.py` are **source-level
+> regression tests**, not public-package validation. They import the hook
+> adapter directly from the source checkout, and the adapter launches
+> `[sys.executable, "-m", "mneme", ...]`; run from `mneme-project-memory/` that
+> can execute the **local source** package rather than the `pipx`-installed
+> public one. Keep running them (step 5) as regression coverage, but validate
+> the *published* package only through the real plugin path below.
+
+## 15. Validate the plugin with Claude Code strict validation
+
+This and the next step are the **real** public-package validation: they exercise
+the `pipx`-installed `mneme` / `mneme-hook` commands through the actual Claude
+Code plugin, not through the source checkout.
+
+From the **repository root**, resolve the plugin directory once and run strict
+validation and a plugin-dir load with enforcement forced to `strict`:
 
 ```powershell
-claude plugin validate .\integrations\claude-code-plugin --strict
+$env:MNEME_HOOK_MODE = "strict"
+$pluginPath = (
+  Resolve-Path `
+    ".\mneme-project-memory\integrations\claude-code-plugin"
+).Path
+
+claude.cmd plugin validate $pluginPath --strict
+claude.cmd --plugin-dir $pluginPath
 ```
 
-Must pass `--strict` (valid manifest, semver version `0.1.0`, exec-form hook).
+`claude.cmd plugin validate ... --strict` must pass (valid manifest, semver
+version `0.1.0`, exec-form hook). `claude.cmd --plugin-dir $pluginPath` loads the
+plugin into a Claude Code session so you can run the smoke tests below.
 
-## 16. Repeat the compliant-Write and blocked-Write tests
+## 16. Run the compliant-Write and blocked-Write smoke tests through Claude Code
 
-With the published package on `PATH` (via `pipx`), re-run the end-to-end hook
-tests against the real binary to confirm enforcement works from the public
-install:
+Inside the Claude Code session started in step 15, issue the two prompts below
+verbatim. These drive the real `PreToolUse` hook (published `mneme-hook` →
+published `mneme check`), which is what actually validates the public package.
+
+**Compliant Write — must succeed.** Request this exact prompt:
+
+```text
+This is specifically a PreToolUse hook allow test.
+
+Attempt the Write tool, not Bash or Edit, to create:
+
+scripts/encoding_smoke_clean.py
+
+with exactly this content:
+
+open("out.txt", "w", encoding="utf-8").write("x")
+
+Do not change any other file.
+```
+
+The Write must succeed (the content pins `encoding="utf-8"`, so it does not
+violate ADR-009).
+
+**Blocked Write — must be blocked.** Request this exact prompt:
+
+```text
+This is specifically a PreToolUse hook-blocking test.
+
+Attempt the Write tool, not Bash or Edit, to create:
+
+scripts/encoding_smoke_block.py
+
+with exactly this content:
+
+open("out.txt", "w").write("x")
+
+Do not rewrite the content to comply. The purpose is to attempt this exact Write and verify that the hook blocks it. Do not change any other file.
+```
+
+The Write must be blocked by the `PreToolUse` hook (the content omits
+`encoding=`, violating ADR-009).
+
+**Clean up** the smoke-test artifacts and the forced mode, then confirm a clean
+tree:
 
 ```powershell
-python -m pytest tests/integrations/claude_code/test_hook_e2e.py -v
+Remove-Item .\scripts\encoding_smoke_clean.py -ErrorAction SilentlyContinue
+Remove-Item .\scripts\encoding_smoke_block.py -ErrorAction SilentlyContinue
+Remove-Item Env:MNEME_HOOK_MODE -ErrorAction SilentlyContinue
+git status --short
 ```
 
-A compliant Write is allowed (exit `0`); a violating Write is blocked (exit `2`)
-in strict mode.
+`git status --short` must report nothing (the clean Write is removed and the
+blocked Write was never created).
 
 ## 17. Create the GitHub release — only after public validation succeeds
 
@@ -237,9 +319,10 @@ Run in order. Do not advance past a failing step.
 - [ ] `v0.5.0` tag pushed on the exact built commit.
 - [ ] Uploaded only the named wheel + sdist with a project-scoped token.
 - [ ] Token removed from the environment.
-- [ ] `pipx install "mneme-hq==0.5.0"` → `mneme` and `mneme-hook` both resolve.
-- [ ] `claude plugin validate ... --strict` passes.
-- [ ] Compliant-Write allowed / violating-Write blocked, from the public install.
+- [ ] Clean `pipx`: `pipx uninstall mneme-hq` then `pipx install "mneme-hq==0.5.0"`; `Get-Command mneme` and `Get-Command mneme-hook` both resolve into the pipx env; `mneme --help` works (do **not** run `mneme-hook --help`).
+- [ ] `claude.cmd plugin validate $pluginPath --strict` passes; `claude.cmd --plugin-dir $pluginPath` loads the plugin (with `MNEME_HOOK_MODE=strict`).
+- [ ] Claude Code smoke tests: compliant Write (`encoding="utf-8"`) succeeds; blocked Write (no `encoding=`) is blocked by the `PreToolUse` hook.
+- [ ] Smoke artifacts removed, `MNEME_HOOK_MODE` cleared, `git status --short` clean.
 - [ ] GitHub release created for `v0.5.0`.
 - [ ] **Only then:** update the plugin README to drop the install workaround and
       advertise `pipx install "mneme-hq>=0.5.0"` (a separate, follow-up change —

--- a/mneme-project-memory/docs/releases/RELEASING.md
+++ b/mneme-project-memory/docs/releases/RELEASING.md
@@ -1,0 +1,246 @@
+# Releasing `mneme-hq` to PyPI
+
+The exact, manual procedure for publishing the `mneme-hq` package. It is
+intentionally **not** automated — there is no PyPI GitHub Actions workflow, and
+adding one is out of scope for a release-alignment PR. Every publish is a
+deliberate, operator-run sequence.
+
+All commands assume:
+
+- You are in the **package directory** `mneme-project-memory/` (this is the
+  build root; `pyproject.toml` lives here).
+- Windows 11 with **PowerShell** is the reference environment (this is where the
+  hook is exercised in CI). Windows-specific steps below are written in
+  PowerShell; the build, `twine`, and `pytest` invocations are cross-platform
+  and run as shown under PowerShell.
+
+> **PyPI artifacts are immutable.** Once a version is uploaded to PyPI it can
+> never be replaced — only *yanked*. A yanked release still occupies its version
+> number forever; you cannot re-upload `0.5.0` with different bytes. Do every
+> verification step below **before** `twine upload`, because upload is the point
+> of no return. If something is wrong after upload, the only remedy is to yank
+> and publish a new patch version.
+
+---
+
+## 1. Start from a clean `main`
+
+```powershell
+git checkout main
+git pull --ff-only
+git status               # must report a clean working tree
+```
+
+Confirm the release commit is exactly what you intend to ship. Do not build from
+a feature branch, a dirty tree, or a detached checkout.
+
+## 2. Create an isolated Python environment
+
+Never build or publish from your day-to-day interpreter. Use a throwaway venv so
+build/publish tooling can never leak into (or be contaminated by) other work.
+
+```powershell
+py -3.11 -m venv .release-venv
+.\.release-venv\Scripts\Activate.ps1
+python --version          # confirm >= 3.11 (the package requires-python)
+```
+
+> If PowerShell blocks the activation script, allow it for this process only:
+> `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`.
+
+## 3. Install build, twine, and test dependencies
+
+```powershell
+python -m pip install --upgrade pip
+python -m pip install build twine
+python -m pip install -e ".[dev]"     # pytest + the package itself
+```
+
+## 4. Remove previous build output
+
+Stale `build/`, `dist/`, or egg-info directories can smuggle old artifacts into
+a fresh upload. Delete them first.
+
+```powershell
+Remove-Item -Recurse -Force build, dist, *.egg-info -ErrorAction SilentlyContinue
+```
+
+## 5. Run the full test suite
+
+```powershell
+python -m pytest
+```
+
+All tests must pass. Because the package is installed (step 3), the
+`mneme` CLI is on `PATH`, so the Claude Code end-to-end tests
+(`tests/integrations/claude_code/test_hook_e2e.py`) run instead of skipping —
+including the compliant-Write / blocked-Write cases.
+
+## 6. Build both wheel and sdist
+
+```powershell
+python -m build
+```
+
+This produces two artifacts under `dist/`:
+
+- `mneme_hq-0.5.0-py3-none-any.whl` (wheel)
+- `mneme_hq-0.5.0.tar.gz` (sdist)
+
+## 7. Run `twine check`
+
+```powershell
+python -m twine check dist/*
+```
+
+Both artifacts must report `PASSED` (valid metadata, renderable README).
+
+## 8. Inspect the built artifacts
+
+Confirm exactly the two expected files exist and nothing stale remains:
+
+```powershell
+Get-ChildItem dist
+```
+
+## 9. Confirm package name and version
+
+```powershell
+python -m pip show mneme-hq        # Name: mneme-hq   Version: 0.5.0
+```
+
+The filenames in `dist/` must also carry `0.5.0`. If they do not, the version in
+`pyproject.toml` was not bumped — stop and fix it.
+
+## 10. Confirm the wheel contains both console scripts
+
+The wheel's `entry_points.txt` must declare **both** console scripts:
+
+```
+mneme = mneme.cli:main
+mneme-hook = mneme.integrations.claude_code.hook:cli_main
+```
+
+The packaging contract test verifies this automatically against the wheel you
+just built:
+
+```powershell
+python -m pytest tests/test_packaging_contract.py -v
+```
+
+`test_built_wheel_contains_both_console_scripts` runs (rather than skipping)
+because `dist/` now holds a wheel. For a manual cross-check:
+
+```powershell
+python -c "import zipfile,glob; w=glob.glob('dist/mneme_hq-*.whl')[0]; z=zipfile.ZipFile(w); print(next(z.read(n).decode('utf-8') for n in z.namelist() if n.endswith('entry_points.txt')))"
+```
+
+Do not proceed unless both scripts are present.
+
+## 11. Tag the exact commit used for the build
+
+Tag the commit you just built and tested — not a later one.
+
+```powershell
+git tag -a v0.5.0 -m "mneme-hq 0.5.0"
+git push origin v0.5.0
+```
+
+## 12. Upload only the verified wheel and sdist
+
+Use a **project-scoped** PyPI API token (scoped to the `mneme-hq` project, not an
+account-wide token). Provide it via environment variables so it never lands in
+shell history or a config file:
+
+```powershell
+$env:TWINE_USERNAME = "__token__"
+$env:TWINE_PASSWORD = "pypi-...your-project-scoped-token..."
+
+python -m twine upload dist/mneme_hq-0.5.0-py3-none-any.whl dist/mneme_hq-0.5.0.tar.gz
+```
+
+Upload the two named artifacts explicitly — not `dist/*` — so nothing unexpected
+in `dist/` can be published by accident.
+
+## 13. Clean the token from the environment
+
+Remove the token from the session immediately after upload:
+
+```powershell
+Remove-Item Env:TWINE_USERNAME, Env:TWINE_PASSWORD
+```
+
+Then close the elevated/publish shell. If the token was ever echoed or logged,
+revoke it in the PyPI project settings and issue a new one.
+
+## 14. Validate the public package from a clean `pipx` environment
+
+Verify what PyPI actually serves — from a *fresh* environment, not the build
+venv (which already has the local package installed).
+
+```powershell
+deactivate
+pipx install "mneme-hq==0.5.0"
+mneme --help
+mneme-hook --help          # both console scripts resolve on PATH
+```
+
+`pipx` installs into an isolated environment, so this proves the published
+wheel — not your local checkout — provides both entry points.
+
+## 15. Repeat Claude Code plugin strict validation
+
+```powershell
+claude plugin validate .\integrations\claude-code-plugin --strict
+```
+
+Must pass `--strict` (valid manifest, semver version `0.1.0`, exec-form hook).
+
+## 16. Repeat the compliant-Write and blocked-Write tests
+
+With the published package on `PATH` (via `pipx`), re-run the end-to-end hook
+tests against the real binary to confirm enforcement works from the public
+install:
+
+```powershell
+python -m pytest tests/integrations/claude_code/test_hook_e2e.py -v
+```
+
+A compliant Write is allowed (exit `0`); a violating Write is blocked (exit `2`)
+in strict mode.
+
+## 17. Create the GitHub release — only after public validation succeeds
+
+Only now, once the public package validates end to end, publish the GitHub
+release for the `v0.5.0` tag:
+
+```powershell
+gh release create v0.5.0 --title "mneme-hq 0.5.0" --notes-file docs/releases/v0.5.0.md
+```
+
+---
+
+## Post-merge publication checklist
+
+Run in order. Do not advance past a failing step.
+
+- [ ] `main` is clean and at the release-alignment squash commit.
+- [ ] Isolated release venv created; Python >= 3.11 confirmed.
+- [ ] `build`, `twine`, and `.[dev]` installed.
+- [ ] `build/`, `dist/`, `*.egg-info` removed.
+- [ ] Full test suite passes (with the package installed, e2e hook tests run).
+- [ ] Wheel + sdist built.
+- [ ] `twine check dist/*` → both PASSED.
+- [ ] `dist/` inspected — exactly the two expected artifacts.
+- [ ] `pip show mneme-hq` → name `mneme-hq`, version `0.5.0`.
+- [ ] Wheel declares both console scripts (`test_packaging_contract.py`).
+- [ ] `v0.5.0` tag pushed on the exact built commit.
+- [ ] Uploaded only the named wheel + sdist with a project-scoped token.
+- [ ] Token removed from the environment.
+- [ ] `pipx install "mneme-hq==0.5.0"` → `mneme` and `mneme-hook` both resolve.
+- [ ] `claude plugin validate ... --strict` passes.
+- [ ] Compliant-Write allowed / violating-Write blocked, from the public install.
+- [ ] GitHub release created for `v0.5.0`.
+- [ ] **Only then:** update the plugin README to drop the install workaround and
+      advertise `pipx install "mneme-hq>=0.5.0"` (a separate, follow-up change —
+      the README is intentionally left unchanged in the alignment PR).

--- a/mneme-project-memory/docs/releases/RELEASING.md
+++ b/mneme-project-memory/docs/releases/RELEASING.md
@@ -57,6 +57,12 @@ python --version          # confirm >= 3.11 (the package requires-python)
 > If PowerShell blocks the activation script, allow it for this process only:
 > `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`.
 
+**Keep this same PowerShell session open through the entire procedure** — it
+holds the `$releaseVenv` variable and the activated venv. The session is
+deactivated exactly once (step 13, before the clean `pipx` validation) and the
+release venv is removed in step 17; only then do you close the shell. Do not
+close the shell after upload.
+
 ## 3. Install build, twine, and test dependencies
 
 ```powershell
@@ -153,29 +159,43 @@ git push origin v0.5.0
 ## 11. Upload only the verified wheel and sdist
 
 Use a **project-scoped** PyPI API token (scoped to the `mneme-hq` project, not an
-account-wide token). Provide it via environment variables so it never lands in
-shell history or a config file:
+account-wide token). Pass only the username on the command line and let Twine
+prompt for the token at its **hidden password prompt** — do not put the token in
+the command:
 
 ```powershell
-$env:TWINE_USERNAME = "__token__"
-$env:TWINE_PASSWORD = "pypi-...your-project-scoped-token..."
-
-python -m twine upload dist/mneme_hq-0.5.0-py3-none-any.whl dist/mneme_hq-0.5.0.tar.gz
+python -m twine upload `
+  --username __token__ `
+  dist/mneme_hq-0.5.0-py3-none-any.whl `
+  dist/mneme_hq-0.5.0.tar.gz
 ```
 
 Upload the two named artifacts explicitly — not `dist/*` — so nothing unexpected
 in `dist/` can be published by accident.
 
-## 12. Clean the token from the environment
+Enter the project-scoped PyPI API token **only at Twine's password prompt**. The
+token must never be placed in:
 
-Remove the token from the session immediately after upload:
+- a PowerShell command (or any command line);
+- the `TWINE_PASSWORD` environment variable;
+- shell history;
+- a script;
+- a repository file;
+- a Twine config file (e.g. `~/.pypirc`).
 
-```powershell
-Remove-Item Env:TWINE_USERNAME, Env:TWINE_PASSWORD
-```
+The password prompt reads the token directly and does not echo it, so it never
+enters your PowerShell history. If the token is ever pasted into a command,
+echoed, or logged anywhere, revoke it in the PyPI project settings and issue a
+new one.
 
-Then close the elevated/publish shell. If the token was ever echoed or logged,
-revoke it in the PyPI project settings and issue a new one.
+## 12. Confirm the token was not persisted
+
+Because the token was typed only at Twine's hidden password prompt, there is
+nothing to unset — it was never assigned to an environment variable, a command,
+a script, a config file, or a repository file. Do **not** close this shell:
+later steps still need the active session and the `$releaseVenv` variable. If the
+token was ever echoed or logged, revoke it in PyPI and issue a new one before
+continuing.
 
 ## 13. Validate the public package from a clean `pipx` environment
 
@@ -310,15 +330,17 @@ gh release create v0.5.0 `
 ## 17. Remove the temporary release environment
 
 Tear down the external release venv created in step 2 and confirm the working
-tree is clean (the venv lived outside the repo, so nothing should remain):
+tree is clean (the venv lived outside the repo, so nothing should remain). The
+venv was already deactivated once in step 13 (before the clean `pipx`
+validation), so do not `deactivate` again here:
 
 ```powershell
-deactivate
 Remove-Item -Recurse -Force $releaseVenv -ErrorAction SilentlyContinue
 git status --short
 ```
 
-`git status --short` must report nothing.
+`git status --short` must report nothing. Only now — after cleanup — is it safe
+to close the PowerShell session.
 
 ---
 
@@ -336,14 +358,15 @@ Run in order. Do not advance past a failing step.
 - [ ] `dist/` inspected — exactly the two expected artifacts.
 - [ ] **Artifact contract** (`test_packaging_contract.py` with `dist/` present): exactly one `mneme_hq-0.5.0-*.whl` + one `mneme_hq-0.5.0.tar.gz`; wheel METADATA and sdist PKG-INFO both declare `Name: mneme-hq` / `Version: 0.5.0`; wheel `entry_points.txt` is exactly the two console scripts. (`pip show` is only a source-env sanity check, not artifact inspection.)
 - [ ] `v0.5.0` tag pushed on the exact built commit.
-- [ ] Uploaded only the named wheel + sdist with a project-scoped token.
-- [ ] Token removed from the environment.
+- [ ] Uploaded only the named wheel + sdist; project-scoped token entered **only at Twine's hidden password prompt** (never in a command, `TWINE_PASSWORD`, history, script, repo file, or Twine config).
+- [ ] Same PowerShell session still open (token was never persisted, so nothing to unset).
+- [ ] `deactivate` run exactly once (step 13) before the clean `pipx` validation.
 - [ ] Clean `pipx`: `pipx uninstall mneme-hq` then `pipx install "mneme-hq==0.5.0"`; `Get-Command mneme` and `Get-Command mneme-hook` both resolve into the pipx env; `mneme --help` works (do **not** run `mneme-hook --help`).
 - [ ] `claude.cmd plugin validate $pluginPath --strict` passes; `claude.cmd --plugin-dir $pluginPath` loads the plugin (with `MNEME_HOOK_MODE=strict`).
 - [ ] Claude Code smoke tests: compliant Write (`encoding="utf-8"`) succeeds; blocked Write (no `encoding=`) is blocked by the `PreToolUse` hook.
 - [ ] Smoke artifacts removed, `MNEME_HOOK_MODE` cleared, `git status --short` clean.
 - [ ] GitHub release created for `v0.5.0` (`--notes-file .\mneme-project-memory\docs\releases\v0.5.0.md`, from repo root).
-- [ ] Temporary release venv removed; `git status --short` clean.
+- [ ] Temporary release venv removed (no second `deactivate`); `git status --short` clean; **then** close the shell.
 - [ ] **Only then:** update the plugin README to drop the install workaround and
       advertise `pipx install "mneme-hq>=0.5.0"` (a separate, follow-up change —
       the README is intentionally left unchanged in the alignment PR).

--- a/mneme-project-memory/docs/releases/RELEASING.md
+++ b/mneme-project-memory/docs/releases/RELEASING.md
@@ -39,9 +39,18 @@ a feature branch, a dirty tree, or a detached checkout.
 Never build or publish from your day-to-day interpreter. Use a throwaway venv so
 build/publish tooling can never leak into (or be contaminated by) other work.
 
+Create it **outside the repository** — a venv inside the working tree is not
+ignored and would make the later clean-tree check (`git status --short`) fail.
+Do not add a `.gitignore` rule just for the release environment; keep it out of
+the tree entirely and clean it up explicitly in step 17.
+
 ```powershell
-py -3.11 -m venv .release-venv
-.\.release-venv\Scripts\Activate.ps1
+$releaseVenv = Join-Path $env:TEMP "mneme-hq-release-0.5.0"
+
+Remove-Item -Recurse -Force $releaseVenv -ErrorAction SilentlyContinue
+py -3.11 -m venv $releaseVenv
+& "$releaseVenv\Scripts\Activate.ps1"
+
 python --version          # confirm >= 3.11 (the package requires-python)
 ```
 
@@ -103,41 +112,36 @@ Confirm exactly the two expected files exist and nothing stale remains:
 Get-ChildItem dist
 ```
 
-## 9. Confirm package name and version
+## 9. Verify package name, version, and console scripts from the artifacts
 
-```powershell
-python -m pip show mneme-hq        # Name: mneme-hq   Version: 0.5.0
-```
-
-The filenames in `dist/` must also carry `0.5.0`. If they do not, the version in
-`pyproject.toml` was not bumped — stop and fix it.
-
-## 10. Confirm the wheel contains both console scripts
-
-The wheel's `entry_points.txt` must declare **both** console scripts:
-
-```
-mneme = mneme.cli:main
-mneme-hook = mneme.integrations.claude_code.hook:cli_main
-```
-
-The packaging contract test verifies this automatically against the wheel you
-just built:
+**The packaging contract test is the authoritative check.** With `dist/`
+populated (step 6), run it against the built wheel and sdist:
 
 ```powershell
 python -m pytest tests/test_packaging_contract.py -v
 ```
 
-`test_built_wheel_contains_both_console_scripts` runs (rather than skipping)
-because `dist/` now holds a wheel. For a manual cross-check:
+It asserts, directly from the artifacts:
 
-```powershell
-python -c "import zipfile,glob; w=glob.glob('dist/mneme_hq-*.whl')[0]; z=zipfile.ZipFile(w); print(next(z.read(n).decode('utf-8') for n in z.namelist() if n.endswith('entry_points.txt')))"
-```
+- exactly one `mneme_hq-0.5.0-*.whl` and exactly one `mneme_hq-0.5.0.tar.gz`;
+- the wheel `*.dist-info/METADATA` declares `Name: mneme-hq` and
+  `Version: 0.5.0`;
+- the sdist `PKG-INFO` declares the same name and version;
+- the wheel `entry_points.txt` `[console_scripts]` is *exactly*:
+  ```
+  mneme = mneme.cli:main
+  mneme-hook = mneme.integrations.claude_code.hook:cli_main
+  ```
 
-Do not proceed unless both scripts are present.
+The declared version comes from `pyproject.toml`, so the test also proves the
+artifacts match the version you intend to ship. Do not proceed unless it passes.
 
-## 11. Tag the exact commit used for the build
+> `python -m pip show mneme-hq` (`Name: mneme-hq`, `Version: 0.5.0`) is only a
+> **source-environment sanity check** — it reports whatever is installed in the
+> active venv (the editable source from step 3), **not** the contents of the
+> built artifacts. It is not artifact inspection; the contract test above is.
+
+## 10. Tag the exact commit used for the build
 
 Tag the commit you just built and tested — not a later one.
 
@@ -146,7 +150,7 @@ git tag -a v0.5.0 -m "mneme-hq 0.5.0"
 git push origin v0.5.0
 ```
 
-## 12. Upload only the verified wheel and sdist
+## 11. Upload only the verified wheel and sdist
 
 Use a **project-scoped** PyPI API token (scoped to the `mneme-hq` project, not an
 account-wide token). Provide it via environment variables so it never lands in
@@ -162,7 +166,7 @@ python -m twine upload dist/mneme_hq-0.5.0-py3-none-any.whl dist/mneme_hq-0.5.0.
 Upload the two named artifacts explicitly — not `dist/*` — so nothing unexpected
 in `dist/` can be published by accident.
 
-## 13. Clean the token from the environment
+## 12. Clean the token from the environment
 
 Remove the token from the session immediately after upload:
 
@@ -173,7 +177,7 @@ Remove-Item Env:TWINE_USERNAME, Env:TWINE_PASSWORD
 Then close the elevated/publish shell. If the token was ever echoed or logged,
 revoke it in the PyPI project settings and issue a new one.
 
-## 14. Validate the public package from a clean `pipx` environment
+## 13. Validate the public package from a clean `pipx` environment
 
 Verify what PyPI actually serves — from a *fresh*, isolated environment, not the
 build venv (which already has the local source package installed). Uninstall
@@ -199,7 +203,7 @@ Notes:
 - Only `mneme` has a `--help`. **Do not run `mneme-hook --help`** — `mneme-hook`
   is the Claude Code hook entrypoint: it reads a hook event from **stdin**, so
   invoking it interactively (with or without `--help`) blocks waiting for EOF.
-  Its real validation is the Claude Code smoke test in steps 15–16.
+  Its real validation is the Claude Code smoke test in steps 14–15.
 
 > The pytest end-to-end tests in
 > `tests/integrations/claude_code/test_hook_e2e.py` are **source-level
@@ -210,7 +214,7 @@ Notes:
 > public one. Keep running them (step 5) as regression coverage, but validate
 > the *published* package only through the real plugin path below.
 
-## 15. Validate the plugin with Claude Code strict validation
+## 14. Validate the plugin with Claude Code strict validation
 
 This and the next step are the **real** public-package validation: they exercise
 the `pipx`-installed `mneme` / `mneme-hook` commands through the actual Claude
@@ -234,9 +238,9 @@ claude.cmd --plugin-dir $pluginPath
 version `0.1.0`, exec-form hook). `claude.cmd --plugin-dir $pluginPath` loads the
 plugin into a Claude Code session so you can run the smoke tests below.
 
-## 16. Run the compliant-Write and blocked-Write smoke tests through Claude Code
+## 15. Run the compliant-Write and blocked-Write smoke tests through Claude Code
 
-Inside the Claude Code session started in step 15, issue the two prompts below
+Inside the Claude Code session started in step 14, issue the two prompts below
 verbatim. These drive the real `PreToolUse` hook (published `mneme-hook` →
 published `mneme check`), which is what actually validates the public package.
 
@@ -291,14 +295,30 @@ git status --short
 `git status --short` must report nothing (the clean Write is removed and the
 blocked Write was never created).
 
-## 17. Create the GitHub release — only after public validation succeeds
+## 16. Create the GitHub release — only after public validation succeeds
 
 Only now, once the public package validates end to end, publish the GitHub
-release for the `v0.5.0` tag:
+release for the `v0.5.0` tag. Run this from the **repository root** (the same
+place as the smoke tests), so the notes path is repository-root-relative:
 
 ```powershell
-gh release create v0.5.0 --title "mneme-hq 0.5.0" --notes-file docs/releases/v0.5.0.md
+gh release create v0.5.0 `
+  --title "mneme-hq 0.5.0" `
+  --notes-file .\mneme-project-memory\docs\releases\v0.5.0.md
 ```
+
+## 17. Remove the temporary release environment
+
+Tear down the external release venv created in step 2 and confirm the working
+tree is clean (the venv lived outside the repo, so nothing should remain):
+
+```powershell
+deactivate
+Remove-Item -Recurse -Force $releaseVenv -ErrorAction SilentlyContinue
+git status --short
+```
+
+`git status --short` must report nothing.
 
 ---
 
@@ -307,15 +327,14 @@ gh release create v0.5.0 --title "mneme-hq 0.5.0" --notes-file docs/releases/v0.
 Run in order. Do not advance past a failing step.
 
 - [ ] `main` is clean and at the release-alignment squash commit.
-- [ ] Isolated release venv created; Python >= 3.11 confirmed.
+- [ ] Isolated release venv created **outside the repo** (`$env:TEMP`); Python >= 3.11 confirmed.
 - [ ] `build`, `twine`, and `.[dev]` installed.
 - [ ] `build/`, `dist/`, `*.egg-info` removed.
 - [ ] Full test suite passes (with the package installed, e2e hook tests run).
 - [ ] Wheel + sdist built.
 - [ ] `twine check dist/*` → both PASSED.
 - [ ] `dist/` inspected — exactly the two expected artifacts.
-- [ ] `pip show mneme-hq` → name `mneme-hq`, version `0.5.0`.
-- [ ] Wheel declares both console scripts (`test_packaging_contract.py`).
+- [ ] **Artifact contract** (`test_packaging_contract.py` with `dist/` present): exactly one `mneme_hq-0.5.0-*.whl` + one `mneme_hq-0.5.0.tar.gz`; wheel METADATA and sdist PKG-INFO both declare `Name: mneme-hq` / `Version: 0.5.0`; wheel `entry_points.txt` is exactly the two console scripts. (`pip show` is only a source-env sanity check, not artifact inspection.)
 - [ ] `v0.5.0` tag pushed on the exact built commit.
 - [ ] Uploaded only the named wheel + sdist with a project-scoped token.
 - [ ] Token removed from the environment.
@@ -323,7 +342,8 @@ Run in order. Do not advance past a failing step.
 - [ ] `claude.cmd plugin validate $pluginPath --strict` passes; `claude.cmd --plugin-dir $pluginPath` loads the plugin (with `MNEME_HOOK_MODE=strict`).
 - [ ] Claude Code smoke tests: compliant Write (`encoding="utf-8"`) succeeds; blocked Write (no `encoding=`) is blocked by the `PreToolUse` hook.
 - [ ] Smoke artifacts removed, `MNEME_HOOK_MODE` cleared, `git status --short` clean.
-- [ ] GitHub release created for `v0.5.0`.
+- [ ] GitHub release created for `v0.5.0` (`--notes-file .\mneme-project-memory\docs\releases\v0.5.0.md`, from repo root).
+- [ ] Temporary release venv removed; `git status --short` clean.
 - [ ] **Only then:** update the plugin README to drop the install workaround and
       advertise `pipx install "mneme-hq>=0.5.0"` (a separate, follow-up change —
       the README is intentionally left unchanged in the alignment PR).

--- a/mneme-project-memory/docs/releases/v0.5.0.md
+++ b/mneme-project-memory/docs/releases/v0.5.0.md
@@ -1,0 +1,145 @@
+# v0.5.0 — Installable Claude Code plugin + `mneme init`
+
+**Mneme is now installable as a first-class Claude Code plugin, and ships a
+one-command project scaffolder.**
+
+This is the first minor release since v0.4.0 (the architectural-compiler
+foundation). It adds two new backwards-compatible, user-facing capabilities and
+realigns the published PyPI package with the hook-reliability fixes that were
+tagged on GitHub but never reached PyPI.
+
+---
+
+## What's new
+
+### `mneme init`
+
+```bash
+mneme init                     # writes .mneme/project_memory.json
+mneme init --path ./mem.json   # custom location
+mneme init --force             # overwrite an existing file
+```
+
+Scaffolds a valid, empty, neutral `project_memory.json` — a minimal skeleton
+(`meta` + empty `items` / `examples` / `decisions`) that round-trips through
+`MemoryStore.load()` and passes `mneme check` with nothing to enforce. No seeded
+decisions: every decision is enforceable, so sample content would create phantom
+rules. Refuses to overwrite unless `--force` is given.
+
+### Installable Claude Code plugin
+
+`integrations/claude-code-plugin/` bundles the enforcement hook, the `mneme`
+skill, and four namespaced slash commands (`/mneme:context`, `/mneme:check`,
+`/mneme:record`, `/mneme:review`) into a single distributable unit. The manifest
+declares plugin version **`0.1.0`** (versioned independently of the `mneme-hq`
+package) and a `mode` userConfig option (`strict` | `warn`, default `strict`).
+
+The plugin registers a `PreToolUse` hook on `Edit|Write|MultiEdit` using Claude
+Code's **exec form** — the bare console script, no shell:
+
+```json
+{ "type": "command", "command": "mneme-hook", "args": [], "timeout": 30 }
+```
+
+No shell string, no wrapper script, no interpreter probing. Claude Code resolves
+`mneme-hook` on `PATH` and spawns it directly, so the hook is
+platform-independent by construction.
+
+### Enforcement-mode resolution
+
+The Claude Code adapter resolves the enforcement mode with a fixed precedence:
+
+```
+MNEME_HOOK_MODE  >  CLAUDE_PLUGIN_OPTION_MODE  >  strict
+```
+
+The plugin's `mode` userConfig value reaches the hook subprocess as
+`CLAUDE_PLUGIN_OPTION_MODE`; an explicit `MNEME_HOOK_MODE` overrides it. An
+unrecognized value in either variable falls back to `strict`, so a typo can
+never silently disable enforcement — and a set-but-invalid explicit override
+does not fall through to the plugin option. Mode resolution stays inside the
+adapter (`resolve_mode()` in `mneme/integrations/claude_code/hook.py`).
+
+---
+
+## Fixed: PyPI metadata realignment
+
+v0.4.1 and v0.4.2 fixed the Claude Code hook (PATH lookup + exit-code
+propagation) and were tagged on GitHub — but the fixes never reached the
+published PyPI package metadata. **PyPI still serves `0.4.0`**, which has the
+exit-code propagation bug: a failed check could exit `0` and let a violating
+edit through in strict mode.
+
+Publishing `0.5.0` makes `pip install mneme-hq` deliver the reliable hook for
+the first time. The underlying fixes it carries forward:
+
+- `mneme/__main__.py` so `python -m mneme` dispatches and `sys.exit(main())`
+  propagates CLI exit codes (v0.4.2).
+- Hook subprocess uses `[sys.executable, "-m", "mneme", ...]` instead of a bare
+  `mneme`, so a missing Scripts directory on `PATH` (Windows Microsoft Store
+  Python) no longer makes the hook fail open silently (v0.4.1).
+
+---
+
+## Why 0.5.0 (not 0.4.3)
+
+The repository's demonstrated versioning is Semantic Versioning under a `0.x`
+series: new backwards-compatible capabilities take a **minor** bump, pure fixes
+take a **patch** bump.
+
+- v0.4.0 introduced a new capability (the ADR compiler) and took a minor bump.
+- v0.4.1 and v0.4.2 were pure hook fixes and took patch bumps.
+- The v0.4.0 release notes' own roadmap table reserves **v0.5** for the next
+  feature milestone.
+
+v0.5.0 adds two new user-facing capabilities (`mneme init`, the installable
+plugin) plus plugin mode configuration — new functionality, backwards
+compatible — so it is a minor release, not a patch.
+
+---
+
+## Tests and compatibility
+
+- `tests/test_cli_init.py` — 6 tests for the scaffolder.
+- `tests/integrations/claude_code/test_plugin_contract.py` — deterministic,
+  shell-free plugin manifest + hook-wiring contract.
+- `tests/integrations/claude_code/test_hook_mode.py` — mode precedence + strict
+  fallback.
+- `tests/integrations/claude_code/test_hook_e2e.py` — compliant/violating Write
+  and Edit against the real `mneme check` binary (skipped without `mneme` on
+  `PATH`).
+- `tests/test_packaging_contract.py` — both console scripts present in
+  `[project.scripts]` and (when built) in the wheel.
+- No regressions. `DecisionRetriever`, `ConflictDetector`, retrieval, and
+  enforcement semantics are unchanged.
+
+---
+
+## Migration
+
+None required. Both new capabilities are additive:
+
+- Existing `project_memory.json` workflows are unchanged; `mneme init` only
+  helps you create a new one.
+- The flat `integrations/claude-code/` integration still works; the plugin is a
+  packaged alternative form of it.
+
+---
+
+## Publishing
+
+This release note accompanies the release-alignment change. The package is
+**not** published by that change. The exact manual PyPI publication procedure
+and the post-merge checklist live in
+[`docs/releases/RELEASING.md`](./RELEASING.md). The plugin README's install
+workaround stays in place until `mneme-hq >= 0.5.0` is actually live on PyPI.
+
+---
+
+## Strategic framing
+
+| Version | Theme |
+|---|---|
+| v0.3 | Enforcement / governance checks |
+| v0.4 | Architectural compiler foundation |
+| **v0.5** | **Distribution: installable plugin, project scaffolding, reliable published hook** |

--- a/mneme-project-memory/docs/releases/v0.5.0.md
+++ b/mneme-project-memory/docs/releases/v0.5.0.md
@@ -75,9 +75,9 @@ adapter (`resolve_mode()` in `mneme/integrations/claude_code/hook.py`).
 
 v0.4.1 and v0.4.2 fixed the Claude Code hook (PATH lookup + exit-code
 propagation) and were tagged on GitHub — but the fixes never reached the
-published PyPI package metadata. **PyPI still serves `0.4.0`**, which has the
-exit-code propagation bug: a failed check could exit `0` and let a violating
-edit through in strict mode.
+published PyPI package metadata. **Before v0.5.0, PyPI served only `0.4.0`**,
+which has the exit-code propagation bug: a failed check could exit `0` and let a
+violating edit through in strict mode.
 
 Publishing `0.5.0` makes `pip install mneme-hq` deliver the reliable hook for
 the first time. The underlying fixes it carries forward:

--- a/mneme-project-memory/docs/releases/v0.5.0.md
+++ b/mneme-project-memory/docs/releases/v0.5.0.md
@@ -1,6 +1,6 @@
-# v0.5.0 — Installable Claude Code plugin + `mneme init`
+# v0.5.0 — Directory-ready Claude Code plugin + `mneme init`
 
-**Mneme is now installable as a first-class Claude Code plugin, and ships a
+**The repository now ships a directory-ready Claude Code plugin, and a
 one-command project scaffolder.**
 
 This is the first minor release since v0.4.0 (the architectural-compiler
@@ -26,13 +26,22 @@ Scaffolds a valid, empty, neutral `project_memory.json` — a minimal skeleton
 decisions: every decision is enforceable, so sample content would create phantom
 rules. Refuses to overwrite unless `--force` is given.
 
-### Installable Claude Code plugin
+### Directory-ready Claude Code plugin
 
 `integrations/claude-code-plugin/` bundles the enforcement hook, the `mneme`
 skill, and four namespaced slash commands (`/mneme:context`, `/mneme:check`,
-`/mneme:record`, `/mneme:review`) into a single distributable unit. The manifest
-declares plugin version **`0.1.0`** (versioned independently of the `mneme-hq`
-package) and a `mode` userConfig option (`strict` | `warn`, default `strict`).
+`/mneme:record`, `/mneme:review`) into a single plugin directory that Claude
+Code can load with `--plugin-dir` (or via a marketplace). The manifest declares
+plugin version **`0.1.0`** — correct for this first directory release, and
+versioned independently of the `mneme-hq` package — and a `mode` userConfig
+option (`strict` | `warn`, default `strict`). The plugin has not yet been
+publicly submitted to a marketplace.
+
+The plugin and the package are distinct artifacts. The `mneme-hq` PyPI package
+provides the `mneme` and `mneme-hook` runtime commands; the plugin *drives*
+those commands and expects them already on `PATH`. Installing the PyPI package
+does **not** install or enable the plugin, and loading the plugin does not
+install the package.
 
 The plugin registers a `PreToolUse` hook on `Edit|Write|MultiEdit` using Claude
 Code's **exec form** — the bare console script, no shell:
@@ -92,7 +101,7 @@ take a **patch** bump.
 - The v0.4.0 release notes' own roadmap table reserves **v0.5** for the next
   feature milestone.
 
-v0.5.0 adds two new user-facing capabilities (`mneme init`, the installable
+v0.5.0 adds two new user-facing capabilities (`mneme init`, the directory-ready
 plugin) plus plugin mode configuration — new functionality, backwards
 compatible — so it is a minor release, not a patch.
 
@@ -122,7 +131,7 @@ None required. Both new capabilities are additive:
 - Existing `project_memory.json` workflows are unchanged; `mneme init` only
   helps you create a new one.
 - The flat `integrations/claude-code/` integration still works; the plugin is a
-  packaged alternative form of it.
+  plugin-directory form of it (loaded via `--plugin-dir`), not a replacement.
 
 ---
 
@@ -142,4 +151,4 @@ workaround stays in place until `mneme-hq >= 0.5.0` is actually live on PyPI.
 |---|---|
 | v0.3 | Enforcement / governance checks |
 | v0.4 | Architectural compiler foundation |
-| **v0.5** | **Distribution: installable plugin, project scaffolding, reliable published hook** |
+| **v0.5** | **Distribution: directory-ready plugin, project scaffolding, reliable published hook** |

--- a/mneme-project-memory/pyproject.toml
+++ b/mneme-project-memory/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mneme-hq"
-version = "0.4.0"
+version = "0.5.0"
 description = "Portable project memory and evaluation nucleus for AI workflows"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mneme-project-memory/tests/integrations/claude_code/test_hook_e2e.py
+++ b/mneme-project-memory/tests/integrations/claude_code/test_hook_e2e.py
@@ -43,6 +43,18 @@ def _envelope(cwd, file_path, new_string):
     })
 
 
+def _write_envelope(cwd, file_path, content):
+    return json.dumps({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "cwd": str(cwd),
+        "tool_input": {
+            "file_path": str(file_path),
+            "content": content,
+        },
+    })
+
+
 @pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
 def test_violation_blocks(project):
     cwd, target = project
@@ -57,4 +69,24 @@ def test_violation_blocks(project):
 def test_compliant_passes(project):
     cwd, target = project
     rc = main(stdin=io.StringIO(_envelope(cwd, target, "import sqlite3")))
+    assert rc == 0
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_violating_write_blocks(project):
+    cwd, target = project
+    err = io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_write_envelope(cwd, target, "import psycopg2\n")),
+        stderr=err,
+    )
+    assert rc == 2
+    output = err.getvalue()
+    assert "test_001" in output or "psycopg2" in output
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_compliant_write_passes(project):
+    cwd, target = project
+    rc = main(stdin=io.StringIO(_write_envelope(cwd, target, "import sqlite3\n")))
     assert rc == 0

--- a/mneme-project-memory/tests/test_packaging_contract.py
+++ b/mneme-project-memory/tests/test_packaging_contract.py
@@ -1,23 +1,29 @@
 """Deterministic packaging contract for the ``mneme-hq`` distribution.
 
-Guards the two console scripts that the Claude Code integration depends on:
+Two layers:
 
-    mneme      = mneme.cli:main
-    mneme-hook = mneme.integrations.claude_code.hook:cli_main
+1. **Source declaration** (always runs, no build): ``pyproject.toml``
+   ``[project.scripts]`` declares exactly the two console scripts the Claude
+   Code integration depends on::
 
-The primary assertion reads the source of truth (``pyproject.toml``
-``[project.scripts]``) with no build step, so it runs in the ordinary test
-suite. When a built wheel is present under ``dist/`` (i.e. during a release
-build) the same two entry points are verified inside the wheel's
-``entry_points.txt`` as well, catching any drift between the declared metadata
-and the packaged artifact.
+       mneme      = mneme.cli:main
+       mneme-hook = mneme.integrations.claude_code.hook:cli_main
 
-Per ADR-009 every text read here pins ``encoding="utf-8"`` explicitly
-(``tomllib`` requires binary mode, and the wheel member bytes are decoded with
-an explicit codec).
+2. **Built-artifact contract** (runs when ``dist/`` holds a build): the wheel
+   and sdist are inspected directly. This is the authoritative verification of
+   the packaged **name**, **version**, and **entry points** — ``pip show`` only
+   reports whatever is installed in the current environment (typically the
+   editable source), so it cannot prove what the artifacts contain.
+
+Per ADR-009 every text decoded from an archive here pins ``encoding="utf-8"``
+explicitly (``tomllib`` requires binary mode, and archive members are decoded
+with an explicit codec).
 """
 from __future__ import annotations
 
+import configparser
+import email
+import tarfile
 import tomllib
 import zipfile
 from pathlib import Path
@@ -25,6 +31,9 @@ from pathlib import Path
 import pytest
 
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = PACKAGE_ROOT / "dist"
+
+PACKAGE_NAME = "mneme-hq"
 
 # The contract: script name -> entry-point target.
 EXPECTED_SCRIPTS = {
@@ -33,15 +42,20 @@ EXPECTED_SCRIPTS = {
 }
 
 
-def _load_pyproject_scripts() -> dict[str, str]:
+def _load_pyproject() -> dict:
     # tomllib.load requires a binary file object; no text encoding applies.
     with (PACKAGE_ROOT / "pyproject.toml").open("rb") as fh:
-        data = tomllib.load(fh)
-    return data["project"]["scripts"]
+        return tomllib.load(fh)
 
+
+def _declared_version() -> str:
+    return _load_pyproject()["project"]["version"]
+
+
+# ── Layer 1: source declaration ──────────────────────────────────────────────
 
 def test_pyproject_declares_both_console_scripts():
-    scripts = _load_pyproject_scripts()
+    scripts = _load_pyproject()["project"]["scripts"]
     for name, target in EXPECTED_SCRIPTS.items():
         assert scripts.get(name) == target, (
             f"[project.scripts] must declare {name} = {target!r}, "
@@ -51,33 +65,88 @@ def test_pyproject_declares_both_console_scripts():
 
 def test_pyproject_declares_no_unexpected_console_scripts():
     # A surprise console script is a packaging regression worth surfacing.
-    assert set(_load_pyproject_scripts()) == set(EXPECTED_SCRIPTS)
+    assert set(_load_pyproject()["project"]["scripts"]) == set(EXPECTED_SCRIPTS)
 
 
-def _built_wheel() -> Path | None:
-    dist = PACKAGE_ROOT / "dist"
-    if not dist.is_dir():
-        return None
-    wheels = sorted(dist.glob("mneme_hq-*.whl"))
-    return wheels[-1] if wheels else None
+# ── Layer 2: built-artifact contract ─────────────────────────────────────────
+#
+# Skipped unless a matching build is present under dist/ (release flow):
+#   cd mneme-project-memory
+#   python -m build
+
+def _require_dist() -> None:
+    if not DIST_DIR.is_dir():
+        pytest.skip("no dist/ directory (run `python -m build` first)")
 
 
-def test_built_wheel_contains_both_console_scripts():
-    """Verify the packaged artifact, not just the declaration.
+def _sole_artifact(pattern: str) -> Path:
+    _require_dist()
+    matches = sorted(DIST_DIR.glob(pattern))
+    assert len(matches) == 1, (
+        f"expected exactly one artifact matching {pattern!r} under dist/, "
+        f"found {[p.name for p in matches]}"
+    )
+    return matches[0]
 
-    Skipped unless a wheel has been built into ``dist/`` (release flow).
-    """
-    wheel = _built_wheel()
-    if wheel is None:
-        pytest.skip("no built wheel under dist/ (run `python -m build` first)")
 
+def _parse_metadata(raw: str) -> email.message.Message:
+    # METADATA / PKG-INFO are RFC 822 headers.
+    return email.message_from_string(raw)
+
+
+def test_wheel_filename_matches_declared_version():
+    version = _declared_version()
+    wheel = _sole_artifact(f"mneme_hq-{version}-*.whl")
+    assert wheel.name.startswith(f"mneme_hq-{version}-")
+
+
+def test_sdist_filename_matches_declared_version():
+    version = _declared_version()
+    _sole_artifact(f"mneme_hq-{version}.tar.gz")
+
+
+def test_wheel_metadata_declares_name_and_version():
+    version = _declared_version()
+    wheel = _sole_artifact(f"mneme_hq-{version}-*.whl")
     with zipfile.ZipFile(wheel) as zf:
-        entry_members = [n for n in zf.namelist() if n.endswith("entry_points.txt")]
-        assert entry_members, f"{wheel.name} has no entry_points.txt"
-        raw = zf.read(entry_members[0]).decode("utf-8")
+        members = [n for n in zf.namelist() if n.endswith(".dist-info/METADATA")]
+        assert len(members) == 1, f"{wheel.name}: expected one METADATA, got {members}"
+        meta = _parse_metadata(zf.read(members[0]).decode("utf-8"))
+    assert meta.get("Name") == PACKAGE_NAME, f"wheel Name = {meta.get('Name')!r}"
+    assert meta.get("Version") == version, f"wheel Version = {meta.get('Version')!r}"
 
-    for name, target in EXPECTED_SCRIPTS.items():
-        assert f"{name} = {target}" in raw, (
-            f"{wheel.name} entry_points.txt is missing {name} = {target!r}\n"
-            f"{raw}"
-        )
+
+def test_sdist_pkg_info_declares_name_and_version():
+    version = _declared_version()
+    sdist = _sole_artifact(f"mneme_hq-{version}.tar.gz")
+    with tarfile.open(sdist, "r:gz") as tf:
+        members = [n for n in tf.getnames() if n.endswith("/PKG-INFO")]
+        # The top-level PKG-INFO has the shallowest path.
+        members.sort(key=lambda n: n.count("/"))
+        assert members, f"{sdist.name}: no PKG-INFO found"
+        extracted = tf.extractfile(members[0])
+        assert extracted is not None, f"{sdist.name}: cannot read {members[0]}"
+        meta = _parse_metadata(extracted.read().decode("utf-8"))
+    assert meta.get("Name") == PACKAGE_NAME, f"sdist Name = {meta.get('Name')!r}"
+    assert meta.get("Version") == version, f"sdist Version = {meta.get('Version')!r}"
+
+
+def test_wheel_entry_points_are_exactly_the_two_console_scripts():
+    version = _declared_version()
+    wheel = _sole_artifact(f"mneme_hq-{version}-*.whl")
+    with zipfile.ZipFile(wheel) as zf:
+        members = [n for n in zf.namelist() if n.endswith("entry_points.txt")]
+        assert len(members) == 1, f"{wheel.name}: expected one entry_points.txt, got {members}"
+        raw = zf.read(members[0]).decode("utf-8")
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str  # preserve script-name case (e.g. mneme-hook)
+    parser.read_string(raw)
+    assert parser.has_section("console_scripts"), (
+        f"{wheel.name} entry_points.txt has no [console_scripts]:\n{raw}"
+    )
+    console_scripts = dict(parser.items("console_scripts"))
+    assert console_scripts == EXPECTED_SCRIPTS, (
+        f"{wheel.name} console_scripts = {console_scripts!r}, "
+        f"expected exactly {EXPECTED_SCRIPTS!r}"
+    )

--- a/mneme-project-memory/tests/test_packaging_contract.py
+++ b/mneme-project-memory/tests/test_packaging_contract.py
@@ -1,0 +1,83 @@
+"""Deterministic packaging contract for the ``mneme-hq`` distribution.
+
+Guards the two console scripts that the Claude Code integration depends on:
+
+    mneme      = mneme.cli:main
+    mneme-hook = mneme.integrations.claude_code.hook:cli_main
+
+The primary assertion reads the source of truth (``pyproject.toml``
+``[project.scripts]``) with no build step, so it runs in the ordinary test
+suite. When a built wheel is present under ``dist/`` (i.e. during a release
+build) the same two entry points are verified inside the wheel's
+``entry_points.txt`` as well, catching any drift between the declared metadata
+and the packaged artifact.
+
+Per ADR-009 every text read here pins ``encoding="utf-8"`` explicitly
+(``tomllib`` requires binary mode, and the wheel member bytes are decoded with
+an explicit codec).
+"""
+from __future__ import annotations
+
+import tomllib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+
+# The contract: script name -> entry-point target.
+EXPECTED_SCRIPTS = {
+    "mneme": "mneme.cli:main",
+    "mneme-hook": "mneme.integrations.claude_code.hook:cli_main",
+}
+
+
+def _load_pyproject_scripts() -> dict[str, str]:
+    # tomllib.load requires a binary file object; no text encoding applies.
+    with (PACKAGE_ROOT / "pyproject.toml").open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["scripts"]
+
+
+def test_pyproject_declares_both_console_scripts():
+    scripts = _load_pyproject_scripts()
+    for name, target in EXPECTED_SCRIPTS.items():
+        assert scripts.get(name) == target, (
+            f"[project.scripts] must declare {name} = {target!r}, "
+            f"got {scripts.get(name)!r}"
+        )
+
+
+def test_pyproject_declares_no_unexpected_console_scripts():
+    # A surprise console script is a packaging regression worth surfacing.
+    assert set(_load_pyproject_scripts()) == set(EXPECTED_SCRIPTS)
+
+
+def _built_wheel() -> Path | None:
+    dist = PACKAGE_ROOT / "dist"
+    if not dist.is_dir():
+        return None
+    wheels = sorted(dist.glob("mneme_hq-*.whl"))
+    return wheels[-1] if wheels else None
+
+
+def test_built_wheel_contains_both_console_scripts():
+    """Verify the packaged artifact, not just the declaration.
+
+    Skipped unless a wheel has been built into ``dist/`` (release flow).
+    """
+    wheel = _built_wheel()
+    if wheel is None:
+        pytest.skip("no built wheel under dist/ (run `python -m build` first)")
+
+    with zipfile.ZipFile(wheel) as zf:
+        entry_members = [n for n in zf.namelist() if n.endswith("entry_points.txt")]
+        assert entry_members, f"{wheel.name} has no entry_points.txt"
+        raw = zf.read(entry_members[0]).decode("utf-8")
+
+    for name, target in EXPECTED_SCRIPTS.items():
+        assert f"{name} = {target}" in raw, (
+            f"{wheel.name} entry_points.txt is missing {name} = {target!r}\n"
+            f"{raw}"
+        )


### PR DESCRIPTION
## Summary

Release-alignment for the `mneme-hq` Python package (`mneme-project-memory/`): cut **v0.5.0** metadata + documentation. **No code is published, tagged, or released here** — this PR only aligns the package for a subsequent manual publish.

**Plugin vs. package (corrected wording).** The repository now contains a **directory-ready** Claude Code plugin under `integrations/claude-code-plugin/` (loaded via `--plugin-dir` or a marketplace). The `mneme-hq` PyPI package supplies the `mneme` / `mneme-hook` runtime commands the plugin drives. Installing the package does **not** install or enable the plugin, and loading the plugin does not install the package. Manifest version `0.1.0` is correct for the plugin's first directory release; the plugin has not yet been publicly submitted.

## Version decision: 0.5.0 (confirmed, not 0.4.3)

The repo's **demonstrated** SemVer behavior under `0.x` is: new backwards-compatible capability → **minor** bump; pure fix → **patch** bump.

| Evidence | Bump |
|---|---|
| `v0.4.0` "Architectural Compiler Foundation" — added a new capability (ADR compiler), explicitly "backwards compatible" | minor (0.3.2 → 0.4.0) |
| `v0.4.1` — hook PATH fix only | patch |
| `v0.4.2` — module-exec / exit-code fix only | patch |
| `docs/releases/v0.4.0.md` roadmap table literally reserves **v0.5** for the next feature milestone | — |

This release adds two new user-facing capabilities (`mneme init`, the directory-ready Claude Code plugin) plus plugin mode configuration — new, backwards-compatible functionality. By the pattern above that is a **minor** release. `0.4.3` would misclassify new capabilities as a patch. **Conclusion: 0.5.0.** (Matches the stated expectation.)

## Files changed

- `mneme-project-memory/pyproject.toml` — version `0.4.0` → `0.5.0`.
- `mneme-project-memory/CHANGELOG.md` — moved `Unreleased` into a new `v0.5.0` section; kept an empty `Unreleased`; added entries for `mneme init`, the directory-ready plugin, exec-form `mneme-hook`, plugin manifest `0.1.0`, mode precedence (`MNEME_HOOK_MODE` > `CLAUDE_PLUGIN_OPTION_MODE` > `strict`), strict fallback on invalid mode, plugin contract validation, clean-Write-allowed / violating-Write-blocked validation, and the tagged-but-unpublished v0.4.1/v0.4.2 hook fixes.
- `mneme-project-memory/docs/releases/v0.5.0.md` — new release notes + version rationale.
- `mneme-project-memory/docs/releases/RELEASING.md` — **new**, exact manual PyPI publication procedure (PowerShell for Windows-specific steps) + post-merge checklist.
- `mneme-project-memory/tests/test_packaging_contract.py` — **new**, deterministic packaging contract. Always asserts `[project.scripts]` declares exactly the two console scripts. When a build is present under `dist/`, it also inspects the artifacts: exactly one `mneme_hq-0.5.0-*.whl` and one `mneme_hq-0.5.0.tar.gz`; the wheel `*.dist-info/METADATA` and sdist `PKG-INFO` both declare `Name: mneme-hq` / `Version: 0.5.0` (version read from `pyproject.toml`); and the wheel `entry_points.txt` `[console_scripts]` is exactly `mneme = mneme.cli:main` and `mneme-hook = mneme.integrations.claude_code.hook:cli_main`. All archive text decoded `encoding="utf-8"` (ADR-009).
- `mneme-project-memory/tests/integrations/claude_code/test_hook_e2e.py` — added compliant-Write / violating-Write e2e cases.

## Tests and build results

- **Full suite (no build):** `379 passed, 5 skipped` (the 5 artifact tests skip when `dist/` is absent).
- **Full suite with built artifacts present:** `384 passed` (the 5 artifact tests run).
- **Clean build:** `python -m build` → `mneme_hq-0.5.0-py3-none-any.whl` + `mneme_hq-0.5.0.tar.gz`.
- **`python -m twine check dist/*`:** both `PASSED`.
- **`python -m pytest tests/test_packaging_contract.py -v`:** `7 passed`. The artifact contract verifies, directly from the built files:
  - exactly one matching wheel (`mneme_hq-0.5.0-*.whl`);
  - exactly one matching sdist (`mneme_hq-0.5.0.tar.gz`);
  - wheel `*.dist-info/METADATA` → `Name: mneme-hq`, `Version: 0.5.0`;
  - sdist `PKG-INFO` → `Name: mneme-hq`, `Version: 0.5.0`;
  - wheel `entry_points.txt` `[console_scripts]` is exactly the two expected scripts:
    ```
    mneme = mneme.cli:main
    mneme-hook = mneme.integrations.claude_code.hook:cli_main
    ```
- **`pip show mneme-hq`** is only a **source-environment sanity check** (reports the editable install in the active venv), **not** artifact inspection — the contract test above is authoritative.
- **Encoding check (ADR-009):** `python scripts/check_encoding.py docs mneme-project-memory` → OK. New Python file I/O pins `encoding="utf-8"` (tomllib binary mode; archive members decoded explicitly).

## Constraints honored

- No publish, no tag, no GitHub release performed. ✅
- Plugin README install workaround **unchanged** until `mneme-hq >= 0.5.0` is live on PyPI. ✅
- Plugin manifest version left at `0.1.0`. ✅
- No PyPI CI workflow added; no auto-install; no telemetry; no LLM in the verdict path. ✅
- `DecisionRetriever` / `ConflictDetector` / core enforcement semantics untouched; mode resolution stays in the Claude Code adapter. ✅

## Confirmations

- **Publication was NOT performed.** Build/twine/artifact checks were run locally for verification only; nothing was uploaded, tagged, or released. Build artifacts are not committed.
- **The plugin README remains unchanged** until PyPI publication of `0.5.0`.

## Post-merge publication checklist

Full procedure in [`docs/releases/RELEASING.md`](mneme-project-memory/docs/releases/RELEASING.md). Summary:

- [ ] Clean `main` at the squash commit; isolated release venv (Python ≥ 3.11).
- [ ] Install `build`, `twine`, `.[dev]`; remove `build/` `dist/` `*.egg-info`.
- [ ] Full test suite passes (package installed → e2e hook tests run).
- [ ] Build wheel + sdist; `twine check dist/*` both PASSED; inspect `dist/`.
- [ ] **Artifact contract** (`python -m pytest tests/test_packaging_contract.py -v`, `dist/` present): one wheel + one sdist; wheel METADATA and sdist PKG-INFO both `mneme-hq` / `0.5.0`; wheel `entry_points.txt` exactly the two console scripts. (`pip show` is only a source-env sanity check.)
- [ ] Tag `v0.5.0` on the exact built commit.
- [ ] `twine upload` only the named wheel + sdist; enter the project-scoped token **only at Twine's hidden password prompt** (never in a command, `TWINE_PASSWORD`, history, script, repo file, or Twine config). Keep the same shell open; `deactivate` runs once before pipx validation; remove `$releaseVenv` and close the shell only after cleanup. PyPI artifacts are immutable.
- [ ] `pipx install "mneme-hq==0.5.0"` from clean → `mneme` and `mneme-hook` resolve.
- [ ] `claude plugin validate ... --strict` passes; compliant-Write allowed / violating-Write blocked from the public install.
- [ ] Create the GitHub release **only after** public validation succeeds.
- [ ] Only then, in a follow-up, update the plugin README to advertise `pipx install "mneme-hq>=0.5.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


