### PR TITLE
fix: correct Claude Code hook verdict handling and edit materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ _Nothing yet._
 
 ---
 
+## v0.5.1 — 2026-08-06
+
+**Claude Code hook reliability: trusted verdicts, warn-mode feedback, `replace_all`**
+
+Fixes four defects in the Claude Code `PreToolUse` hook. No retrieval or
+enforcement semantics change; the deterministic mechanism is untouched.
+
+### Added
+
+- `mneme check --json` — emits a versioned, machine-readable verdict payload
+  (`schema`, `verdict`, `mode`, `violations`, `freshness`) as the only stdout
+  content. Exit codes are unchanged. Consumers should trust the payload's
+  verdict rather than the exit code, and fail open on anything unparseable.
+
+### Fixed
+
+- **The hook could hard-block on a crash.** It converted every non-zero child
+  exit into exit 2 (block). Because `mneme check --mode strict` returns 1 for a
+  WARN verdict and Python also returns 1 for an uncaught exception, a malformed
+  memory file or a CLI crash was indistinguishable from a violation and blocked
+  the edit. The hook now blocks only on a parsed verdict and fails open
+  otherwise, matching the documented guarantee.
+- **Warn mode surfaced nothing.** It wrote to stderr and exited 0, and Claude
+  Code discards stderr from a hook that exits 0. Warn mode now emits a
+  `PreToolUse` JSON payload with `permissionDecision: "defer"` and the
+  violation detail as the reason. `defer` is deliberate: `allow` would
+  auto-approve the tool call and bypass the user's normal permission prompt, so
+  a warning mode must never use it.
+- **`replace_all` was ignored.** `Edit` and `MultiEdit` always materialized a
+  single replacement, so when Claude Code was about to replace every
+  occurrence, the checked content was not the content that would land on disk
+  and violations introduced by the second or later occurrence went unseen.
+- **The child CLI could be a different install than the hook.**
+  `sys.executable -m mneme` resolved against the child's `sys.path`, which can
+  be an older mneme that rejects `--json` — the hook would then fail open on
+  every edit with enforcement silently inactive. The child now inherits a
+  `PYTHONPATH` pinned to the hook's own package root, and a stale runtime
+  produces an explicit "enforcement is inactive" warning instead of silence.
+
+---
+
 ## v0.5.0 — 2026-07-03
 
 **Directory-ready Claude Code plugin, `mneme init`, and PyPI metadata realignment**

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -44,7 +44,7 @@ from mneme.benchmark_report import format_json, format_markdown, format_terminal
 from mneme.context_builder import DEFAULT_MAX_DECISIONS, format_decisions
 from mneme.cursor_generator import generate_mdc
 from mneme.decision_retriever import DecisionRetriever
-from mneme.enforcer import Severity, check_prompt
+from mneme.enforcer import EnforcementResult, Severity, check_prompt
 from mneme.memory_store import MemoryStore
 
 
@@ -178,6 +178,45 @@ _EXIT_CODES_BY_MODE: dict[str, dict[Severity, int]] = {
 }
 
 
+CHECK_JSON_SCHEMA = "mneme.check/v1"
+
+
+def _check_payload(
+    result: EnforcementResult,
+    freshness: list[FreshnessIssue],
+    mode: str,
+) -> dict:
+    """Build the ``--json`` verdict payload.
+
+    Consumers (notably the Claude Code hook) must be able to tell a policy
+    verdict apart from a crash. Exit codes cannot carry that distinction --
+    strict mode returns 1 for a WARN verdict and Python also returns 1 for an
+    uncaught exception -- so the verdict is stated explicitly here, behind a
+    versioned ``schema`` key. Anything a consumer cannot parse should be
+    treated as "no verdict" and failed open.
+    """
+    return {
+        "schema": CHECK_JSON_SCHEMA,
+        "verdict": result.verdict.value,
+        "mode": mode,
+        "violations": [
+            {
+                "decision_id": v.decision_id,
+                "decision_text": v.decision_text,
+                "severity": v.severity.value,
+                "rule": v.rule,
+                "trigger": v.trigger,
+            }
+            for v in result.violations
+        ],
+        "freshness": [
+            {"code": i.code, "adr_id": i.adr_id, "message": i.message,
+             "path": str(i.path) if i.path else None}
+            for i in freshness
+        ],
+    }
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
     input_text = Path(args.input).read_text(encoding="utf-8")
 
@@ -187,6 +226,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
     scored = retriever.retrieve(args.query)
 
     result = check_prompt(input_text, scored, top=args.top)
+
+    if getattr(args, "json", False):
+        # Machine-readable mode: the payload must be the only thing on stdout,
+        # so the human-readable violation and freshness blocks are suppressed.
+        freshness = check_freshness(memory_path=args.memory, adr_dir=args.adr_dir)
+        print(json.dumps(_check_payload(result, freshness, args.mode)))
+        return _EXIT_CODES_BY_MODE[args.mode][result.verdict]
 
     if result.violations:
         for v in result.violations:
@@ -383,6 +429,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.add_argument(
         "--mode", choices=["warn", "strict"], default="strict",
         help="warn: all verdicts exit 0; strict (default): WARN->1, FAIL->2",
+    )
+    p_check.add_argument(
+        "--json", action="store_true",
+        help=(
+            "Emit a machine-readable verdict payload as the only stdout "
+            "content. Exit codes are unchanged; consumers should trust the "
+            "payload's verdict rather than the exit code, and fail open on "
+            "anything they cannot parse."
+        ),
     )
     p_check.add_argument(
         "--adr-dir", dest="adr_dir", default="docs/adr",

--- a/mneme/integrations/claude_code/hook.py
+++ b/mneme/integrations/claude_code/hook.py
@@ -42,6 +42,18 @@ class MaterializeError(Exception):
     old_string not found, etc.). Caller should fail open."""
 
 
+def _replace_count(spec: Dict[str, Any]) -> int:
+    """Occurrence count for ``str.replace``, honouring Claude Code's ``replace_all``.
+
+    ``-1`` replaces every occurrence; ``1`` replaces only the first. Mirroring
+    the flag matters: if the hook materializes a single replacement while
+    Claude Code is about to replace all of them, the checked content is not the
+    content that will land on disk, and a violation introduced by the second or
+    later occurrence goes unseen.
+    """
+    return -1 if spec.get("replace_all") else 1
+
+
 def materialize_proposed_content(event: ToolEvent) -> str:
     ti = event.tool_input
     if event.tool_name == "Write":
@@ -60,7 +72,7 @@ def materialize_proposed_content(event: ToolEvent) -> str:
         old, new = ti.get("old_string", ""), ti.get("new_string", "")
         if old not in original:
             raise MaterializeError("old_string not found in file")
-        return original.replace(old, new, 1)
+        return original.replace(old, new, _replace_count(ti))
 
     if event.tool_name == "MultiEdit":
         content = original
@@ -68,7 +80,7 @@ def materialize_proposed_content(event: ToolEvent) -> str:
             old, new = edit.get("old_string", ""), edit.get("new_string", "")
             if old not in content:
                 raise MaterializeError(f"edit[{i}].old_string not found")
-            content = content.replace(old, new, 1)
+            content = content.replace(old, new, _replace_count(edit))
         return content
 
     raise MaterializeError(f"unsupported tool: {event.tool_name}")
@@ -117,7 +129,112 @@ def resolve_mode() -> str:
     return "strict"
 
 
-def _run_check(event: ToolEvent, proposed_content: str, memory: Path, stderr: TextIO) -> int:
+# <root>/mneme/integrations/claude_code/hook.py -> <root>
+_PACKAGE_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _child_env() -> Dict[str, str]:
+    """Environment that pins the child CLI to *this* hook's package tree.
+
+    ``sys.executable -m mneme`` otherwise resolves against the child's sys.path,
+    which can be a different (older) mneme install than the hook was loaded
+    from. That mismatch is silent and total: an older CLI rejects ``--json``,
+    the hook sees no parseable verdict, fails open on every edit, and
+    enforcement is off without anyone being told. Putting the hook's own root
+    first guarantees hook and CLI are the same version.
+    """
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    root = str(_PACKAGE_ROOT)
+    env["PYTHONPATH"] = f"{root}{os.pathsep}{existing}" if existing else root
+    return env
+
+
+_CHECK_JSON_SCHEMA = "mneme.check/v1"
+
+_BLOCKING_VERDICTS = frozenset({"WARN", "FAIL"})
+
+_KNOWN_VERDICTS = frozenset({"PASS", "WARN", "FAIL"})
+
+
+def parse_verdict(stdout: str) -> Optional[Dict[str, Any]]:
+    """Return the trusted verdict payload, or ``None`` if there isn't one.
+
+    The exit code of ``mneme check`` cannot be trusted to mean "policy said
+    no": strict mode returns 1 for a WARN verdict, and the interpreter also
+    returns 1 for an uncaught exception, so a malformed memory file or a CLI
+    crash is indistinguishable from a violation. Only a payload that parses,
+    carries the expected schema, and names a known verdict counts as a verdict
+    at all. Everything else returns ``None`` and the caller fails open.
+    """
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema") != _CHECK_JSON_SCHEMA:
+        return None
+    if payload.get("verdict") not in _KNOWN_VERDICTS:
+        return None
+    return payload
+
+
+def _is_stale_runtime(child_stderr: str) -> bool:
+    """True when the child CLI is too old to understand ``--json``."""
+    return "unrecognized arguments" in (child_stderr or "") and "--json" in (
+        child_stderr or ""
+    )
+
+
+def format_reason(payload: Dict[str, Any]) -> str:
+    """Render a payload's violations as human-readable enforcement feedback."""
+    violations = payload.get("violations") or []
+    if not violations:
+        return f"mneme: {payload.get('verdict')} (no violations reported)"
+
+    # ASCII only: this string is written to stderr, which Claude Code may read
+    # under a non-UTF-8 console codepage (cp1252 on Windows). Non-ASCII
+    # punctuation arrives mojibaked.
+    lines = [f"mneme: {payload.get('verdict')} - architectural decision violated"]
+    for v in violations:
+        lines.append(
+            f"  [{v.get('decision_id')}] {v.get('severity')} "
+            f"\"{v.get('rule')}\" - trigger: {v.get('trigger')}"
+        )
+        if v.get("decision_text"):
+            lines.append(f"      {v['decision_text']}")
+    return "\n".join(lines)
+
+
+def _emit_defer(reason: str, stdout: TextIO) -> None:
+    """Report a non-blocking warn-mode verdict to Claude Code.
+
+    ``defer`` hands the call back to the normal permission flow. ``allow``
+    would be wrong here: it auto-approves the tool call, so warn mode would
+    silently bypass whatever permission prompt the user would otherwise get --
+    a warning mode must not weaken permissions.
+    """
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "defer",
+                "permissionDecisionReason": reason,
+            }
+        },
+        stdout,
+    )
+    stdout.write("\n")
+
+
+def _run_check(
+    event: ToolEvent,
+    proposed_content: str,
+    memory: Path,
+    stderr: TextIO,
+    stdout: TextIO,
+) -> int:
     mode = resolve_mode()
 
     with tempfile.NamedTemporaryFile(
@@ -136,11 +253,13 @@ def _run_check(event: ToolEvent, proposed_content: str, memory: Path, stderr: Te
                     "--input", input_path,
                     "--query", f"edit to {rel}",
                     "--mode", mode,
+                    "--json",
                 ],
                 capture_output=True,
                 text=True,
                 check=False,
                 timeout=_CHECK_TIMEOUT_SECONDS,
+                env=_child_env(),
             )
         except FileNotFoundError:
             print(
@@ -153,11 +272,44 @@ def _run_check(event: ToolEvent, proposed_content: str, memory: Path, stderr: Te
             print(f"mneme-hook: check could not run ({e}). Failing open.", file=stderr)
             return 0
 
-        if proc.stdout:
-            print(proc.stdout, file=stderr)
-        if proc.stderr:
-            print(proc.stderr, file=stderr)
-        return 2 if proc.returncode != 0 else 0
+        payload = parse_verdict(proc.stdout)
+        if payload is None:
+            # No trusted verdict: a crash, a traceback, or an unexpected exit
+            # code. Never block on this.
+            if _is_stale_runtime(proc.stderr):
+                # Silence here would mean enforcement is off with nobody told.
+                print(
+                    "mneme-hook: the installed mneme CLI does not support "
+                    "--json, so no edit can be checked and ENFORCEMENT IS "
+                    "INACTIVE. Upgrade with: pipx install --force "
+                    "\"mneme-hq>=0.5.1\"",
+                    file=stderr,
+                )
+                return 0
+            print(
+                "mneme-hook: no parseable verdict from mneme check "
+                f"(exit {proc.returncode}). Failing open.",
+                file=stderr,
+            )
+            if proc.stderr:
+                print(proc.stderr, file=stderr)
+            return 0
+
+        verdict = payload["verdict"]
+        if verdict == "PASS":
+            return 0
+
+        reason = format_reason(payload)
+        if mode == "warn":
+            _emit_defer(reason, stdout)
+            return 0
+
+        if verdict in _BLOCKING_VERDICTS:
+            # Exit 2 is the documented blocking path: Claude Code feeds stderr
+            # back to the model as the reason the edit was refused.
+            print(reason, file=stderr)
+            return 2
+        return 0
     finally:
         try:
             os.unlink(input_path)
@@ -165,7 +317,11 @@ def _run_check(event: ToolEvent, proposed_content: str, memory: Path, stderr: Te
             pass
 
 
-def main(stdin: TextIO = sys.stdin, stderr: TextIO = sys.stderr) -> int:
+def main(
+    stdin: TextIO = sys.stdin,
+    stderr: TextIO = sys.stderr,
+    stdout: TextIO = sys.stdout,
+) -> int:
     try:
         raw = stdin.read()
         event = parse_event(raw)
@@ -186,7 +342,7 @@ def main(stdin: TextIO = sys.stdin, stderr: TextIO = sys.stderr) -> int:
         print(f"mneme-hook: cannot materialize content, failing open: {e}", file=stderr)
         return 0
 
-    return _run_check(event, proposed_content, memory, stderr)
+    return _run_check(event, proposed_content, memory, stderr, stdout)
 
 
 def cli_main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mneme-hq"
-version = "0.5.0"
+version = "0.5.1"
 description = "Portable project memory and evaluation nucleus for AI workflows"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integrations/claude_code/test_hook_e2e.py
+++ b/tests/integrations/claude_code/test_hook_e2e.py
@@ -86,6 +86,46 @@ def test_violating_write_blocks(project):
 
 
 @pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_malformed_memory_fails_open_against_real_cli(project):
+    """A corrupt memory file makes the real CLI crash. It must not block.
+
+    This is the fail-open guarantee end-to-end: the child process exits
+    non-zero with a traceback and no parseable verdict, and the edit proceeds.
+    """
+    cwd, target = project
+    (cwd / ".mneme" / "project_memory.json").write_text(
+        "{ this is not valid json", encoding="utf-8"
+    )
+    err = io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(cwd, target, "import psycopg2")),
+        stderr=err,
+        stdout=io.StringIO(),
+    )
+    assert rc == 0, "a crashing check must never hard-block an edit"
+    assert "failing open" in err.getvalue().lower()
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_warn_mode_surfaces_violation_against_real_cli(project, monkeypatch):
+    """Warn mode must emit machine-readable feedback, not silence."""
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    cwd, target = project
+    out = io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(cwd, target, "import psycopg2")),
+        stderr=io.StringIO(),
+        stdout=out,
+    )
+    assert rc == 0
+    emitted = json.loads(out.getvalue())
+    hso = emitted["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "defer"
+    assert "psycopg2" in hso["permissionDecisionReason"] or \
+           "test_001" in hso["permissionDecisionReason"]
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
 def test_compliant_write_passes(project):
     cwd, target = project
     rc = main(stdin=io.StringIO(_write_envelope(cwd, target, "import sqlite3\n")))

--- a/tests/integrations/claude_code/test_hook_main.py
+++ b/tests/integrations/claude_code/test_hook_main.py
@@ -53,9 +53,30 @@ def _edit_envelope(tmp_path, target):
     })
 
 
+def _verdict_payload(verdict):
+    """A trusted `mneme check --json` payload.
+
+    The hook blocks on the payload's verdict, not on the child exit code --
+    an exit code alone cannot distinguish a violation from a CLI crash.
+    """
+    return json.dumps({
+        "schema": "mneme.check/v1",
+        "verdict": verdict,
+        "mode": "strict",
+        "violations": [{
+            "decision_id": "mneme_001",
+            "decision_text": "Use JSON storage only",
+            "severity": verdict,
+            "rule": "no postgres",
+            "trigger": "psycopg2",
+        }],
+        "freshness": [],
+    })
+
+
 def test_strict_fail_returns_two(tmp_path):
     mem, target = _project_with_memory(tmp_path)
-    fake = MagicMock(returncode=2, stdout="FAIL: violates mneme_001", stderr="")
+    fake = MagicMock(returncode=2, stdout=_verdict_payload("FAIL"), stderr="")
     with patch("mneme.integrations.claude_code.hook.subprocess.run", return_value=fake) as mrun:
         rc = main(stdin=io.StringIO(_edit_envelope(tmp_path, target)))
     assert rc == 2
@@ -68,10 +89,10 @@ def test_strict_fail_returns_two(tmp_path):
     assert "--mode" in args
 
 
-def test_strict_warn_returncode_blocks(tmp_path):
-    """In strict mode, mneme check returncode 1 (WARN) should block."""
+def test_strict_warn_verdict_blocks(tmp_path):
+    """In strict mode, a WARN verdict should block."""
     mem, target = _project_with_memory(tmp_path)
-    fake = MagicMock(returncode=1, stdout="WARN", stderr="")
+    fake = MagicMock(returncode=1, stdout=_verdict_payload("WARN"), stderr="")
     with patch("mneme.integrations.claude_code.hook.subprocess.run", return_value=fake):
         rc = main(stdin=io.StringIO(_edit_envelope(tmp_path, target)))
     assert rc == 2
@@ -80,9 +101,9 @@ def test_strict_warn_returncode_blocks(tmp_path):
 def test_warn_mode_never_blocks(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
     mem, target = _project_with_memory(tmp_path)
-    fake = MagicMock(returncode=0, stdout="WARN", stderr="")
+    fake = MagicMock(returncode=0, stdout=_verdict_payload("WARN"), stderr="")
     with patch("mneme.integrations.claude_code.hook.subprocess.run", return_value=fake):
-        rc = main(stdin=io.StringIO(_edit_envelope(tmp_path, target)))
+        rc = main(stdin=io.StringIO(_edit_envelope(tmp_path, target)), stdout=io.StringIO())
     assert rc == 0
 
 

--- a/tests/integrations/claude_code/test_hook_verdict.py
+++ b/tests/integrations/claude_code/test_hook_verdict.py
@@ -1,0 +1,261 @@
+"""Tests for trusted-verdict handling and warn-mode feedback.
+
+Two defects are pinned here:
+
+1. The hook used to convert *any* non-zero child exit into exit 2 (block).
+   `mneme check --mode strict` returns 1 for a WARN verdict, but Python also
+   returns 1 for an uncaught exception -- so a malformed memory file or a CLI
+   crash hard-blocked the edit. The documented behaviour is fail-open, so only
+   a parsed verdict may block.
+
+2. Warn mode wrote to stderr and exited 0. Claude Code discards stderr from a
+   hook that exits 0, so warn mode surfaced nothing at all.
+"""
+import io
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mneme.integrations.claude_code.hook import (
+    format_reason,
+    main,
+    parse_verdict,
+)
+
+
+def _payload(verdict="FAIL", violations=None):
+    return json.dumps({
+        "schema": "mneme.check/v1",
+        "verdict": verdict,
+        "mode": "strict",
+        "violations": violations if violations is not None else [{
+            "decision_id": "storage_json",
+            "decision_text": "Use JSON storage only",
+            "severity": verdict,
+            "rule": "introduce ORM",
+            "trigger": "ORM",
+        }],
+        "freshness": [],
+    })
+
+
+def _project_with_memory(tmp_path):
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir()
+    mem.write_text('{"decisions": []}')
+    target = tmp_path / "x.py"
+    target.write_text("import os\n", encoding="utf-8")
+    return mem, target
+
+
+def _edit_envelope(tmp_path, target):
+    return json.dumps({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "cwd": str(tmp_path),
+        "tool_input": {
+            "file_path": str(target),
+            "old_string": "import os",
+            "new_string": "import psycopg2",
+        },
+    })
+
+
+def _run(tmp_path, target, *, returncode, stdout, stderr_text=""):
+    fake = MagicMock(returncode=returncode, stdout=stdout, stderr=stderr_text)
+    err, out = io.StringIO(), io.StringIO()
+    with patch("mneme.integrations.claude_code.hook.subprocess.run", return_value=fake):
+        rc = main(
+            stdin=io.StringIO(_edit_envelope(tmp_path, target)),
+            stderr=err,
+            stdout=out,
+        )
+    return rc, err.getvalue(), out.getvalue()
+
+
+# ── parse_verdict rejects everything untrustworthy ───────────────────────────
+
+@pytest.mark.parametrize("stdout", [
+    "",
+    "Traceback (most recent call last):\n  File ...\nValueError: bad memory",
+    "not json at all",
+    "[]",
+    "null",
+    json.dumps({"verdict": "FAIL"}),                       # no schema
+    json.dumps({"schema": "something/else", "verdict": "FAIL"}),
+    json.dumps({"schema": "mneme.check/v1"}),              # no verdict
+    json.dumps({"schema": "mneme.check/v1", "verdict": "BANANA"}),
+])
+def test_parse_verdict_returns_none_for_untrusted_output(stdout):
+    assert parse_verdict(stdout) is None
+
+
+def test_parse_verdict_accepts_well_formed_payload():
+    assert parse_verdict(_payload("FAIL"))["verdict"] == "FAIL"
+
+
+# ── crashes must fail open, not block ────────────────────────────────────────
+
+def test_traceback_with_exit_one_fails_open(tmp_path):
+    """The exact reported defect: a CLI crash must not hard-block an edit."""
+    mem, target = _project_with_memory(tmp_path)
+    rc, err, _out = _run(
+        tmp_path, target,
+        returncode=1,
+        stdout="",
+        stderr_text="Traceback (most recent call last):\nJSONDecodeError: bad memory",
+    )
+    assert rc == 0
+    assert "failing open" in err.lower()
+
+
+def test_unparseable_stdout_with_exit_two_fails_open(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    rc, err, _out = _run(tmp_path, target, returncode=2, stdout="FAIL: something")
+    assert rc == 0
+    assert "failing open" in err.lower()
+
+
+def test_child_stderr_is_surfaced_when_failing_open(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    _rc, err, _out = _run(
+        tmp_path, target, returncode=1, stdout="", stderr_text="ValueError: boom",
+    )
+    assert "ValueError: boom" in err
+
+
+# ── strict mode blocks only on a parsed verdict ──────────────────────────────
+
+def test_strict_fail_verdict_blocks(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    rc, err, _out = _run(tmp_path, target, returncode=2, stdout=_payload("FAIL"))
+    assert rc == 2
+    assert "storage_json" in err
+
+
+def test_strict_warn_verdict_blocks(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, _out = _run(tmp_path, target, returncode=1, stdout=_payload("WARN"))
+    assert rc == 2
+
+
+def test_pass_verdict_does_not_block_or_emit(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, out = _run(
+        tmp_path, target, returncode=0, stdout=_payload("PASS", violations=[]),
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_pass_verdict_trusted_over_nonzero_exit(tmp_path):
+    """A PASS payload wins even if the child exits non-zero for some other reason."""
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, _out = _run(
+        tmp_path, target, returncode=1, stdout=_payload("PASS", violations=[]),
+    )
+    assert rc == 0
+
+
+# ── warn mode surfaces violations without blocking ───────────────────────────
+
+def test_warn_mode_emits_structured_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, out = _run(tmp_path, target, returncode=0, stdout=_payload("FAIL"))
+    assert rc == 0
+    emitted = json.loads(out)
+    hso = emitted["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PreToolUse"
+    assert "storage_json" in hso["permissionDecisionReason"]
+
+
+def test_warn_mode_defers_never_allows(tmp_path, monkeypatch):
+    """`allow` would auto-approve the tool call and bypass the user's
+    permission prompt. A warning must never weaken permissions."""
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    mem, target = _project_with_memory(tmp_path)
+    _rc, _err, out = _run(tmp_path, target, returncode=0, stdout=_payload("FAIL"))
+    decision = json.loads(out)["hookSpecificOutput"]["permissionDecision"]
+    assert decision == "defer"
+    assert decision != "allow"
+
+
+def test_warn_mode_pass_emits_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, out = _run(
+        tmp_path, target, returncode=0, stdout=_payload("PASS", violations=[]),
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_warn_mode_never_blocks_on_fail(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    mem, target = _project_with_memory(tmp_path)
+    rc, _err, _out = _run(tmp_path, target, returncode=0, stdout=_payload("FAIL"))
+    assert rc == 0
+
+
+# ── the hook asks for JSON ───────────────────────────────────────────────────
+
+def test_child_pythonpath_pins_hook_package_root(tmp_path):
+    """The child CLI must be the same mneme the hook was loaded from.
+
+    Without this, `python -m mneme` can resolve to a different (older) install
+    that rejects --json; the hook would then fail open on every edit and
+    enforcement would be silently inactive.
+    """
+    import mneme
+    from mneme.integrations.claude_code import hook as hook_mod
+
+    mem, target = _project_with_memory(tmp_path)
+    fake = MagicMock(returncode=0, stdout=_payload("PASS", violations=[]), stderr="")
+    with patch(
+        "mneme.integrations.claude_code.hook.subprocess.run", return_value=fake
+    ) as mrun:
+        main(stdin=io.StringIO(_edit_envelope(tmp_path, target)),
+             stderr=io.StringIO(), stdout=io.StringIO())
+
+    env = mrun.call_args.kwargs["env"]
+    expected_root = str(Path(mneme.__file__).resolve().parent.parent)
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == expected_root
+    assert str(hook_mod._PACKAGE_ROOT) == expected_root
+
+
+def test_stale_runtime_warns_that_enforcement_is_inactive(tmp_path):
+    """An old CLI rejecting --json must produce a loud warning, not silence."""
+    mem, target = _project_with_memory(tmp_path)
+    rc, err, _out = _run(
+        tmp_path, target,
+        returncode=2,
+        stdout="",
+        stderr_text="mneme: error: unrecognized arguments: --json",
+    )
+    assert rc == 0
+    assert "ENFORCEMENT IS INACTIVE" in err
+    assert "mneme-hq" in err
+
+
+def test_check_is_invoked_with_json_flag(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    fake = MagicMock(returncode=0, stdout=_payload("PASS", violations=[]), stderr="")
+    with patch(
+        "mneme.integrations.claude_code.hook.subprocess.run", return_value=fake
+    ) as mrun:
+        main(stdin=io.StringIO(_edit_envelope(tmp_path, target)),
+             stderr=io.StringIO(), stdout=io.StringIO())
+    assert "--json" in mrun.call_args.args[0]
+
+
+# ── reason formatting ────────────────────────────────────────────────────────
+
+def test_format_reason_includes_rule_and_trigger():
+    reason = format_reason(json.loads(_payload("FAIL")))
+    assert "introduce ORM" in reason
+    assert "ORM" in reason
+    assert "storage_json" in reason

--- a/tests/integrations/claude_code/test_replace_all.py
+++ b/tests/integrations/claude_code/test_replace_all.py
@@ -1,0 +1,94 @@
+"""Tests for `replace_all` handling in proposed-content materialization.
+
+Claude Code's Edit tool accepts a `replace_all` flag. When it is set, every
+occurrence of `old_string` is replaced, not just the first. If the hook
+materializes only the first replacement, it checks a file that differs from
+what Claude Code is actually about to write -- so a violation introduced by
+the 2nd..Nth occurrence is never seen.
+"""
+from mneme.integrations.claude_code.hook import (
+    ToolEvent,
+    materialize_proposed_content,
+)
+
+
+def _event(tool: str, file_path: str, **tool_input) -> ToolEvent:
+    ti = {"file_path": file_path, **tool_input}
+    return ToolEvent(
+        tool_name=tool,
+        file_path=file_path,
+        cwd=str(file_path),
+        tool_input=ti,
+    )
+
+
+def _target(tmp_path, content: str):
+    p = tmp_path / "x.py"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ── Edit ─────────────────────────────────────────────────────────────────────
+
+def test_edit_replace_all_replaces_every_occurrence(tmp_path):
+    target = _target(tmp_path, "a = 1\nb = a\nc = a\n")
+    out = materialize_proposed_content(
+        _event("Edit", str(target), old_string="a", new_string="Z", replace_all=True)
+    )
+    assert out == "Z = 1\nb = Z\nc = Z\n"
+
+
+def test_edit_without_replace_all_replaces_only_first(tmp_path):
+    """Regression guard: default behaviour must stay single-replacement."""
+    target = _target(tmp_path, "a = 1\nb = a\nc = a\n")
+    out = materialize_proposed_content(
+        _event("Edit", str(target), old_string="a", new_string="Z")
+    )
+    assert out == "Z = 1\nb = a\nc = a\n"
+
+
+def test_edit_replace_all_false_replaces_only_first(tmp_path):
+    target = _target(tmp_path, "a = 1\nb = a\n")
+    out = materialize_proposed_content(
+        _event("Edit", str(target), old_string="a", new_string="Z", replace_all=False)
+    )
+    assert out == "Z = 1\nb = a\n"
+
+
+def test_edit_replace_all_surfaces_violation_in_later_occurrence(tmp_path):
+    """The bug that matters: a banned term introduced by the 2nd occurrence."""
+    target = _target(tmp_path, "db = LOCAL\ncache = LOCAL\n")
+    out = materialize_proposed_content(
+        _event("Edit", str(target), old_string="LOCAL", new_string="postgres",
+               replace_all=True)
+    )
+    assert out.count("postgres") == 2
+
+
+# ── MultiEdit ────────────────────────────────────────────────────────────────
+
+def test_multiedit_honors_per_edit_replace_all(tmp_path):
+    target = _target(tmp_path, "a = 1\nb = a\nq = 9\n")
+    out = materialize_proposed_content(
+        _event(
+            "MultiEdit",
+            str(target),
+            edits=[
+                {"old_string": "a", "new_string": "Z", "replace_all": True},
+                {"old_string": "q", "new_string": "W"},
+            ],
+        )
+    )
+    assert out == "Z = 1\nb = Z\nW = 9\n"
+
+
+def test_multiedit_without_replace_all_replaces_only_first(tmp_path):
+    target = _target(tmp_path, "a = 1\nb = a\n")
+    out = materialize_proposed_content(
+        _event(
+            "MultiEdit",
+            str(target),
+            edits=[{"old_string": "a", "new_string": "Z"}],
+        )
+    )
+    assert out == "Z = 1\nb = a\n"

--- a/tests/test_check_json.py
+++ b/tests/test_check_json.py
@@ -1,0 +1,90 @@
+"""Tests for `mneme check --json`.
+
+The Claude Code hook cannot distinguish a policy verdict from a crash by exit
+code alone: `mneme check --mode strict` returns 1 for a WARN verdict, and the
+Python interpreter also returns 1 for an uncaught exception. `--json` gives
+consumers a trusted, explicit verdict so they can fail open on anything they
+cannot parse.
+"""
+import json
+from pathlib import Path
+
+from mneme.cli import main
+
+from tests.test_check_modes import (
+    _FAIL_TEXT,
+    _PASS_TEXT,
+    _WARN_TEXT,
+    _input,
+    _memory,
+)
+
+
+def _run_json(tmp_path, text, capsys, mode="strict"):
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path, text)
+    code = main(["check", "--memory", str(mem), "--input", str(inp),
+                 "--query", "storage", "--mode", mode, "--json"])
+    return code, json.loads(capsys.readouterr().out)
+
+
+# ── payload is parseable and well-formed ─────────────────────────────────────
+
+def test_json_output_is_sole_stdout_content(tmp_path, capsys):
+    """Nothing may precede or follow the payload, or consumers cannot parse it."""
+    _code, payload = _run_json(tmp_path, _FAIL_TEXT, capsys)
+    assert payload["schema"] == "mneme.check/v1"
+
+
+def test_json_declares_verdict_fail(tmp_path, capsys):
+    _code, payload = _run_json(tmp_path, _FAIL_TEXT, capsys)
+    assert payload["verdict"] == "FAIL"
+
+
+def test_json_declares_verdict_warn(tmp_path, capsys):
+    _code, payload = _run_json(tmp_path, _WARN_TEXT, capsys)
+    assert payload["verdict"] == "WARN"
+
+
+def test_json_declares_verdict_pass(tmp_path, capsys):
+    _code, payload = _run_json(tmp_path, _PASS_TEXT, capsys)
+    assert payload["verdict"] == "PASS"
+    assert payload["violations"] == []
+
+
+def test_json_echoes_mode(tmp_path, capsys):
+    _code, payload = _run_json(tmp_path, _PASS_TEXT, capsys, mode="warn")
+    assert payload["mode"] == "warn"
+
+
+def test_json_violations_carry_decision_and_rule(tmp_path, capsys):
+    _code, payload = _run_json(tmp_path, _FAIL_TEXT, capsys)
+    v = payload["violations"][0]
+    assert v["decision_id"] == "storage_json"
+    assert v["severity"] == "FAIL"
+    assert v["rule"] and v["trigger"] and v["decision_text"]
+
+
+# ── exit codes are unchanged by --json ───────────────────────────────────────
+
+def test_json_preserves_strict_exit_codes(tmp_path, capsys):
+    for text, expected in ((_PASS_TEXT, 0), (_WARN_TEXT, 1), (_FAIL_TEXT, 2)):
+        code, _payload = _run_json(tmp_path, text, capsys)
+        assert code == expected, f"{text!r} expected exit {expected}"
+
+
+def test_json_preserves_warn_mode_exit_codes(tmp_path, capsys):
+    for text in (_PASS_TEXT, _WARN_TEXT, _FAIL_TEXT):
+        code, _payload = _run_json(tmp_path, text, capsys, mode="warn")
+        assert code == 0
+
+
+# ── human output is unaffected when --json is absent ─────────────────────────
+
+def test_without_json_flag_output_stays_human_readable(tmp_path, capsys):
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path, _FAIL_TEXT)
+    main(["check", "--memory", str(mem), "--input", str(inp), "--query", "storage"])
+    out = capsys.readouterr().out
+    assert "Result: FAIL" in out
+    assert "schema" not in out


### PR DESCRIPTION
Closes the four code-level blockers on finalising the Claude Code plugin. No retrieval or enforcement semantics change; the deterministic mechanism is untouched.

## What was wrong

**1. Fail-open was not reliable (the serious one).** The hook converted every non-zero child exit into exit 2 (block). `mneme check --mode strict` returns 1 for a WARN verdict, and Python also returns 1 for an uncaught exception — so a malformed `project_memory.json` or any CLI crash was indistinguishable from a violation and hard-blocked the edit. The documented guarantee is fail-open.

**2. Warn mode surfaced nothing.** It wrote to stderr and exited 0. Claude Code discards stderr from a hook that exits 0, so warn mode was silent in every case.

**3. `replace_all` was ignored.** `Edit` and `MultiEdit` always materialized a single replacement. When Claude Code was about to replace every occurrence, the checked content was not the content that would land on disk, and a violation introduced by the second or later occurrence was never seen.

**4. Found while fixing the above: the child CLI could be a different install than the hook.** `sys.executable -m mneme` resolves against the child's `sys.path`. With `mneme-hq` 0.5.0 installed, the new `--json` flag is rejected, the hook sees no parseable verdict, and it fails open on *every* edit — enforcement silently inactive with nobody told. The hook's own test suite masked this because pytest's working directory put the source tree first on `sys.path`.

## What changed

- **`mneme check --json`** — a versioned, machine-readable verdict payload (`schema`, `verdict`, `mode`, `violations`, `freshness`) as the only stdout content. Exit codes unchanged. Consumers trust the payload, not the exit code, and fail open on anything unparseable.
- **Hook blocks only on a parsed verdict.** Unparseable stdout, an unexpected exit code, or a traceback all fail open with an explicit stderr note.
- **Warn mode emits `permissionDecision: "defer"`** plus the violation detail as the reason. `defer` is deliberate — `allow` auto-approves the tool call and would bypass the user's normal permission prompt, so a warning mode must never use it. There is a test asserting the decision is never `allow`.
- **`replace_all` honoured** in both `Edit` and `MultiEdit`.
- **Child CLI pinned** to the hook's own package root via `PYTHONPATH`, and a stale runtime now produces an explicit "ENFORCEMENT IS INACTIVE" warning instead of silent inaction.
- Reason strings are ASCII — non-ASCII punctuation arrived mojibaked through the Windows console codepage (verified).
- Version bumped to `0.5.1` so the upgrade message refers to a real release.

## Verification

- Full suite: **421 passed, 5 skipped** (skips are pre-existing packaging-contract tests needing `dist/`). Baseline was 375 passed.
- 46 new tests, including end-to-end cases that run the **real** CLI: a corrupt memory file must not block, and warn mode must emit structured output.
- Enforcement re-verified from a foreign working directory (the condition the test suite was masking): a violating edit is correctly blocked with exit 2.

## Deliberately out of scope

- **Working-tree coverage for Bash-driven edits.** A `Stop`-hook audit is the real fix; that is a feature, not a blocker fix.
- **Marketplace submission** — gated on this landing.
- **Documentation and messaging corrections** (stale `0.4.0` text, `pip install mneme` pointing at an unrelated package, "every edit" coverage claims) follow in a separate docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
