### PR TITLE
fix: decouple enforcement scope from retrieval score (#254)

### DIFF
--- a/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
+++ b/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
@@ -1,0 +1,134 @@
+---
+id: ADR-017
+title: "Enforcement Scope Is Independent of Retrieval Scope"
+status: accepted
+priority: foundational
+date: 2026-08-08
+scope: enforcement.retrieval_separation
+---
+
+# ADR-017: Enforcement Scope Is Independent of Retrieval Scope
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Deciders:** Theo Valmis
+
+---
+
+## Context
+
+Until this decision, `mneme check` evaluated a proposed edit only against the
+decisions that a lexical retriever ranked highest for the query. The Claude Code
+hook builds that query as `"edit to <file_path>"`, and `enforcer._top_nonzero`
+discarded every decision scoring zero. A decision that shared no token with the
+filename was therefore never evaluated at all.
+
+The observable consequence (issue #254) is that byte-identical content was caught
+or missed on the strength of the filename:
+
+```
+mneme check --input storage_db.py --query "edit to storage_db.py"  ->  FAIL, 1 violation
+mneme check --input service.py    --query "edit to service.py"     ->  PASS, 0 violations
+```
+
+Both files contained exactly `import psycopg2`, against a decision whose
+`anti_patterns` list contains `psycopg2`. Measured retrieval scores against that
+fixture: `storage_db.py` 3.00, `service.py` 0.00, `models.py` 0.00, `db.py` 0.00.
+`db.py` misses because the decision's scope says `database`, and `db` is not a
+lexical match for it.
+
+This was not merely missing test coverage. The end-to-end test
+(`tests/integrations/claude_code/test_hook_e2e.py`) named its target
+`storage_db.py` and its comment stated the name was chosen so the token
+`storage` would match the fixture's scope — the test was built around the
+limitation rather than exposing it.
+
+No ADR governed the separation between retrieval and enforcement. An external
+design review recommended settling the question "against ADR-014"; ADR-014 is
+the harness-complementary positioning vocabulary and is unrelated. All sixteen
+existing ADRs were checked: this decision was genuinely uncovered.
+
+### Why the obvious fix is wrong on its own
+
+Evaluating every decision against the existing matcher was measured across 216
+tracked files in this repository:
+
+| Enforcement scope | Files reporting FAIL |
+|---|---|
+| Retrieval-gated (before this ADR) | 44 of 216 |
+| Every decision, existing matcher | 170 of 216 |
+
+Every one of those 170, and every one of the pre-existing 44, was manually
+confirmed to be a **false positive**. The matcher explodes a rule phrase into
+individual terms and fires when any single term appears, so the rule
+`open() without encoding= in Python` reports a violation against any prose
+containing the word `open`; other observed triggers were `without`, `content`,
+`any`, `main`, and `governance`. This is the noise already recorded as issue
+ #150. Globalising it would convert a documented nuisance into a repo-wide edit
+block, and would have made strict mode unusable.
+
+## Decision
+
+1. **Enforcement scope is not a ranking question.** "Is this forbidden?" has the
+   same answer regardless of whether the filename happened to share a token with
+   the decision's scope. Retrieval ranking and its top-N cutoff no longer decide
+   whether a decision is enforced.
+
+2. **Retrieval remains responsible for context injection only.** Scoring,
+   ranking, and the top-N cutoff continue to govern which decisions are shown to
+   an agent as relevant context. That is a relevance question, and ranking is
+   correct for it.
+
+3. **Corpus-wide enforcement applies to unambiguous literal rules.** A rule that
+   reduces to exactly one significant term — `psycopg2`, `no postgres` — is
+   evaluated against every decision supplied, independent of retrieval score. For
+   such a rule, term matching and literal matching coincide: there is no phrase
+   to take apart and therefore no guess about which word carries the meaning.
+
+4. **Multi-term rules remain retrieval-gated for now.** A rule such as
+   `open() without encoding= in Python` is prose describing a pattern, not a
+   mechanically decidable rule. Applying it corpus-wide produces the measured
+   false-positive blowup above. These keep their existing top-N behaviour until
+   a typed literal vocabulary replaces them (issue #250).
+
+5. **`--top` is re-scoped, not removed.** It continues to bound the
+   retrieval-gated tier — how many decisions have their multi-term rules applied,
+   and how much context is injected. It never limits which decisions are
+   enforced.
+
+6. **This is an interim boundary, not the destination.** Splitting rules by term
+   count is a proxy for "mechanically decidable". The durable fix is an explicit
+   typed vocabulary (`FORBID_LITERAL` and a containment-based exemption) whose
+   rules are enforceable by construction, at which point the term-count proxy is
+   retired. That work is issue #250 and is not part of this decision.
+
+## Consequences
+
+- Issue #254 is closed for literal rules: the reproduction now reports FAIL under
+  `service.py`, `models.py`, `db.py`, and `handler.py` as well as
+  `storage_db.py`, and compliant content still passes under all of them.
+- False positives do not increase. Repo-wide FAIL count measured after this
+  change is 44 of 216 — identical to the pre-change baseline.
+- `tests/test_enforcer.py::test_zero_score_decisions_are_skipped` asserted the
+  defective behaviour and is replaced by two tests pinning the new contract: a
+  zero-scoring decision enforces its literal rules, and does not apply its
+  multi-term rules.
+- Enforcement cost is now linear in corpus size rather than bounded by `--top`.
+  At realistic corpus sizes (10–100 decisions) this is a bounded set of string
+  matches and is not a measurable cost.
+- Rules whose author expected a multi-word phrase to be enforced still will not
+  fire outside the retrieval-gated tier. This is deliberate: the alternative is
+  the measured 170-of-216 false-positive rate. Issue #250 is the path to making
+  those rules expressible, and until it lands the limitation is documented rather
+  than silently absorbed.
+- Enforcement remains scoped to the tools the PreToolUse hook covers. This ADR
+  does not change which edits reach the checker.
+
+## Related
+
+- Issue #254 (this decision), #150 (matcher false positives), #250 (typed rule
+  vocabulary), #249 (context injection below a score floor)
+- ADR-005: Brand vs Package Namespace Enforcement — the incident that exposed
+  unenforceable ADR-sourced decisions
+- ADR-014: Harness-Complementary Positioning Vocabulary — cited by an external
+  review as governing this area; it does not

--- a/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
+++ b/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
@@ -107,8 +107,18 @@ block, and would have made strict mode unusable.
 - Issue #254 is closed for literal rules: the reproduction now reports FAIL under
   `service.py`, `models.py`, `db.py`, and `handler.py` as well as
   `storage_db.py`, and compliant content still passes under all of them.
-- False positives do not increase. Repo-wide FAIL count measured after this
-  change is 44 of 216 — identical to the pre-change baseline.
+- False positives do not increase. Measured over the same 216 tracked files
+  before and after, the repo-wide FAIL count is 44 in both cases.
+
+  Adding this ADR and its regression test brings the tracked set to 218 files
+  and the count to 46. Both new files fail on the pre-existing multi-term rules
+  `direct-to-main governance edits` and `unreviewed enforcement changes`,
+  triggered by the bare words `main` and `enforcement` appearing in prose that
+  documents enforcement. That is the #150 matcher behaving as it already did on
+  the retrieval-gated path, which this ADR does not change — and it is a
+  concrete instance of the self-reference problem: the document describing a
+  rule is itself flagged by it. Recorded here because it is the first thing a
+  reader will notice when re-running the measurement.
 - `tests/test_enforcer.py::test_zero_score_decisions_are_skipped` asserted the
   defective behaviour and is replaced by two tests pinning the new contract: a
   zero-scoring decision enforces its literal rules, and does not apply its

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -425,7 +425,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.add_argument("--memory", required=True, help="Path to project_memory.json")
     p_check.add_argument("--input", required=True, help="Path to input file to check")
     p_check.add_argument("--query", required=True, help="Context query for retrieval")
-    p_check.add_argument("--top", type=int, default=DEFAULT_MAX_DECISIONS)
+    p_check.add_argument(
+        "--top", type=int, default=DEFAULT_MAX_DECISIONS,
+        help=(
+            "Size of the retrieval-gated tier. Bounds how many decisions have "
+            "their multi-term rules applied; unambiguous literal rules are "
+            "enforced across the whole corpus regardless (ADR-017)."
+        ),
+    )
     p_check.add_argument(
         "--mode", choices=["warn", "strict"], default="strict",
         help="warn: all verdicts exit 0; strict (default): WARN->1, FAIL->2",

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -1,13 +1,19 @@
 """
 enforcer.py — Pre-flight enforcement of Mneme decisions against a prompt.
 
-Checks an input text against retrieved decisions and returns a structured
+Checks an input text against the decision corpus and returns a structured
 result with PASS / WARN / FAIL verdict and per-violation details.
+
+Retrieval and enforcement answer different questions. Retrieval asks "what
+context is relevant?" -- a ranking question, where a top-N cutoff is right.
+Enforcement asks "is this forbidden?" -- a safety question, where ranking is
+wrong, because a violation does not stop being a violation when the filename
+happens to share no token with the decision's scope. See ADR-017.
 
 Severity semantics:
     FAIL  — input contains a term from a decision's anti_patterns list.
     WARN  — input mentions a term that a "no X" constraint forbids.
-    PASS  — no violations found among the top-N retrieved decisions.
+    PASS  — no violations found.
 
 Exit codes for the CLI:
     0 = PASS, 1 = WARN, 2 = FAIL
@@ -77,28 +83,86 @@ def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]
     return kept
 
 
+def _is_literal_rule(text: str, min_len: int = 3) -> bool:
+    """True when a rule reduces to exactly one significant term.
+
+    For a one-term rule such as ``"psycopg2"`` or ``"no postgres"``, the
+    term-matching below is indistinguishable from matching the rule's own
+    literal text: there is no phrase to take apart and therefore no guess
+    about which word carries the meaning. Those rules are safe to evaluate
+    against every decision in the corpus.
+
+    Multi-term rules are the opposite. ``"open() without encoding= in Python"``
+    explodes into {open, without, encoding, python}, any one of which fires on
+    its own -- so the rule reports a violation on prose that merely contains
+    the word "open". Evaluating those corpus-wide turns a documented
+    false-positive nuisance (#150) into a repo-wide edit block, so they stay
+    behind retrieval until a typed literal vocabulary replaces them (#250).
+    """
+    return len(_rule_terms(text, min_len=min_len)) == 1
+
+
+def _enforcement_scope(
+    scored: list[ScoredDecision],
+    top: int,
+) -> list[tuple[ScoredDecision, bool]]:
+    """Every decision to evaluate, paired with whether to restrict it.
+
+    Enforcement is not a ranking question -- "is this forbidden?" has the same
+    answer whether or not the filename happened to share a token with the
+    decision's scope (#254). So the corpus is evaluated in two tiers:
+
+    - the retrieval-gated tier (top-N, positive score) keeps its pre-#254
+      behaviour and is checked against every rule it carries;
+    - every remaining decision is checked against its unambiguous literal
+      rules only.
+
+    Returns ``(scored_decision, literal_rules_only)`` pairs, gated tier first,
+    each decision appearing once.
+    """
+    gated = _top_nonzero(scored, top)
+    gated_ids = {g.decision.id for g in gated}
+
+    out: list[tuple[ScoredDecision, bool]] = [(g, False) for g in gated]
+    seen: set[str] = set(gated_ids)
+    for s in scored:
+        if s.decision.id in seen:
+            continue
+        seen.add(s.decision.id)
+        out.append((s, True))
+    return out
+
+
 def check_prompt(
     input_text: str,
     scored: list[ScoredDecision],
     top: int = 3,
 ) -> EnforcementResult:
-    """Check input_text against the top-N retrieved decisions.
+    """Check input_text against the decision corpus.
+
+    Unambiguous literal rules are checked against every decision supplied,
+    regardless of retrieval score; multi-term rules are checked only for the
+    top-N retrieved decisions. See ``_enforcement_scope``.
 
     Args:
         input_text: The prompt or content to validate.
         scored:     Pre-scored decisions (from DecisionRetriever.retrieve()),
                     sorted descending by score.
-        top:        Maximum number of decisions to check.
+        top:        Size of the retrieval-gated tier. This bounds how many
+                    decisions have their *multi-term* rules applied; it never
+                    limits which decisions are enforced.
 
     Returns:
         EnforcementResult with verdict and list of Violations.
     """
     violations: list[Violation] = []
 
-    for s in _top_nonzero(scored, top):
+    for s, literal_only in _enforcement_scope(scored, top):
         d = s.decision
 
         for ap in d.anti_patterns:
+            if literal_only and not _is_literal_rule(ap):
+                continue
             for term in _rule_terms(ap):
                 if _word_in_text(term, input_text):
                     violations.append(Violation(
@@ -116,6 +180,8 @@ def check_prompt(
             if not m:
                 continue
             forbidden_phrase = m.group(1).strip()
+            if literal_only and not _is_literal_rule(forbidden_phrase):
+                continue
             for term in _rule_terms(forbidden_phrase, min_len=3):
                 if _word_in_text(term, input_text):
                     violations.append(Violation(

--- a/tests/integrations/claude_code/test_hook_e2e.py
+++ b/tests/integrations/claude_code/test_hook_e2e.py
@@ -22,10 +22,28 @@ def project(tmp_path):
     (tmp_path / ".mneme" / "project_memory.json").write_text(
         FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
     )
-    # Use "storage_db.py" so the query "edit to .../storage_db.py" contains
-    # the token "storage", which matches the fixture decision's scope field
-    # and ensures the retriever returns a non-zero score.
+    # "storage_db.py" shares the token "storage" with the fixture decision's
+    # scope, so the retriever returns a non-zero score for it. This used to be
+    # a *requirement* for enforcement to fire at all; since ADR-017 it is just
+    # one case. `neutral_project` below covers the other.
     target = tmp_path / "storage_db.py"
+    target.write_text(SEED_OLD + "\n", encoding="utf-8")
+    return tmp_path, target
+
+
+@pytest.fixture
+def neutral_project(tmp_path):
+    """Same fixture, but a filename that scores zero against the decision.
+
+    Regression cover for #254: enforcement must not depend on the filename
+    sharing a token with the decision's scope. Before ADR-017 the hook let this
+    edit through with no violation.
+    """
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    target = tmp_path / "service.py"
     target.write_text(SEED_OLD + "\n", encoding="utf-8")
     return tmp_path, target
 
@@ -129,4 +147,40 @@ def test_warn_mode_surfaces_violation_against_real_cli(project, monkeypatch):
 def test_compliant_write_passes(project):
     cwd, target = project
     rc = main(stdin=io.StringIO(_write_envelope(cwd, target, "import sqlite3\n")))
+    assert rc == 0
+
+
+# ── #254: enforcement under a filename that retrieves nothing ────────────────
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_violation_blocks_under_neutral_filename(neutral_project):
+    """The defect, end to end through the real CLI.
+
+    `service.py` scores 0.00 against the fixture decision, so before ADR-017
+    the decision was never evaluated and this edit was allowed.
+    """
+    cwd, target = neutral_project
+    err = io.StringIO()
+    rc = main(stdin=io.StringIO(_envelope(cwd, target, "import psycopg2")), stderr=err)
+    assert rc == 2, "a violating edit must block regardless of the filename"
+    assert "test_001" in err.getvalue() or "psycopg2" in err.getvalue()
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_violating_write_blocks_under_neutral_filename(neutral_project):
+    cwd, target = neutral_project
+    err = io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_write_envelope(cwd, target, "import psycopg2\n")),
+        stderr=err,
+    )
+    assert rc == 2
+    assert "test_001" in err.getvalue() or "psycopg2" in err.getvalue()
+
+
+@pytest.mark.skipif(shutil.which("mneme") is None, reason="mneme CLI not on PATH")
+def test_compliant_passes_under_neutral_filename(neutral_project):
+    """Corpus-wide enforcement must not become blanket blocking."""
+    cwd, target = neutral_project
+    rc = main(stdin=io.StringIO(_envelope(cwd, target, "import sqlite3")))
     assert rc == 0

--- a/tests/test_enforcement_scope.py
+++ b/tests/test_enforcement_scope.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #254 — enforcement must not be retrieval-gated.
+
+Retrieval answers "what context is relevant?" — a ranking question, where a
+top-N cutoff is correct. Enforcement answers "is this forbidden?" — a safety
+question, where ranking is wrong. Before #254, `enforcer._top_nonzero` filtered
+retrieved decisions to `score > 0`, so a decision that scored zero against the
+hook's `"edit to <file_path>"` query was never evaluated at all. Byte-identical
+violating content was therefore caught or missed purely on whether the filename
+happened to contain a scope keyword.
+
+These tests deliberately use *neutral* filenames that share no token with the
+fixture decision's scope. `tests/integrations/claude_code/test_hook_e2e.py`
+names its target `storage_db.py` and says so in a comment — it was built around
+the limitation rather than exposing it, which is why the defect survived.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from mneme.cli import main
+from mneme.decision_retriever import DecisionRetriever
+from mneme.enforcer import Severity, check_prompt
+from mneme.memory_store import MemoryStore
+
+# The same fixture the Claude Code e2e suite uses: one decision, scoped to
+# ["storage", "database"], forbidding psycopg2.
+FIXTURE = (
+    Path(__file__).parent
+    / "integrations" / "claude_code" / "fixtures" / "project_memory.json"
+)
+
+VIOLATING_CONTENT = "import psycopg2\n"
+
+# Filenames sharing no retrieval token with scope ["storage", "database"].
+# "db.py" is included deliberately: the scope says "database", and "db" is not
+# a lexical match for it.
+NEUTRAL_FILENAMES = ["service.py", "models.py", "db.py", "handler.py"]
+
+
+@pytest.fixture
+def memory(tmp_path):
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    return mem
+
+
+def _write(tmp_path, name, content=VIOLATING_CONTENT):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ── the defect, stated directly ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("filename", NEUTRAL_FILENAMES)
+def test_violation_is_caught_under_a_neutral_filename(memory, tmp_path, filename):
+    """Forbidden content must FAIL regardless of what the file is called."""
+    target = _write(tmp_path, filename)
+    exit_code = main([
+        "check",
+        "--memory", str(memory),
+        "--input", str(target),
+        "--query", f"edit to {filename}",
+        "--mode", "strict",
+    ])
+    assert exit_code == 2, (
+        f"{filename}: identical violating content must be caught; enforcement "
+        f"must not depend on the filename containing a scope keyword"
+    )
+
+
+def test_verdict_is_identical_for_identical_content_across_filenames(
+    memory, tmp_path,
+):
+    """The scope-keyword filename and a neutral one must agree.
+
+    This is the exact reproduction from #254: byte-identical content, only the
+    filename differs, opposite verdicts.
+    """
+    verdicts = {}
+    for filename in ["storage_db.py", *NEUTRAL_FILENAMES]:
+        target = _write(tmp_path, filename)
+        verdicts[filename] = main([
+            "check",
+            "--memory", str(memory),
+            "--input", str(target),
+            "--query", f"edit to {filename}",
+            "--mode", "strict",
+        ])
+    assert len(set(verdicts.values())) == 1, (
+        f"identical content produced different verdicts by filename: {verdicts}"
+    )
+
+
+def test_zero_scoring_decision_is_still_enforced(memory):
+    """Unit-level statement of the same property.
+
+    Enforcement reads the whole corpus, not the retriever's positive-score
+    top-N. A decision that scores 0.00 against the query still has its
+    anti_patterns checked against the content.
+    """
+    store = MemoryStore(memory)
+    store.load()
+    scored = DecisionRetriever(store.decisions()).retrieve("edit to service.py")
+
+    # Premise: the decision genuinely scores zero for this query. If this
+    # assertion ever fails the test has stopped testing what it claims to.
+    assert all(s.score == 0 for s in scored), (
+        f"premise broken: expected an all-zero retrieval score, got "
+        f"{[(s.decision.id, s.score) for s in scored]}"
+    )
+
+    result = check_prompt(VIOLATING_CONTENT, scored)
+    assert result.verdict == Severity.FAIL
+    assert any(v.trigger == "psycopg2" for v in result.violations)
+
+
+def test_compliant_content_still_passes_under_a_neutral_filename(memory, tmp_path):
+    """Corpus-wide enforcement must not turn into blanket failure."""
+    target = _write(tmp_path, "service.py", "import sqlite3\n")
+    exit_code = main([
+        "check",
+        "--memory", str(memory),
+        "--input", str(target),
+        "--query", "edit to service.py",
+        "--mode", "strict",
+    ])
+    assert exit_code == 0

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -152,9 +152,36 @@ def test_violation_records_trigger_term():
     assert "postgres" in warn_v.trigger
 
 
-def test_zero_score_decisions_are_skipped():
+def test_zero_score_decision_still_enforces_its_literal_rules():
+    """Zero retrieval score no longer exempts a decision from enforcement.
+
+    Replaces `test_zero_score_decisions_are_skipped`, which pinned the #254
+    defect: `_top_nonzero` dropped every zero-scoring decision, so identical
+    content was caught or missed on the strength of the filename alone.
+
+    STORAGE's `no postgres` constraint is a one-term rule, so it applies
+    corpus-wide and WARNs here. Its `introduce ORM` anti_pattern is multi-term
+    and stays retrieval-gated, so it does not fire -- which is why the verdict
+    is WARN and not FAIL. See ADR-017.
+    """
     scored = [_scored(STORAGE, score=0.0)]
     result = check_prompt("Use postgres and introduce ORM.", scored)
+    assert result.verdict == Severity.WARN
+    assert any(v.trigger == "postgres" for v in result.violations)
+    assert not any(v.severity == Severity.FAIL for v in result.violations)
+
+
+def test_zero_score_decision_does_not_apply_multi_term_rules():
+    """The #150 guardrail: corpus-wide enforcement is literal rules only.
+
+    A multi-term rule explodes into individual tokens, any one of which fires
+    on its own. Applying those to every decision would turn documented
+    false-positive noise into a repo-wide edit block, so they remain gated.
+    """
+    scored = [_scored(STORAGE, score=0.0)]
+    # "introduce" alone would trigger the "introduce ORM" anti_pattern under
+    # the pre-#254 disjunctive matcher had the decision been retrieved.
+    result = check_prompt("Let me introduce the new reporting feature.", scored)
     assert result.verdict == Severity.PASS
 
 


### PR DESCRIPTION
Closes #254.

## The defect

Enforcement silently missed violations when the filename lacked a scope keyword. `enforcer._top_nonzero` filtered retrieved decisions to `score > 0`, so a decision scoring zero was never evaluated. Byte-identical content, opposite verdicts:

```
storage_db.py -> FAIL, 1 violation
service.py    -> PASS, 0 violations
```

Both files contained exactly `import psycopg2`, against a decision whose `anti_patterns` contains `psycopg2`. Measured scores: `storage_db.py` 3.00, `service.py` 0.00, `models.py` 0.00, `db.py` 0.00. `db.py` misses because the scope says `database` and `db` is not a lexical match.

Silent non-enforcement is worse than no tool, because users trust it. This was the pilot blocker.

## Why the obvious fix is wrong on its own

Evaluating every decision against the existing matcher, measured across 216 tracked files:

| Enforcement scope | Files reporting FAIL |
|---|---|
| Retrieval-gated (before) | 44 of 216 |
| Every decision, existing matcher | 170 of 216 |

Every one of those 170 — and every one of the pre-existing 44 — was manually confirmed a **false positive**. The matcher explodes a rule phrase into terms and fires on any single one, so `open() without encoding= in Python` reports a violation against prose containing the word `open`. Other observed triggers: `without`, `content`, `any`, `main`, `governance`. That is the noise already filed as #150; globalising it would have made strict mode unusable.

## The change

Enforcement evaluates the corpus in two tiers:

- **Unambiguous literal rules** — those reducing to exactly one significant term, where term matching and literal matching coincide — apply regardless of retrieval score.
- **Multi-term prose rules** stay retrieval-gated until a typed literal vocabulary replaces them (#250).

`--top` is re-scoped rather than removed: it bounds the retrieval-gated tier and context injection, never which decisions are enforced.

## Measured after the change

```
repro:           FAIL under service.py, models.py, db.py, handler.py and storage_db.py
compliant:       PASS under all of them
repo-wide FAIL:  44 of 216 -- identical to baseline, false positives do not increase
suite:           458 passed
```

## Tests

`test_zero_score_decisions_are_skipped` asserted the defective behaviour and is replaced by two tests pinning the new contract. New `tests/test_enforcement_scope.py` covers the CLI path across four neutral filenames. The e2e hook suite gains a neutral-filename fixture — its existing fixture chose `storage_db.py` precisely so retrieval would work, which is why the defect survived.

## ADR-017

No existing ADR governed the retrieval/enforcement separation; all 16 were checked. An external design review recommended settling this "against ADR-014", which is the positioning-vocabulary ADR and is unrelated — that citation was fabricated. ADR-017 records the decision, including the measurement basis and the fact that the ADR and its own test trip the pre-existing `#150` rules on the bare words `main` and `enforcement`.

## Follow-ups not in this PR

- #250 typed literal vocabulary — the durable replacement for the term-count proxy
- #150 matcher false positives — unchanged here, now the main remaining source of noise
- Full-file vs introduced-delta enforcement, and rule path-applicability — both surfaced by external review, both genuinely uncovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)