### PR TITLE
docs: correct Claude Code install instructions and qualify hook coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,16 +477,43 @@ during the warn-first rollout.
 Architectural governance for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 Enforce ADRs and engineering constraints automatically — before drift reaches your repo.
 
+Two steps — the runtime and the Claude Code integration are separate artifacts:
+
 ```bash
-pip install mneme-hq
-python scripts/install_claude_code.py        # project-scoped: writes to ./.claude/
-# or: python scripts/install_claude_code.py --user   # writes to ~/.claude/
+# 1. Install the runtime
+pipx install "mneme-hq>=0.5.1"
+
+# 2. Load the plugin
+claude --plugin-dir ./integrations/claude-code-plugin
 ```
 
-This installs a `PreToolUse` hook so every Edit / Write / MultiEdit is checked
-against `.mneme/project_memory.json` in strict mode by default. See
-[docs/integrations/claude-code.md](docs/integrations/claude-code.md) for
-details, including retrieval behaviour and mode switching.
+This registers a `PreToolUse` hook so `Edit` and `Write` tool calls are checked
+against `.mneme/project_memory.json`, in strict mode by default. Files written
+by shell commands are **not** covered — see the
+[plugin README](integrations/claude-code-plugin/README.md) for the coverage
+boundary, fail-open guarantees, and mode switching.
+
+<details>
+<summary>Legacy: flat installer (source checkout only)</summary>
+
+Before the plugin, the integration was installed by a script that writes
+`.claude/settings.json` and hyphenated commands (`/mneme-check`,
+`/mneme-context`, `/mneme-record`, `/mneme-review`) — distinct from the
+plugin's namespaced `/mneme:check` and friends.
+
+```bash
+python scripts/install_claude_code.py          # project-scoped: writes ./.claude/
+# or: python scripts/install_claude_code.py --user
+```
+
+**This requires a git clone.** `scripts/` is not shipped in the `mneme-hq`
+wheel, so the script does not exist in a `pip`/`pipx` install. Prefer the
+plugin above.
+
+</details>
+
+See [docs/integrations/claude-code.md](docs/integrations/claude-code.md) for
+retrieval behaviour and further detail.
 
 ---
 

--- a/docs/qa-glossary.md
+++ b/docs/qa-glossary.md
@@ -28,7 +28,7 @@ RAG retrieves information. Mneme HQ retrieves decisions. RAG's goal is to inform
 
 ### 4. How does Mneme HQ integrate with Claude Code?
 
-Mneme HQ ships a `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or surfaces the violation without blocking (warn mode). Install with `pip install mneme-hq` then `python scripts/install_claude_code.py`. The installer is idempotent and writes `.claude/settings.json`, slash commands (`/mneme-check`, `/mneme-context`, `/mneme-record`, `/mneme-review`), and a discovery skill.
+Mneme HQ ships a `PreToolUse` hook for Claude Code that intercepts `Edit` and `Write` tool calls. The hook reconstructs the full post-edit file, runs `mneme check` against the active constraint set, and either blocks the write (strict mode) or reports the violation without blocking (warn mode). Files written by shell commands are not covered, since a `Bash` call does not fire a file-edit hook. Install in two steps: `pipx install "mneme-hq>=0.5.1"` for the runtime, then load the plugin with `claude --plugin-dir ./integrations/claude-code-plugin`, which provides namespaced commands (`/mneme:check`, `/mneme:context`, `/mneme:record`, `/mneme:review`) and a discovery skill. A legacy flat installer (`python scripts/install_claude_code.py`, hyphenated `/mneme-check` commands) still exists but requires a git clone — `scripts/` is not shipped in the wheel.
 
 ### 5. How does Mneme HQ integrate with Cursor?
 
@@ -127,14 +127,14 @@ No. The retrieval, the injection, the conflict detection, and the verdict are al
 ### 19. What's the install footprint?
 
 ```
-pip install mneme-hq
+pipx install "mneme-hq>=0.5.1"
 ```
 
-Dependencies: `anthropic >= 0.25.0`, `python-dotenv >= 1.0.0`. That's the whole list. Python 3.11+. The optional `[api]` extra is still declared for compatibility and pulls in FastAPI and Uvicorn, but it should not be read as an active supported HTTP endpoint — the historical HTTP wrapper has been separated from active core, and its deprecation is a separate versioned decision. No vector database, no model server, no background service.
+Dependencies: `anthropic >= 0.25.0`, `python-dotenv >= 1.0.0`, `PyYAML >= 6.0`. That's the whole list. Python 3.11+. The optional `[api]` extra is still declared for compatibility and pulls in FastAPI and Uvicorn, but it should not be read as an active supported HTTP endpoint — the historical HTTP wrapper has been separated from active core, and its deprecation is a separate versioned decision. No vector database, no model server, no background service.
 
 ### 20. How do I add Mneme HQ to an existing project?
 
-Three steps. First, `pip install mneme-hq`. Second, create a `project_memory.json` at your repo root with three to ten of the architectural decisions you care most about (or compile your existing `docs/adr/` directory via `compile_adrs`). Third, install the Claude Code hook with `python scripts/install_claude_code.py`, or wire `mneme check --mode warn` into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.
+Three steps. First, `pipx install "mneme-hq>=0.5.1"`. Second, create a `project_memory.json` at your repo root with three to ten of the architectural decisions you care most about (or compile your existing `docs/adr/` directory via `compile_adrs`). Third, load the Claude Code plugin with `claude --plugin-dir ./integrations/claude-code-plugin`, or wire `mneme check --mode warn` into your CI on PRs. Start in warn mode; promote to strict once the corpus stabilizes.
 
 ### 21. What's the Layer 1 freeze?
 
@@ -274,7 +274,7 @@ The set of load-bearing principles that govern Mneme HQ's design: deterministic 
 
 ### Claude Code hook
 
-A `PreToolUse` hook for Claude Code that intercepts every `Edit`, `Write`, and `MultiEdit` operation. Reconstructs the post-edit file, runs `mneme check`, blocks (strict) or warns (warn) based on configured mode. Shipped in v0.3.2. Install with `python scripts/install_claude_code.py`.
+A `PreToolUse` hook for Claude Code that intercepts `Edit` and `Write` tool calls (not files written by shell commands). Reconstructs the post-edit file, runs `mneme check --json`, blocks (strict) or reports without blocking (warn) based on configured mode. Shipped in v0.3.2; hook reliability fixed in v0.5.1. Install via the plugin — see the Claude Code integration entry above.
 
 ### Conflict detector
 

--- a/integrations/claude-code-plugin/README.md
+++ b/integrations/claude-code-plugin/README.md
@@ -12,23 +12,22 @@ into a single distributable unit.
 ## Prerequisite: install Mneme
 
 The plugin drives the `mneme-hook` / `mneme` CLI, which ships with the
-`mneme-hq` package.
+`mneme-hq` package. Installation is two steps — the runtime and the plugin are
+separate artifacts, and installing one does not install the other.
 
-> **Current install state (verified 2026-07-02).** The reliable Claude Code
-> hook requires the `v0.4.2` fixes (module execution + exit-code propagation).
-> The published PyPI release is **`0.4.0`**, which has the known exit-propagation
-> bug — a failed check could exit 0 and let a violating edit through. `v0.4.2`
-> is tagged and released on GitHub but **not yet published to PyPI**. Until it
-> is, install Mneme from the repository so you get the reliable hook:
->
-> ```bash
-> git clone https://github.com/MnemeHQ/mneme
-> pip install -e mneme   # or: pipx install ./mneme
-> ```
->
-> Once `mneme-hq >= 0.4.2` is on PyPI, `pipx install "mneme-hq>=0.4.2"` becomes
-> the one-line install. See the PR / release notes for the outstanding publish
-> step.
+**Step 1 — install the runtime:**
+
+```bash
+pipx install "mneme-hq>=0.5.1"
+```
+
+`>=0.5.1` is a real requirement, not a preference. Earlier releases do not
+support the `--json` verdict the hook relies on; on `0.5.0` and below a
+crashing check could hard-block an edit, and `warn` mode reported nothing at
+all. If the installed runtime is too old, the hook says so explicitly rather
+than silently disabling enforcement.
+
+**Step 2 — install the plugin** (see below).
 
 If `mneme-hook` is not on `PATH`, the hook **fails open**: Claude Code reports a
 non-blocking hook error and the edit proceeds. Enforcement simply stays inactive
@@ -45,15 +44,25 @@ claude --plugin-dir /path/to/mneme/integrations/claude-code-plugin
 
 After changes, reload in-session with `/reload-plugins`.
 
-**From a marketplace** (once published), add the marketplace and enable the
-`mneme` plugin from Claude Code's plugin UI. On enable, Claude Code prompts for
-the **enforcement mode** (`strict` or `warn`).
+**From a marketplace:** not yet available. The plugin has not been submitted to
+the Claude Code community catalog, so `--plugin-dir` above is currently the
+only installation path. Once it is listed, enabling it from Claude Code's
+plugin UI will prompt for the **enforcement mode** (`strict` or `warn`).
 
 ## How enforcement works
 
-The plugin registers a `PreToolUse` hook on `Edit|Write|MultiEdit`. The hook
-uses Claude Code's **exec form** — it invokes the `mneme-hook` console script
-directly on `PATH`, with no shell in between:
+The plugin registers a `PreToolUse` hook matching `Edit|Write|MultiEdit`.
+
+> **What this covers.** `Edit` and `Write` tool calls, which is how Claude Code
+> edits files directly. The matcher also lists `MultiEdit` for compatibility;
+> current Claude Code documents `Edit` and `Write`. **Edits made by shell
+> commands are not covered** — a `Bash` call that writes a file does not fire a
+> `PreToolUse` file-edit hook and is never checked. Complete working-tree
+> coverage would need a `Stop`-hook audit, which this plugin does not ship. Use
+> `/mneme:review` to catch what the per-edit hook misses.
+
+The hook uses Claude Code's **exec form** — it invokes the `mneme-hook` console
+script directly on `PATH`, with no shell in between:
 
 ```json
 { "type": "command", "command": "mneme-hook", "args": [], "timeout": 30 }
@@ -61,14 +70,18 @@ directly on `PATH`, with no shell in between:
 
 `mneme-hook` (the existing Claude Code adapter, unchanged by this plugin):
 
-1. Reconstructs the full post-edit file content (not just the changed string).
+1. Reconstructs the full post-edit file content (not just the changed string),
+   honouring `replace_all` so the checked content matches what will land on disk.
 2. Discovers `.mneme/project_memory.json` by walking up from the working dir.
-3. Runs `mneme check` with a query derived from the target file path.
-4. Exits **2** (block) on a violating verdict in `strict` mode, or **0** (allow)
-   otherwise. In `warn` mode it never blocks.
+3. Runs `mneme check --json` with a query derived from the target file path.
+4. Reads the **structured verdict** from that payload. In `strict` mode a
+   violating verdict exits **2** (block); in `warn` mode it never blocks.
 
-Exit code **2 is the only blocking result**; any other exit code is a
-non-blocking hook error, so execution failures never block an edit.
+The hook blocks **only** on a verdict it could parse and trust. An exit code on
+its own is not treated as a verdict — `mneme check --mode strict` returns 1 for
+a WARN verdict, but Python also returns 1 for an uncaught exception, so a
+malformed memory file would otherwise be indistinguishable from a violation.
+Anything unparseable fails open with a note on stderr.
 
 Claude Code surfaces the block as an error containing the violated decision id,
 so it can adjust course without you intervening.
@@ -99,6 +112,15 @@ precedence:
 An unrecognized value falls back to `strict`, so a typo never silently disables
 enforcement. Use `warn` while iterating on decisions to avoid friction.
 
+In `warn` mode the hook emits a `PreToolUse` JSON payload with
+`permissionDecision: "defer"` and the violation detail as the reason, rather
+than writing to stderr — Claude Code discards stderr from a hook that exits 0,
+which is why warn mode previously reported nothing at all. `defer` is
+deliberate: `allow` would auto-approve the tool call and bypass the permission
+prompt you would otherwise get, so a *warning* mode must never use it. How
+Claude Code renders a `defer` reason has not been confirmed end-to-end in a
+live session.
+
 ## Retrieval: what the hook checks and what it misses
 
 The automatic hook query is `"edit to <file_path>"` — tokens from the target
@@ -124,8 +146,13 @@ The hook allows the edit — never blocks — when:
 - `.mneme/project_memory.json` cannot be found by walking up from the working dir
 - The tool event is malformed
 - `mneme check` times out (10 s internal) or any other execution error occurs
+- `mneme check` crashes, or returns anything the hook cannot parse as a trusted
+  verdict — a corrupt memory file, a traceback, or an unexpected exit code
+- The installed `mneme-hq` is older than 0.5.1 and rejects `--json` (the hook
+  warns loudly that enforcement is inactive rather than failing silently)
 
-Only a real violating verdict from `mneme check` in `strict` mode blocks an edit.
+Only a parsed, violating verdict from `mneme check` in `strict` mode blocks an
+edit.
 
 ## Platform support
 

--- a/integrations/claude-code-plugin/skills/mneme/SKILL.md
+++ b/integrations/claude-code-plugin/skills/mneme/SKILL.md
@@ -11,8 +11,9 @@ description: |
 # Mneme — project memory & governance
 
 This project uses Mneme to enforce architectural decisions. When this plugin is
-enabled, a `PreToolUse` hook checks every Edit / Write / MultiEdit against the
-project's recorded decisions and can block edits that violate them.
+enabled, a `PreToolUse` hook checks `Edit` and `Write` tool calls against the
+project's recorded decisions and can block edits that violate them. Files
+written by shell commands are not covered.
 
 ## When this skill activates
 
@@ -38,10 +39,15 @@ project's recorded decisions and can block edits that violate them.
 
 ## Hook enforcement
 
-A `PreToolUse` hook runs automatically on Edit / Write / MultiEdit. It
-reconstructs the full post-edit file content, then calls `mneme check` with the
-query `"edit to <file_path>"`. Decisions whose scope or text share tokens with
-the file name are retrieved and checked.
+A `PreToolUse` hook runs automatically on `Edit` and `Write` tool calls (the
+matcher also lists `MultiEdit` for compatibility). It reconstructs the full
+post-edit file content, then calls `mneme check --json` with the query
+`"edit to <file_path>"`. Decisions whose scope or text share tokens with the
+file name are retrieved and checked.
+
+**Not covered:** files written by `Bash` commands. A shell redirect or `sed`
+never fires a `PreToolUse` file-edit hook. Run `/mneme:review` after such
+changes.
 
 **Retrieval caveat:** The automatic hook query is derived from the file path, so
 decisions with scope keywords that don't appear in file names may not be retrieved
@@ -52,11 +58,10 @@ and the violated decision id is surfaced in the error.
 
 ## Requirements & configuration
 
-- **Mneme must be installed** and `mneme-hook` must be on `PATH`. The reliable
-  hook needs the `v0.4.2` fixes, which are not yet on PyPI (published: `0.4.0`);
-  until then install from the repository root (`pip install -e .`).
-  See the plugin README for details. Without Mneme the hook fails open (edits
-  are never blocked).
+- **Mneme must be installed** and `mneme-hook` must be on `PATH`:
+  `pipx install "mneme-hq>=0.5.1"`. The version floor is required — earlier
+  releases lack the `--json` verdict the hook depends on. Without Mneme the
+  hook fails open (edits are never blocked). See the plugin README for details.
 - **Enforcement mode** is set by the plugin's `mode` configuration option and
   reaches the hook as `CLAUDE_PLUGIN_OPTION_MODE`. Precedence:
   `MNEME_HOOK_MODE` > `CLAUDE_PLUGIN_OPTION_MODE` > `strict`; unknown values fall

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,16 +1,28 @@
-# Mneme for Claude Code
+# Mneme for Claude Code — legacy flat integration
+
+> **Superseded by the [plugin](../claude-code-plugin/).** This is the original
+> script-installed integration, kept for existing setups. New installs should
+> use the plugin, which bundles the same hook with namespaced commands.
+>
+> Two differences matter when following older docs:
+>
+> - This integration installs **hyphenated** commands (`/mneme-check`,
+>   `/mneme-context`, `/mneme-record`, `/mneme-review`). The plugin installs
+>   **namespaced** ones (`/mneme:check`, …). They are not interchangeable.
+> - The installer below requires a **git clone**. `scripts/` is not shipped in
+>   the `mneme-hq` wheel, so `python scripts/install_claude_code.py` does not
+>   exist in a `pip` or `pipx` install.
 
 Architectural governance for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 Enforce ADRs and engineering constraints automatically — before drift reaches your repo.
 
 ## Quick install
 
-> **Version requirement:** Use **v0.4.2 or later** for Claude Code hooks.
-> v0.4.1 fixed PATH lookup but exit-code propagation was incomplete —
-> failed checks could return exit 0 and allow violating edits through.
-> v0.4.2 is the first fully reliable hook release.
+> **Version requirement:** use **`mneme-hq>=0.5.1`**. Earlier releases lack the
+> `--json` verdict the hook depends on; on 0.5.0 and below a crashing check
+> could hard-block an edit and `warn` mode reported nothing at all.
 
-1. `pip install mneme-hq>=0.4.2`  (or `pip install -e .` from this repo)
+1. `pipx install "mneme-hq>=0.5.1"`  (or `pip install -e .` from this repo)
 2. Run the installer: `python scripts/install_claude_code.py`
 3. Confirm: edit a file in Claude Code that violates a decision in
    `.mneme/project_memory.json` — Claude Code should be blocked with


### PR DESCRIPTION
The plugin documentation described a world that no longer exists. It told readers PyPI served `0.4.0`, pointed them at an installer that isn't in the wheel, and claimed the hook intercepts *every* edit. This is the comms half of the plugin audit, deliberately held until [#245](https://github.com/MnemeHQ/mneme/pull/245) landed and 0.5.1 was actually published — so the version it names is now a real, installable thing.

## Install

- **Plugin README + SKILL.md**: dropped the stale `0.4.0`/`0.4.2` workaround block; both now give the canonical two-step install — `pipx install "mneme-hq>=0.5.1"`, then load the plugin. The floor is a **requirement, not a preference**: earlier releases lack the `--json` verdict the hook depends on, and on 0.5.0 a crashing check could hard-block an edit while warn mode reported nothing.
- **Root README**: no longer pairs `pip install mneme-hq` with `python scripts/install_claude_code.py`. That sequence **cannot work** — `scripts/` is excluded from the wheel (`packages.find include = ["mneme*"]`), so the script doesn't exist in a pip/pipx install. The flat installer is now a collapsed *"legacy — source checkout only"* section, and the hyphenated `/mneme-check` commands are explicitly distinguished from the plugin's namespaced `/mneme:check`.
- **Flat integration README**: retitled as the legacy path, stale `>=0.4.2` floor corrected.

## Coverage

"Intercepts every `Edit`, `Write`, and `MultiEdit`" is gone. Replaced with `Edit` and `Write`, plus an explicit statement that **files written by shell commands are never checked** — a `Bash` call doesn't fire a `PreToolUse` file-edit hook. Complete working-tree coverage would need a `Stop`-hook audit, which isn't shipped, so the docs now point at `/mneme:review` instead of implying completeness.

Marketplace availability is stated plainly as **not yet submitted**, rather than implied by "once published".

## Behaviour, corrected to match v0.5.1

- The hook blocks **only** on a parsed, trusted verdict — an exit code alone is not a verdict, since strict-mode WARN and an uncaught Python exception both return 1.
- Warn mode emits `permissionDecision: "defer"`, documented alongside *why* `allow` is deliberately avoided: it would auto-approve the call and bypass the user's permission prompt.
- Fail-open list extended to cover crashes, unparseable output, and a stale runtime.

## Claims now avoided

Per the audit, the docs no longer assert "every edit", "execution errors never block" as an unqualified absolute, "marketplace available", or "cross-platform validated" — the platform section still says plainly that macOS and Linux have not been exercised, which remains true because CI does not run `pytest`.

## Also fixed in passing

`docs/qa-glossary.md` listed the dependencies as `anthropic` + `python-dotenv` and called that "the whole list". It omitted `PyYAML>=6.0`. Now matches `pyproject.toml`.

## Verification

- ADR-005 install-command gate: **pass**
- `check_encoding.py docs scripts`: **pass**, 74 files
- Full suite: **442 passed, 5 skipped**
- Grep for residual `0.4.0` / `0.4.2` / "intercepts every" across all touched surfaces: **zero hits**
- Line endings normalized to LF so the diff is 130/59 rather than whole-file

## Not in scope

The live site carries its own copy of the qa-glossary content in the `mnemehq-site` repo. This PR corrects the core-repo source only; the published page still has the old coverage wording and installer path, and needs a separate site PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)