### PR TITLE
fix: reject malformed ADR constraint directives instead of dropping them (#258)

### DIFF
--- a/mneme/adr_constraints.py
+++ b/mneme/adr_constraints.py
@@ -9,7 +9,16 @@ machine-actionable directives, one per line, in the form::
     - FORBID_PATH: src/legacy/**
     - REQUIRE_PATH: billing/**
 
-This module is a strict, deterministic parser. Unknown directive kinds raise.
+This module is a strict, deterministic parser. Unknown directive kinds raise,
+and so does a bullet that was evidently meant to be a directive but is
+malformed — wrong case, wrong separator, empty value, or a missing colon.
+Silently dropping those would let a typo defeat governance while the author
+believes the rule was recorded (#258).
+
+Ordinary prose bullets are still ignored, so the section can carry a note
+without failing compilation. See ``_looks_like_directive`` for where the line
+is drawn.
+
 The section is bounded by the next H2 header or end of body — content beyond
 the section boundary is ignored, even if it looks like a directive.
 """
@@ -43,6 +52,49 @@ _SECTION_HEADER = re.compile(r"^##\s+Constraints\s*$", re.MULTILINE)
 _NEXT_H2 = re.compile(r"^##\s+\S", re.MULTILINE)
 _DIRECTIVE_LINE = re.compile(r"^\s*-\s*([A-Z_]+)\s*:\s*(.+?)\s*$")
 
+# A list bullet of any kind, with its content captured.
+_BULLET = re.compile(r"^\s*[-*]\s+(.*)$")
+
+# The head of a bullet that reads as an attempted directive name: a single
+# token, no whitespace, starting with a letter.
+_HEAD_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+
+def _normalise_kind(token: str) -> str:
+    """Fold a directive-name token toward its canonical form."""
+    return token.upper().replace("-", "_")
+
+
+def _looks_like_directive(content: str) -> bool:
+    """True when a bullet was evidently meant to be a directive.
+
+    Deliberately narrow, because the alternative failure is worse: too broad a
+    discriminator turns ordinary prose in a ``## Constraints`` section into a
+    compile error, and authors would learn to avoid the section entirely.
+
+    A bullet qualifies when either:
+
+    - the text before its first colon is a single token that looks like a
+      directive name -- all-uppercase, or containing ``_`` or ``-``. This
+      catches ``forbid_dependency:``, ``FORBID-DEPENDENCY:`` and
+      ``FORBID_DEPENDENCY:`` with an empty value, while leaving
+      ``Prefer sqlite: it keeps the deployment single-file`` alone, whose
+      pre-colon text contains a space; or
+    - it has no colon at all, but its first token names a known kind --
+      catching ``- FORBID_DEPENDENCY mongodb``.
+    """
+    head, sep, _ = content.partition(":")
+    if sep:
+        head = head.strip()
+        if _HEAD_TOKEN.match(head) and (
+            head.isupper() or "_" in head or "-" in head
+        ):
+            return True
+        return False
+
+    first = content.split()[0] if content.split() else ""
+    return _normalise_kind(first) in VALID_KINDS
+
 
 def parse_constraints_section(body: str) -> list[ConstraintDirective]:
     """Extract directives from the first ``## Constraints`` section in body.
@@ -63,15 +115,36 @@ def parse_constraints_section(body: str) -> list[ConstraintDirective]:
     out: list[ConstraintDirective] = []
     for line in section_text.splitlines():
         m = _DIRECTIVE_LINE.match(line)
-        if not m:
+        if m:
+            kind, value = m.group(1), m.group(2).strip()
+            if kind not in VALID_KINDS:
+                raise ConstraintParseError(
+                    f"unknown constraint directive {kind!r} "
+                    f"(expected one of {sorted(VALID_KINDS)})"
+                )
+            if not value:
+                # `(.+?)` can match a lone space, so a whitespace-only value
+                # satisfies the regex and then strips to nothing -- a directive
+                # that names a real kind and forbids nothing.
+                raise ConstraintParseError(
+                    f"constraint directive {kind!r} has an empty value: "
+                    f"{line.strip()!r}"
+                )
+            out.append(ConstraintDirective(kind=kind, value=value))
             continue
-        kind, value = m.group(1), m.group(2).strip()
-        if kind not in VALID_KINDS:
+
+        # Not a well-formed directive. Before dropping it, decide whether it
+        # was meant to be one -- silently discarding an attempted rule is the
+        # dangerous direction for governance (#258).
+        bullet = _BULLET.match(line)
+        if bullet and _looks_like_directive(bullet.group(1).strip()):
             raise ConstraintParseError(
-                f"unknown constraint directive {kind!r} "
-                f"(expected one of {sorted(VALID_KINDS)})"
+                f"malformed constraint directive: {line.strip()!r}. "
+                f"Directives must be written as "
+                f"`- KIND: value` with an uppercase, underscore-separated "
+                f"KIND and a non-empty value "
+                f"(expected one of {sorted(VALID_KINDS)})."
             )
-        out.append(ConstraintDirective(kind=kind, value=value))
     return out
 
 

--- a/tests/test_adr_constraints.py
+++ b/tests/test_adr_constraints.py
@@ -71,3 +71,93 @@ def test_directive_value_strips_whitespace():
     body = "## Constraints\n- FORBID_DEPENDENCY:    mongodb   \n"
     [d] = parse_constraints_section(body)
     assert d.value == "mongodb"
+
+
+# ── #258: malformed directives must not be silently dropped ──────────────────
+#
+# The module documents itself as "a strict, deterministic parser", but that
+# strictness only ever applied to lines matching `_DIRECTIVE_LINE`. A bullet
+# that was clearly *meant* to be a directive and failed the regex fell through
+# `if not m: continue` and vanished. Governance fails in the dangerous
+# direction there: the author believes a rule was recorded, the compiler
+# emitted nothing, and the decision ships with no enforcement payload.
+#
+# This matters most right before a new directive vocabulary lands (#250), when
+# authors are typing names they have never typed before.
+
+import pytest
+
+
+@pytest.mark.parametrize("line,reason", [
+    ("- forbid_dependency: mongodb", "lowercase kind"),
+    ("- Forbid_Dependency: mongodb", "mixed-case kind"),
+    ("- FORBID-DEPENDENCY: mongodb", "hyphen instead of underscore"),
+    ("- FORBID_DEPENDENCY:", "missing value"),
+    ("- FORBID_DEPENDENCY:   ", "whitespace-only value"),
+    ("- FORBID_DEPENDENCY mongodb", "missing colon"),
+])
+def test_malformed_directive_raises_instead_of_being_dropped(line, reason):
+    body = f"## Constraints\n{line}\n"
+    with pytest.raises(ConstraintParseError) as exc:
+        parse_constraints_section(body)
+    # The author has to be able to find the offending line.
+    assert line.lstrip("- ").split(":")[0].strip() in str(exc.value) or \
+        line.strip() in str(exc.value), (
+            f"{reason}: error must identify the offending directive, got {exc.value!r}"
+        )
+
+
+def test_malformed_directive_raises_even_alongside_valid_ones():
+    """A valid directive must not mask a broken sibling."""
+    body = (
+        "## Constraints\n"
+        "- FORBID_DEPENDENCY: mongodb\n"
+        "- forbid_path: src/legacy/**\n"
+    )
+    with pytest.raises(ConstraintParseError):
+        parse_constraints_section(body)
+
+
+@pytest.mark.parametrize("line", [
+    "- Should not be parsed as a directive",
+    "- See the migration notes at https://example.com/docs",
+    "- Prefer sqlite: it keeps the deployment single-file",
+    "- one, two, three",
+    "(none yet)",
+    "",
+])
+def test_prose_bullets_are_still_ignored(line):
+    """Strictness must not turn ordinary prose into a compile failure.
+
+    The discriminator is deliberately narrow: a bullet counts as a directive
+    attempt only when the text before its first colon is a single token that
+    looks like a directive name. `Prefer sqlite: ...` has a lowercase one-word
+    head with no underscore, so it reads as prose; `forbid_path: ...` does not.
+    """
+    body = f"## Constraints\n{line}\n"
+    assert parse_constraints_section(body) == []
+
+
+def test_prose_and_valid_directive_coexist():
+    body = (
+        "## Constraints\n"
+        "- These rules apply to the billing subsystem only.\n"
+        "- FORBID_DEPENDENCY: mongodb\n"
+    )
+    assert parse_constraints_section(body) == [
+        ConstraintDirective(kind="FORBID_DEPENDENCY", value="mongodb")
+    ]
+
+
+def test_malformed_directive_outside_the_section_is_ignored():
+    """Section bounding still wins: strictness applies only inside."""
+    body = (
+        "## Constraints\n"
+        "- FORBID_DEPENDENCY: redis\n"
+        "\n"
+        "## Notes\n"
+        "- forbid_dependency: kafka\n"
+    )
+    assert parse_constraints_section(body) == [
+        ConstraintDirective(kind="FORBID_DEPENDENCY", value="redis")
+    ]


### PR DESCRIPTION
Closes #258. Gates #250.

## Problem

`adr_constraints.py` documents itself as "a strict, deterministic parser. Unknown directive kinds raise." That strictness only ever applied to lines matching `_DIRECTIVE_LINE`. Anything directive-shaped that failed the regex fell through `if not m: continue` and vanished silently:

| Input | Why it failed the regex |
|---|---|
| `- forbid_string: pip install mneme` | `[A-Z_]+` rejects lowercase |
| `- FORBID_STRING:` | `(.+?)` requires a character |
| `- FORBID-STRING: pip install mneme` | `-` is not in `[A-Z_]` |
| `- FORBID_DEPENDENCY mongodb` | no colon |

Three of the four are plausible first-time authoring mistakes. Governance fails in the dangerous direction: the author believes a rule was recorded, the compiler emits nothing, the decision ships toothless. That is the ADR-005 shape — a correctly-intended rule with nothing enforcing it.

## Found while writing the tests

`- FORBID_DEPENDENCY:   ` (whitespace-only value) was worse than the cases in the issue. `(.+?)` happily matches a lone space, so it satisfied `_DIRECTIVE_LINE`, stripped to an empty value, and produced a **valid-looking directive naming a real kind that forbids nothing**. Now rejected explicitly.

## Change

Malformed directives raise `ConstraintParseError`, consistent with existing unknown-kind behaviour, quoting the offending line.

Prose is still ignored, so the section can carry a note without failing compilation. The discriminator is deliberately narrow, because too broad a rule would turn prose into a compile error and teach authors to avoid the section:

- text before the first colon is a single token that looks like a directive name (all-uppercase, or containing `_`/`-`), **or**
- no colon at all, but the first token names a known kind

So `Prefer sqlite: it keeps the deployment single-file` reads as prose (pre-colon text contains a space); `forbid_path: src/**` does not.

## No regression

All 5 files in the repo with a `## Constraints` section still parse, including `examples/mneme-own-adrs` (3 directives each). `mneme adr import --dry-run` completes cleanly over both `docs/adr` and `examples/mneme-own-adrs`. Full suite: 462 passed.

## Why now

#250 adds `FORBID_STRING` to `VALID_KINDS`, putting directive names in front of authors who have never typed them before — exactly when typos happen. Landing new vocabulary on a parser that swallows malformed directives would make the feature look supported while quietly doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)