### PR TITLE
ci: add pytest workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,10 @@ jobs:
       run: python -m build
         
     - name: Run tests with pytest
+      shell: bash
       run: |
-        pytest tests/ -v | tee pytest-results.txt
+        set -euo pipefail
+        python -m pytest tests/ -v | tee pytest-results.txt
         
     - name: Check for skipped tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
+        
+    - name: Run tests with pytest
+      run: |
+        pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,33 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
         
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install build
         python -m pip install -e ".[dev]"
+        
+    - name: Build distribution
+      run: python -m build
         
     - name: Run tests with pytest
       run: |
-        pytest tests/ -v
+        pytest tests/ -v | tee pytest-results.txt
+        
+    - name: Check for skipped tests
+      run: |
+        if grep -q " skipped" pytest-results.txt; then
+          echo "Error: Tests were silently skipped. Packaging-contract tests require dist/."
+          exit 1
+        fi


### PR DESCRIPTION
## Closed as superseded

Thanks, Prashant. This PR established the direction for a pytest merge gate, but the repository has since landed and is using the canonical workflow at `.github/workflows/tests.yml` on `main`.

The current workflow already provides the required core pytest gate with minimal `contents: read` permissions and `.[dev]` installation, and it is now part of the active CI/release architecture. Reintroducing this older workflow would create a competing test workflow rather than complete missing functionality.

Closing as superseded, not rejected. The contribution helped establish the CI requirement that is now implemented on `main`.