### PR TITLE
fix: keep CLI output alive under legacy console codepages (#253)

### DIFF
--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -514,7 +515,39 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _force_utf8_stdio() -> None:
+    """Make stdout/stderr able to carry any character a decision contains.
+
+    Decision text is arbitrary user content. This repo's own memory carries
+    U+2192 in the imported ADR-001, ADR-005 and ADR-014 decisions, and on
+    Windows the console defaults to cp1252, which cannot encode it -- so
+    rendering a perfectly valid decision crashed the CLI with
+    UnicodeEncodeError partway through its output (#253).
+
+    Source-level ASCII discipline cannot fix this, because the character comes
+    from the memory file rather than from mneme. Applied here in ``main`` so
+    every subcommand is covered: previously only ``benchmark`` and
+    ``adr import`` guarded themselves, while ``test_query`` and ``check``
+    -- both of which render decision text -- did not.
+
+    Note this differs from the Claude Code hook's ASCII-only rule. The hook
+    writes into a protocol another process parses, so it constrains what it
+    emits; the CLI writes for a human and instead widens what its stream can
+    carry.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                # Detached or already-wrapped stream: rendering degrades to
+                # whatever the caller supplied, which is still better than
+                # refusing to run.
+                pass
+
+
 def main(argv: list[str] | None = None) -> int:
+    _force_utf8_stdio()
     parser = _build_parser()
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/test_cli_console_encoding.py
+++ b/tests/test_cli_console_encoding.py
@@ -1,0 +1,97 @@
+"""Regression tests for issue #253 — CLI output under a legacy console codepage.
+
+`mneme test_query` crashed with UnicodeEncodeError on Windows' default cp1252
+console. The issue proposed replacing "the unicode arrow" in the explanation
+string with ASCII, but there is no such character in mneme's source: the arrow
+comes from the *user's memory data*. ADR-005, ADR-014 and ADR-001 all carry
+U+2192 in their imported decision text in this repo's own
+`.mneme/project_memory.json`.
+
+Decision text is arbitrary user content, so no amount of source-level ASCII
+discipline fixes this. The output stream itself has to be able to carry it.
+That makes it a `main()`-level concern rather than a per-subcommand one: every
+subcommand that renders a decision can hit it.
+
+These run the CLI in a subprocess with PYTHONIOENCODING forced to cp1252,
+because the crash is a property of the real stdout encoding and pytest's
+capture replaces stdout with a UTF-8-capable object.
+"""
+import json
+import subprocess
+import sys
+
+import pytest
+
+# U+2192 RIGHTWARDS ARROW: the exact character from the issue's traceback.
+ARROW = "→"
+
+NON_ASCII_MEMORY = {
+    "meta": {"name": "encoding-test", "description": "non-ascii fixture"},
+    "items": [],
+    "examples": [],
+    "decisions": [
+        {
+            "id": "arrow_001",
+            "decision": f"Route requests client {ARROW} gateway {ARROW} service",
+            "rationale": f"explicit hop order {ARROW} easier tracing",
+            "scope": ["routing"],
+            "constraints": ["no direct client-to-service calls"],
+            "anti_patterns": ["bypass gateway"],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def memory(tmp_path):
+    p = tmp_path / "project_memory.json"
+    # ensure_ascii=False writes the raw character, matching how real memory
+    # files carry it once an ADR with an arrow has been imported.
+    p.write_text(json.dumps(NON_ASCII_MEMORY, ensure_ascii=False), encoding="utf-8")
+    return p
+
+
+def _run(args):
+    """Invoke the CLI in a subprocess pinned to a cp1252 stdout."""
+    return subprocess.run(
+        [sys.executable, "-m", "mneme", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={**_base_env(), "PYTHONIOENCODING": "cp1252"},
+    )
+
+
+def _base_env():
+    import os
+    env = dict(os.environ)
+    env.pop("PYTHONIOENCODING", None)
+    return env
+
+
+def test_test_query_survives_legacy_console_codepage(memory):
+    """The reported crash: test_query renders decision text and died on it."""
+    r = _run([
+        "test_query", "--memory", str(memory), "--query", "routing gateway",
+    ])
+    assert "UnicodeEncodeError" not in r.stderr, (
+        f"test_query crashed on non-ASCII decision text:\n{r.stderr}"
+    )
+    assert r.returncode == 0
+    # The command must reach its final section, not die partway through.
+    assert "Injected" in r.stdout
+
+
+def test_check_survives_legacy_console_codepage(memory, tmp_path):
+    """`check` prints decision_text for every violation, so it is exposed too."""
+    target = tmp_path / "handler.py"
+    target.write_text("we bypass gateway here\n", encoding="utf-8")
+    r = _run([
+        "check", "--memory", str(memory), "--input", str(target),
+        "--query", "routing gateway", "--mode", "warn",
+    ])
+    assert "UnicodeEncodeError" not in r.stderr, (
+        f"check crashed on non-ASCII decision text:\n{r.stderr}"
+    )
+    assert "Result:" in r.stdout


### PR DESCRIPTION
Closes #253.

`mneme test_query` crashed with `UnicodeEncodeError` on Windows' cp1252 console, printing its scored-decisions list then dying before the "Injected" section.

## The issue's premise was wrong, usefully

#253 proposed replacing "the unicode arrow" in the explanation string with ASCII. **There is no such character in mneme's source.** U+2192 arrives from the *memory data*: ADR-001, ADR-005 and ADR-014 all carry it in their imported decision text in this repo's own `.mneme/project_memory.json`.

Decision text is arbitrary user content, so source-level ASCII discipline cannot fix this — the stream has to be able to carry it.

## Broader than test_query

`check` renders `decision_text` for every violation and crashed identically. Only `benchmark` and `adr import` had guarded themselves. The guard is applied once in `main()` so every subcommand is covered, with `errors="replace"` so an exotic character degrades a glyph rather than killing the run.

## Deliberately the opposite of the hook's rule

The Claude Code hook is ASCII-only because it writes into a protocol another process parses, so it constrains what it emits. The CLI writes for a human and instead widens what its stream accepts.

## Tests

`tests/test_cli_console_encoding.py` runs the CLI in a subprocess with `PYTHONIOENCODING=cp1252` — the crash is a property of the real stdout encoding, and pytest's capture replaces stdout with a UTF-8-capable object, which is why this was invisible to the existing suite. Both `test_query` and `check` are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)