### PR TITLE
[memory] realign package paths after flattening

### DIFF
--- a/.mneme/project_memory.json
+++ b/.mneme/project_memory.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "mneme-repo",
-    "description": "Canonical live enforcement memory for the public Mneme repo. Mneme uses this file to govern its own repo. The flagship demo file at mneme-project-memory/examples/project_memory.json is a snapshot for documentation only - this file is the source of truth.",
+    "description": "Canonical live enforcement memory for the public Mneme repo. Mneme uses this file to govern its own repo. The flagship demo file at examples/project_memory.json is a snapshot for documentation only - this file is the source of truth.",
     "version": "1.0.0",
     "owner": "Mneme HQ",
     "created": "2026-05-06"
@@ -43,7 +43,7 @@
       "id": "rule-bench-retrieval-coupling",
       "type": "rule",
       "title": "Benchmark harness and core retrieval cannot change in the same PR",
-      "content": "Changes to the benchmark harness (mneme-project-memory/examples/benchmarks, scripts that drive benchmarking) must not land in the same PR as changes to core retrieval (mneme.retriever, mneme.context_builder, mneme.evaluator, mneme.pipeline). Splitting these PRs prevents a regression in retrieval from being silently absorbed by a tuned harness, and preserves an auditable benchmark history.",
+      "content": "Changes to the benchmark harness (examples/benchmarks, scripts that drive benchmarking) must not land in the same PR as changes to core retrieval (mneme.retriever, mneme.context_builder, mneme.evaluator, mneme.pipeline). Splitting these PRs prevents a regression in retrieval from being silently absorbed by a tuned harness, and preserves an auditable benchmark history.",
       "tags": [
         "benchmark",
         "retrieval",
@@ -121,7 +121,7 @@
       "id": "arch-canonical-memory-location",
       "type": "architecture_decision",
       "title": "Canonical memory location is .mneme/ at repo root",
-      "content": "The canonical live enforcement memory for this repo is .mneme/project_memory.json at the repo root. The file at mneme-project-memory/examples/project_memory.json is a documentation snapshot used by the flagship example only and must not diverge from this canonical file in ways that imply a competing source of truth.",
+      "content": "The canonical live enforcement memory for this repo is .mneme/project_memory.json at the repo root. The file at examples/project_memory.json is a documentation snapshot used by the flagship example only and must not diverge from this canonical file in ways that imply a competing source of truth.",
       "tags": [
         "meta",
         "memory",


### PR DESCRIPTION
## Summary

PR #230 moved the installable package from `mneme-project-memory/` to the repository root. That left three stale path references inside `.mneme/project_memory.json`. This isolated PR updates exactly those three references.

Governance meaning is unchanged — only the recorded repository paths were corrected. No code, test, fixture, documentation, site or ADR file changed.

## Exact changes

```
meta.description:
mneme-project-memory/examples/project_memory.json
→ examples/project_memory.json

rule-bench-retrieval-coupling:
mneme-project-memory/examples/benchmarks
→ examples/benchmarks

arch-canonical-memory-location:
mneme-project-memory/examples/project_memory.json
→ examples/project_memory.json
```

For both items, only the `content` string changed. `id`, `type`, `title`, `tags` and `priority` are untouched. In `meta`, only `description` changed — `name`, `version`, `owner` and `created` are byte-identical.

## Isolation proof

```
Changed files: 1
.mneme/project_memory.json only
```

This PR complies with `rule-memory-pr-isolation`, which requires any edit to `.mneme/project_memory.json` to land in a dedicated PR titled with a `[memory]` prefix, reviewed as a memory change and not bundled with feature work.

Diff is `1 file changed, 3 insertions(+), 3 deletions(-)`. A structural comparison of the parsed JSON before and after confirms exactly **three differing leaves** (`.meta.description`, `.items[2].content`, `.items[7].content`), with top-level key order, all three array lengths (`items` 8, `examples` 2, `decisions` 19) and all element ID orderings identical. File size changed by exactly 63 bytes — the three removed `mneme-project-memory/` prefixes and nothing else. CRLF line endings (511), absence of BOM and the trailing newline are all preserved.

## Validation

| Surface | Result |
|---|---|
| JSON parse | `JSON valid` |
| Remaining `mneme-project-memory` in the file | **0 matches** |
| New path occurrences | `examples/project_memory.json` ×2, `examples/benchmarks` ×1 |
| Core tests (`python -m pytest -p no:cacheprovider`) | **379 passed, 5 skipped** |
| Benchmark Layer 2 | **7/7 caught, pass rate 100%**, exit 0 |
| Benchmark Layer 1 | **recall@3 = 1.00, precision@3 = 0.33, irrelevant = 100%** |
| Governance check (explicit, warn mode) | `Result: PASS`, **exit code 0** |
| `git diff --check` | clean, no whitespace errors |

The governance check was run with the complete runnable command rather than the non-runnable shorthand in `CLAUDE.md`:

```
python -m mneme.cli check --memory .mneme/project_memory.json \
  --input <temp-file-outside-repo> \
  --query "[memory] realign package paths after flattening .mneme/project_memory.json" \
  --mode warn
```

The temporary input file was created outside the repository and deleted afterwards.

### Targeted retrieval results

`rule-bench-retrieval-coupling` **surfaces as the top result**, score `9.00` (matched: decision, constraints):

```
python -m mneme.cli test_query --memory .mneme/project_memory.json \
  --query "change examples benchmarks and core retrieval together" --top 5
```

`arch-canonical-memory-location` **does not surface** for its targeted query. This is **pre-existing behaviour, not caused by this PR**, and was verified by running the identical query against the unmodified base file — the entry is absent from the ranked list in both cases.

Root cause: `arch-canonical-memory-location` is the only item with `type: architecture_decision`. `MemoryStore.decisions()` loads 26 of the file's 27 entries and excludes that one, so it is never a retrieval candidate regardless of its content. Per the scope of this PR, retrieval code and scoring were **not** altered; the actual result is reported here instead. Worth a separate look, but out of scope for a path-only memory correction.

Separately, `test_query` exits non-zero on a Windows `cp1252` console with `UnicodeEncodeError` when printing the injected-context section (the `↓`/`→` glyphs). Also verified identical against the base file — a pre-existing console-encoding limitation, unrelated to this change.

## Behavioural scope

- No runtime code changed.
- No retrieval or enforcement implementation changed.
- No benchmark fixture changed.
- Only the recorded paths were corrected.

## Deferred work

This PR does **not** address, and does not claim to complete:

1. The seven published site references to the old package path (`site/benchmark/`, `site/demo/` ×3, `site/docs/cli/`, `site/integrations/adr-import/`, `site/llms.txt`) — separate `site:` PR.
2. Unrelated documentation cleanup — stale `pip install mneme` occurrences, the ADR-004 "PyPI package name `mneme`" row, old `TheoV823/mneme` repository slugs, the bare shorthand governance command, historical `docs/plans/` paths and stale freeze-document links.
3. Ignored residual build artifacts still on disk under the old `mneme-project-memory/` directory (`.pytest_cache/`, `__pycache__/`, `mneme.egg-info/`) — zero tracked files, pre-existing, left in place.
