### PR TITLE
docs: land ADR-005 install-command gate and record supply-chain rationale

### DIFF
--- a/.github/workflows/install-command-check.yml
+++ b/.github/workflows/install-command-check.yml
@@ -1,0 +1,20 @@
+name: install command check
+
+# ADR-005: the PyPI distribution is `mneme-hq`. `pip install mneme` resolves to
+# an unrelated, abandoned third-party package this project does not own.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-install-command:
+    name: Verify install commands name mneme-hq
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run ADR-005 install-command gate
+        run: python scripts/check_install_command.py

--- a/docs/adr/ADR-005-brand-vs-package-namespace-enforcement.md
+++ b/docs/adr/ADR-005-brand-vs-package-namespace-enforcement.md
@@ -87,6 +87,13 @@ In code-bearing contexts, the only acceptable spellings are:
 
 ## Enforcement
 
+- **Install-command gate (landed 2026-08-06):** `scripts/check_install_command.py`
+  fails CI if any tracked file instructs `pip install mneme` not `mneme-hq`
+  (or the `pipx` / `uv pip` equivalents). Editable installs
+  (`pip install -e mneme`) take a local directory path, not a distribution
+  name, and are not flagged; neither is a line that names both the correct and
+  forbidden forms, so this ADR's own comparison table stays legal. Wired up as
+  `.github/workflows/install-command-check.yml`.
 - **Pre-publish check:** the deploy script (or a pre-commit hook) should fail
   if `Mneme HQ` appears inside a fenced code block, `<pre>`, `<code>`, or
   immediately after a `$ ` shell prompt in any tracked file.
@@ -94,10 +101,40 @@ In code-bearing contexts, the only acceptable spellings are:
   identifiers must cite ADR-004 + ADR-005 and explicitly justify why the
   package rename is in scope. Default answer: it is not.
 
+## Amendment 2026-08-06: supply-chain rationale and the cost of the missing gate
+
+The original text framed `pip install mneme` (rather than `mneme-hq`) as a
+correctness problem. It is also a **supply-chain problem**, and that is the
+stronger reason.
+
+`mneme` on PyPI is an unrelated, abandoned third-party project — a
+Flask/MongoDB note-taking application by Risto Stevcev, v0.201, last released
+**19 May 2014**, Python 2.7 classifiers only, sdist only. It is unmaintained,
+and this project neither owns nor controls that namespace. Publishing
+`pip install mneme` in place of `mneme-hq` does not merely give users a broken
+command: it directs them to install from a namespace outside our control.
+
+**What the missing gate cost.** The version of this ADR accepted on 2026-05-04
+closed with *"A small lint/grep gate is owed; until it lands, this ADR is the
+contract reviewers cite."* The gate was never built. By 2026-08-06 the
+violation had reached production: `mnemehq.com` served `pip install mneme` not `mneme-hq`
+on three pages — `/qa-glossary/`, `/use-cases/ci-governance-for-ai-generated-code/`,
+and `/integrations/warp/` — and **three of those occurrences were inside the
+JSON-LD `FAQPage` block**, so the wrong command was being syndicated to search
+rich results and AI answer engines rather than merely displayed. Fixed in
+MnemeHQ/mnemehq-site#7.
+
+The decision was correct and recorded from the start. It still reached
+production because nothing enforced it. A recorded decision with no gate is a
+preference, not a constraint — which is the failure mode this project exists to
+prevent, and worth stating plainly in our own ADR record.
+
 ## Consequences
 
 - One-time cleanup pass across README and `site/use-cases/*`.
 - Future brand changes are safer: prose can move freely, code identity is
   pinned.
-- A small lint/grep gate is owed; until it lands, this ADR is the contract
-  reviewers cite.
+- ~~A small lint/grep gate is owed~~ — **landed 2026-08-06**; see Enforcement.
+- The site repository (`MnemeHQ/mnemehq-site`) is a separate repository since
+  the website extraction and does **not** inherit this gate. It needs its own
+  copy, or the production surface stays unguarded.

--- a/docs/qa-glossary.md
+++ b/docs/qa-glossary.md
@@ -8,7 +8,7 @@ This document is the canonical reference for both human readers and AI assistant
 **Site:** [mnemehq.com](https://mnemehq.com/)
 **Repository:** [github.com/TheoV823/mneme](https://github.com/TheoV823/mneme)
 **License:** MIT
-**Install:** `pip install mneme`
+**Install:** `pip install mneme-hq`
 
 ---
 
@@ -28,7 +28,7 @@ RAG retrieves information. Mneme HQ retrieves decisions. RAG's goal is to inform
 
 ### 4. How does Mneme HQ integrate with Claude Code?
 
-Mneme HQ ships a `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with `pip install mneme` then `python scripts/install_claude_code.py`. The installer is idempotent and writes `.claude/settings.json`, slash commands (`/mneme-check`, `/mneme-context`, `/mneme-record`, `/mneme-review`), and a discovery skill.
+Mneme HQ ships a `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with `pip install mneme-hq` then `python scripts/install_claude_code.py`. The installer is idempotent and writes `.claude/settings.json`, slash commands (`/mneme-check`, `/mneme-context`, `/mneme-record`, `/mneme-review`), and a discovery skill.
 
 ### 5. How does Mneme HQ integrate with Cursor?
 
@@ -127,14 +127,14 @@ No. The retrieval, the injection, the conflict detection, and the verdict are al
 ### 19. What's the install footprint?
 
 ```
-pip install mneme
+pip install mneme-hq
 ```
 
 Dependencies: `anthropic >= 0.25.0`, `python-dotenv >= 1.0.0`. That's the whole list. Python 3.11+. The optional `[api]` extra is still declared for compatibility and pulls in FastAPI and Uvicorn, but it should not be read as an active supported HTTP endpoint — the historical HTTP wrapper has been separated from active core, and its deprecation is a separate versioned decision. No vector database, no model server, no background service.
 
 ### 20. How do I add Mneme HQ to an existing project?
 
-Three steps. First, `pip install mneme`. Second, create a `project_memory.json` at your repo root with three to ten of the architectural decisions you care most about (or compile your existing `docs/adr/` directory via `compile_adrs`). Third, install the Claude Code hook with `python scripts/install_claude_code.py`, or wire `mneme check --mode warn` into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.
+Three steps. First, `pip install mneme-hq`. Second, create a `project_memory.json` at your repo root with three to ten of the architectural decisions you care most about (or compile your existing `docs/adr/` directory via `compile_adrs`). Third, install the Claude Code hook with `python scripts/install_claude_code.py`, or wire `mneme check --mode warn` into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.
 
 ### 21. What's the Layer 1 freeze?
 

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -45,6 +45,11 @@ ALLOWLIST: dict[str, str] = {
     # Dated historical planning records. Rewriting them would falsify the
     # archive; they are not user-facing install instructions.
     "docs/plans/": "historical planning records, not user instructions",
+    # The gate itself must name the forbidden form to detect and explain it,
+    # and its tests must use it as fixture data. Without these entries the
+    # check fails on itself the moment it is committed.
+    "scripts/check_install_command.py": "the gate's own pattern and messages",
+    "tests/test_check_install_command.py": "the gate's own test fixtures",
 }
 
 

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""ADR-005 enforcement gate: the PyPI distribution name must be `mneme-hq`.
+
+ADR-005 forbids `pip install mneme` because that name belongs to an unrelated,
+abandoned third-party package (a Flask/MongoDB note-taking app, v0.201, last
+released 2014) that this project neither owns nor controls. Instructing users
+to run it points them at a namespace outside our control.
+
+ADR-005 recorded that gate as owed and it was never built. In the meantime the
+violation reached production: mnemehq.com served `pip install mneme` on three
+pages, including inside JSON-LD structured data, where it was syndicated to
+search rich results and AI answer engines. This script is that gate.
+
+Exit codes:
+    0 = no violations
+    1 = violations found (listed on stdout)
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The distribution name is `mneme-hq`; the import root and CLI are both
+# `mneme`. Match an install command naming the bare `mneme` distribution,
+# without matching `mneme-hq` or longer identifiers.
+VIOLATION = re.compile(
+    r"\b(?:pip|pipx|uv pip)\s+install\s+(?P<flags>(?:-[\w-]+\s+)*)mneme(?!-hq)(?![\w-])"
+)
+
+# `pip install -e mneme` / `--editable mneme` takes a *local directory path*,
+# not a PyPI distribution name, so it never resolves to the wrong package.
+# Installing a source checkout that happens to live in a folder called `mneme`
+# is legitimate and must not be flagged.
+EDITABLE_FLAGS = ("-e", "--editable")
+
+CORRECT = "mneme-hq"
+
+SCANNED_SUFFIXES = {".md", ".html", ".htm", ".py", ".txt", ".rst", ".yml", ".yaml", ".json"}
+
+# Paths where the forbidden string is a deliberate, documented artifact rather
+# than an instruction to a user. Each entry needs a reason.
+ALLOWLIST: dict[str, str] = {
+    # Dated historical planning records. Rewriting them would falsify the
+    # archive; they are not user-facing install instructions.
+    "docs/plans/": "historical planning records, not user instructions",
+}
+
+
+def is_allowlisted(path: str) -> str | None:
+    for prefix, reason in ALLOWLIST.items():
+        if path.startswith(prefix):
+            return reason
+    return None
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], capture_output=True, text=True, check=True
+    ).stdout
+    return [p for p in out.splitlines() if Path(p).suffix.lower() in SCANNED_SUFFIXES]
+
+
+def scan(paths: list[str]) -> list[tuple[str, int, str]]:
+    findings: list[tuple[str, int, str]] = []
+    for path in paths:
+        if is_allowlisted(path):
+            continue
+        try:
+            text = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            match = VIOLATION.search(line)
+            if not match:
+                continue
+            flags = match.group("flags").split()
+            if any(f in EDITABLE_FLAGS for f in flags):
+                continue
+            # A line that names both the correct and the forbidden form is a
+            # correct-vs-wrong comparison (as in ADR-005's own table), not an
+            # instruction. Those must keep naming the forbidden form.
+            if CORRECT in line:
+                continue
+            findings.append((path, lineno, line.strip()))
+    return findings
+
+
+def main() -> int:
+    findings = scan(tracked_files())
+    if not findings:
+        print("ADR-005 install-command gate: OK (no `pip install mneme` found)")
+        return 0
+
+    print("ADR-005 VIOLATION: the PyPI distribution is `mneme-hq`, not `mneme`.")
+    print()
+    print("`pip install mneme` installs an unrelated, abandoned third-party")
+    print("package this project does not own. Use `mneme-hq`:")
+    print()
+    print('    pipx install "mneme-hq>=0.5.0"')
+    print()
+    print(f"{len(findings)} occurrence(s):")
+    for path, lineno, line in findings:
+        print(f"  {path}:{lineno}: {line}")
+    print()
+    print("If a line legitimately contrasts the correct and forbidden forms")
+    print("(as ADR-005's own table does), name `mneme-hq` on the same line.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_install_command.py
+++ b/tests/test_check_install_command.py
@@ -71,6 +71,17 @@ def test_allowlist_does_not_cover_user_docs():
     assert gate.is_allowlisted("docs/qa-glossary.md") is None
 
 
+def test_allowlist_covers_the_gate_itself():
+    """The gate must name the forbidden form to detect and explain it.
+
+    Regression: this was missed because `git ls-files` skips untracked files,
+    so the gate passed locally and only failed once its own source and tests
+    were committed.
+    """
+    assert gate.is_allowlisted("scripts/check_install_command.py")
+    assert gate.is_allowlisted("tests/test_check_install_command.py")
+
+
 def test_repo_is_clean():
     """The gate must pass on the repository as committed."""
     findings = gate.scan(gate.tracked_files())

--- a/tests/test_check_install_command.py
+++ b/tests/test_check_install_command.py
@@ -1,0 +1,80 @@
+"""Tests for the ADR-005 install-command gate.
+
+The gate must catch instructions to install the wrong PyPI distribution
+without flagging the many legitimate uses of the bare word `mneme`, which is
+the import root, the CLI name, and a common local directory name.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_install_command.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_install_command", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gate = _load()
+
+
+def _flagged(line: str) -> bool:
+    match = gate.VIOLATION.search(line)
+    if not match:
+        return False
+    if any(f in gate.EDITABLE_FLAGS for f in match.group("flags").split()):
+        return False
+    return gate.CORRECT not in line
+
+
+@pytest.mark.parametrize("line", [
+    "pip install mneme",
+    "**Install:** `pip install mneme`",
+    "pipx install mneme",
+    "uv pip install mneme",
+    "      - run: pip install mneme",
+    "pip install --upgrade mneme",
+    "    - pip install mneme",
+])
+def test_flags_wrong_distribution(line):
+    assert _flagged(line), f"should have been flagged: {line!r}"
+
+
+@pytest.mark.parametrize("line", [
+    "pip install mneme-hq",
+    'pipx install "mneme-hq>=0.5.0"',
+    # Editable installs take a local directory path, not a distribution name.
+    "pip install -e mneme   # local checkout",
+    "pip install --editable mneme",
+    "pipx install ./mneme",
+    # ADR-005's own correct-vs-forbidden table must keep naming both forms.
+    "| pip install command | `pip install mneme-hq` | `pip install mneme` |",
+    # `mneme` as CLI / import root / unrelated identifier.
+    "mneme check --mode warn",
+    "python -m mneme check",
+    "pip install mneme_hq",
+    "pip install mnemex",
+])
+def test_does_not_flag_legitimate_usage(line):
+    assert not _flagged(line), f"false positive: {line!r}"
+
+
+def test_allowlist_covers_historical_plans():
+    assert gate.is_allowlisted("docs/plans/2026-05-03-mneme-for-claude-code.md")
+
+
+def test_allowlist_does_not_cover_user_docs():
+    assert gate.is_allowlisted("docs/qa-glossary.md") is None
+
+
+def test_repo_is_clean():
+    """The gate must pass on the repository as committed."""
+    findings = gate.scan(gate.tracked_files())
+    assert findings == [], (
+        "ADR-005 violations present:\n"
+        + "\n".join(f"  {p}:{n}: {ln}" for p, n, ln in findings)
+    )


### PR DESCRIPTION
ADR-005 has forbidden `pip install mneme` since **2026-05-04**. It closed with:

> "A small lint/grep gate is owed; until it lands, this ADR is the contract reviewers cite."

**The gate was never built.** By 2026-08-06 the violation had reached production: mnemehq.com served the wrong install command on three pages, and **three of those occurrences were inside the JSON-LD `FAQPage` block** — so it was being syndicated to search rich results and AI answer engines, not merely displayed to readers. Corrected in [mnemehq-site#7](https://github.com/MnemeHQ/mnemehq-site/pull/7).

This PR lands the owed gate and records why the rule exists.

## Why the rule exists (the part that was missing)

The original ADR treated this as a correctness problem. It is also a **supply-chain problem**, and that is the stronger reason.

`mneme` on PyPI is an unrelated, abandoned third-party project — a Flask/MongoDB note-taking app, v0.201, last released **19 May 2014**, Python 2.7 classifiers only, sdist only. Unmaintained, and this project neither owns nor controls that namespace. Publishing that command doesn't just hand users a broken install; it points them at a namespace outside our control.

## Changes

- **`scripts/check_install_command.py`** — fails CI on any tracked file naming the bare `mneme` distribution in a `pip` / `pipx` / `uv pip` install command.
  - Editable installs (`pip install -e mneme`) take a **local directory path**, not a distribution name, so they are not flagged. This was a real false positive caught during development.
  - A line naming both the correct and forbidden forms is treated as a comparison, which keeps ADR-005's own Correct/Forbidden table legal.
  - `docs/plans/` is allowlisted: dated historical records, not user instructions.
- **`.github/workflows/install-command-check.yml`** — runs it on PRs and pushes to main.
- **`tests/test_check_install_command.py`** — 20 tests covering both directions, plus a guard that the repo itself stays clean.
- **ADR-005 amended** with the supply-chain rationale and a plain note that a recorded decision with no gate is a preference, not a constraint — which is the failure mode this project exists to prevent, and worth stating in our own record.
- **`docs/qa-glossary.md`** — four violations corrected.

## Verification

- Gate passes on the repo: `ADR-005 install-command gate: OK`
- Full suite: **399 passed, 5 skipped** (skips are the pre-existing packaging tests needing `dist/`)
- `mneme check --mode warn` on the amended ADR: **Result: PASS**
- The gate caught **its own author** mid-PR — three sentences I wrote in the ADR amendment named the forbidden form without the correct one beside it. Rephrased rather than allowlisted.

## One follow-up, deliberately not done here

`mneme check` now reports `ADR_CHANGED` for ADR-005: the source file no longer matches the decision imported into `.mneme/project_memory.json`. Refreshing that import requires modifying `project_memory.json`, which CLAUDE.md restricts to a `[memory]` task — so it is intentionally left for a separate change.

## Also worth noting

The site repository is separate since the website extraction and **does not inherit this gate**. It needs its own copy, or the production surface stays unguarded. Recorded in the ADR's Consequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
