### PR TITLE
fix: replace raw YouTube iframe with facade on Liskov insight

### DIFF
--- a/scripts/embed_videos.py
+++ b/scripts/embed_videos.py
@@ -138,9 +138,12 @@ def replace_video_wrap(html: str, facade: str):
     ``facade`` (in place, preserving any surrounding intro copy). Returns
     (new_html, replaced). No-op (replaced=False) if no .video-wrap is present or
     a yt-facade already exists."""
-    if "yt-facade" in html or 'class="video-wrap"' not in html:
+    if "yt-facade" in html:
         return html, False
-    m = re.search(r'<div class="video-wrap"[^>]*>', html)
+    # Hand-written embeds have used both wrapper classes. Matching only
+    # .video-wrap silently skipped the .video-embed pages, leaving a raw
+    # auto-loading iframe in place.
+    m = re.search(r'<div class="(?:video-wrap|video-embed)"[^>]*>', html)
     if not m:
         return html, False
     start = m.start()

--- a/scripts/video_map.py
+++ b/scripts/video_map.py
@@ -7,6 +7,7 @@ VIDEO_MAP = {
     "concepts/governance-before-generation": ("tO_Z9rqXXfQ", True),
     "concepts/precedence-semantics": ("tktp6ik0Gxk", True),
     "insights/ai-native-engineering-intent-debt": ("nwSBZXolBhA", True),
+    "insights/barbara-liskov-python-encapsulation-ai-governance": ("qAKrMdUycb8", True),
     "insights/architectural-governance-across-heterogeneous-ai-coding-agents": ("xtTDcb2JB2c", True),
     "insights/autonomous-code-remediation-requires-architectural-governance": ("DDo0x1lkBNI", True),
     "insights/github-copilot-space-framework": ("Rjlzm0psfB4", True),

--- a/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
+++ b/site/insights/barbara-liskov-python-encapsulation-ai-governance/index.html
@@ -233,6 +233,7 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 </script>
 <!-- mneme:vendor:rb2b:end -->
 <!-- mneme:marketing-head:end -->
+  <link rel="stylesheet" href="/assets/css/video.css">
 </head>
 <body>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KL7FB67N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -272,8 +273,9 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 
     <p>The framing for this piece comes from a recent <a href="https://www.youtube.com/watch?v=T9CGjbPZeaM" rel="noopener">interview with Barbara Liskov on data abstraction, distributed systems, and the design problems she has spent her career on</a>. A widely-shared <a href="https://www.youtube.com/shorts/KZBX0NytylM" rel="noopener">&ldquo;Downsides of Python&rdquo; clip</a> pulled from that conversation surfaces a long-standing argument: Python allows you to express architectural boundaries, but it does not strongly enforce them. That argument is not new. It is significantly more important now than when she first made it.</p>
 
-    <div class="video-embed">
-      <iframe src="https://www.youtube.com/embed/qAKrMdUycb8" title="Barbara Liskov, 2008 ACM A.M. Turing Award Lecture: The Power of Abstraction" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe>
+    <div class="yt-facade" data-video-id="qAKrMdUycb8" data-title="Barbara Liskov’s Critique of Python Predicts the Governance Problem in AI Coding" role="button" tabindex="0" aria-label="Play video: Barbara Liskov’s Critique of Python Predicts the Governance Problem in AI Coding">
+      <img class="yt-facade__thumb" src="https://i.ytimg.com/vi/qAKrMdUycb8/maxresdefault.jpg" alt="" loading="lazy">
+      <span class="yt-facade__play" aria-hidden="true"></span>
     </div>
     <p class="video-caption">Barbara Liskov&rsquo;s 2008 ACM A.M. Turing Award Lecture, &ldquo;The Power of Abstraction&rdquo; &mdash; <a href="https://www.youtube.com/watch?v=qAKrMdUycb8" rel="noopener">watch on YouTube</a></p>
 
@@ -518,5 +520,6 @@ window.__mnemePixels.push({ done:false, cat:'visitor_id', fn:function () {
 <!-- mneme:marketing-body:end -->
 
 
+<script src="/assets/js/video.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
The single genuinely slow page on the site, found while verifying the
pagespeed collector in #227.

`/insights/barbara-liskov-python-encapsulation-ai-governance/` was the only page
still shipping a raw auto-loading YouTube iframe, which pulls the full YouTube
player on every load:

| | this page | insights avg |
|---|---|---|
| mobile | **48** (LCP 11.17s) | 81.5 (4.45s) |
| desktop | **87** | 98.1 |

Its run-to-run spread is tight (44-54), which is what makes it trustworthy —
almost every other per-page number in that sweep is dominated by measurement
noise (see #227). This is the one page where the signal is real.

## Root cause

Not a one-off hand edit — a gap in the facade rollout from #207. The page wraps
its embed in `.video-embed`, but `embed_videos.py` only matched `.video-wrap`,
so the page was silently skipped and never registered in `video_map.py`.

Fixed at the source rather than by hand-editing the page:

- Widen the matcher to accept both wrapper classes.
- Register the page in `video_map.py`, so the script owns it and the drift
  cannot recur unnoticed.

The page already carries VideoObject schema, so it registers as core (facade
only, no schema insert). Caption and schema preserved; re-run is a no-op
(`written=0 unchanged=21`).

## Verification

- Raw iframe gone, `yt-facade` present, VideoObject schema intact.
- Idempotent: second run writes nothing.
- check_encoding, check_insights, check_nav_footer all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)