### PR TITLE
docs: add quickstart guide

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,73 @@
+# 5-Minute Quickstart
+
+This guide will walk you through setting up Mneme, adding a decision, and checking a prompt in under 5 minutes. No API key is required for this tutorial.
+
+## 1. Install
+
+Install the core Python package:
+
+```bash
+pip install mneme-hq
+```
+
+
+
+## 2. Initialize Project Memory
+
+Create a new, empty memory file for your project. This is where your architectural decisions will be stored.
+
+```bash
+mneme init
+```
+
+This creates a file at `.mneme/project_memory.json`.
+
+## 3. Add a Decision
+
+Let's record a simple architectural decision: "Use JSON for configuration files, avoid YAML."
+
+```bash
+mneme add_decision \
+  --memory .mneme/project_memory.json \
+  --id "config-format" \
+  --decision "Use JSON for configuration files" \
+  --scope "config" \
+  --constraint "Use JSON only" \
+  --anti-pattern "Do not use YAML"
+```
+
+## 4. Check a Prompt
+
+Now, let's pretend an AI coding assistant is about to generate code based on a user prompt. We will use `mneme check` to validate if the prompt violates our recorded decision.
+
+First, let's try a compliant prompt:
+
+```bash
+python -c "import pathlib; pathlib.Path('prompt_clean.txt').write_text('Add a new JSON config file', encoding='utf-8')"
+
+mneme check \
+  --memory .mneme/project_memory.json \
+  --input prompt_clean.txt \
+  --query "configuration"
+```
+
+You should see a `PASS` verdict because the prompt respects the decision. The command will exit with code `0`.
+
+Now, let's try a prompt that violates our decision:
+
+```bash
+python -c "import pathlib; pathlib.Path('prompt_violation.txt').write_text('Set up a new YAML config file for this module', encoding='utf-8')"
+
+mneme check \
+  --memory .mneme/project_memory.json \
+  --input prompt_violation.txt \
+  --query "configuration"
+```
+
+You should see a `FAIL` verdict because the prompt mentions YAML, which we explicitly defined as an anti-pattern. The command will exit with code `2`.
+
+## Next Steps
+
+You have successfully verified that Mneme can enforce architectural decisions before code generation even begins. 
+
+- **Integrations:** Learn how to enforce these checks automatically in [Claude Code](integrations/claude-code.md) or your CI pipeline.


### PR DESCRIPTION
## Superseded by maintainer takeover

Thanks, Prashant. The five-minute quickstart remains useful and the command sequence you contributed is still valid against the current CLI.

The branch is now substantially behind the released repository state, so rather than rewrite the old branch history the guide has been carried forward from current `main` on `docs/quickstart-takeover`.

The replacement preserves your core flow:

- install `mneme-hq`
- `mneme init`
- add a JSON-vs-YAML decision
- verify a compliant PASS / exit 0
- verify a prohibited FAIL / exit 2

It only tightens current terminology, explicit strict-mode wording, and documentation links.

Closing as superseded, not rejected. Credit remains with this PR for the original quickstart contribution and validation.