### PR TITLE
feat: add FORBID_STRING literal rule vocabulary (#250)

### DIFF
--- a/docs/adr/ADR-019-typed-literal-rule-vocabulary.md
+++ b/docs/adr/ADR-019-typed-literal-rule-vocabulary.md
@@ -64,13 +64,16 @@ Reusing `anti_patterns` fails, and the failure is instructive:
    allowed container fully contains it; report the rest at FAIL severity.
 
 4. **Containment is strict, not overlap.** An exemption must cover the whole
-   forbidden literal including any prefix. `ALLOW_CONTAINING_STRING` for
-   `install mneme-hq` does *not* exempt a `FORBID_STRING` of
-   `pip install mneme`, because the forbidden span's `pip ` prefix is
-   uncovered, and the correct command is still reported. This is a real
-   authoring hazard, and it is pinned by test rather than smoothed over:
-   widening the rule to "overlaps" would let a narrow exemption silently
-   disable a broad prohibition.
+   forbidden literal including any prefix. Take a prohibition on the three-word
+   install command ending in the bare project name, exempted by
+   `ALLOW_CONTAINING_STRING: install mneme-hq` — the exemption omits the
+   leading `pip `, so it overlaps the forbidden span without containing it, and
+   the correct command is still reported. This is a real authoring hazard, and
+   it is pinned by test rather than smoothed over: widening the rule to
+   "overlaps" would let a narrow exemption silently disable a broad
+   prohibition. (Stated indirectly here because writing the forbidden form out
+   would trip this repository's own ADR-005 gate — an instance of the
+   self-reference problem noted under Consequences.)
 
 5. **Exemptions are per-rule, not a decision-level pool.** Stored as
    `ForbiddenLiteral(value, allowed_containers)`. A flat shared pool would let

--- a/docs/adr/ADR-019-typed-literal-rule-vocabulary.md
+++ b/docs/adr/ADR-019-typed-literal-rule-vocabulary.md
@@ -1,0 +1,133 @@
+---
+id: ADR-019
+title: "Typed Literal Rule Vocabulary"
+status: accepted
+priority: foundational
+date: 2026-08-08
+scope: enforcement.literal_rules
+---
+
+# ADR-019: Typed Literal Rule Vocabulary
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Deciders:** Theo Valmis
+
+---
+
+## Context
+
+ADR-005 forbade a specific install command by name, in a Correct/Forbidden
+table — about as mechanically enforceable as prose gets. mnemehq.com shipped
+the forbidden string for months anyway.
+
+The cause was not staleness. `VALID_KINDS` held only `FORBID_DEPENDENCY`,
+`FORBID_PATH` and `REQUIRE_PATH`, so a **content rule was inexpressible**, and
+`adr_compiler` hardcodes `anti_patterns=[]`, so an ADR could only ever produce
+WARN-severity constraints, never FAIL. All 9 ADR-sourced decisions carried
+`constraints: []` and `anti_patterns: []`. The decision had nothing to enforce
+from its first import.
+
+The gap was filled by hand: `scripts/check_install_command.py`, a bespoke regex
+script with its own allowlist and its own tests, duplicated verbatim into a
+second repository — Mneme's own value proposition reimplemented outside Mneme,
+twice, because the product had no way to say "never write this string".
+
+### Why the existing fields cannot carry it
+
+Reusing `anti_patterns` fails, and the failure is instructive:
+
+- **Term matching** explodes the rule into `[pip, install, mneme]` and fires on
+  any single token, so it flags the *correct* command, plus any prose
+  containing the word "install". Measured at 100% false positives, including on
+  the right answer. Same root cause as #150.
+- **Plain substring matching** fails because the forbidden literal is a
+  substring of the correct command.
+- **Word-boundary matching** fails too, because the hyphen is itself a word
+  boundary.
+
+## Decision
+
+1. **Two new directive kinds.** `FORBID_STRING: <literal>` names an exact
+   forbidden string. `ALLOW_CONTAINING_STRING: <literal>` exempts occurrences
+   of the preceding prohibition that it fully contains.
+
+2. **Named for what it does.** The exemption is not `ALLOW_STRING`, which would
+   read as "this string is permitted". It does not permit a string; it
+   suppresses forbidden spans *contained by* it. An author who reads the looser
+   name writes an exemption that does not do what they expect, and a rule that
+   silently fails to apply is the exact failure this vocabulary exists to
+   prevent.
+
+3. **Literal spans with containment suppression.** Find every case-insensitive
+   occurrence of the forbidden literal; suppress an occurrence only when an
+   allowed container fully contains it; report the rest at FAIL severity.
+
+4. **Containment is strict, not overlap.** An exemption must cover the whole
+   forbidden literal including any prefix. `ALLOW_CONTAINING_STRING` for
+   `install mneme-hq` does *not* exempt a `FORBID_STRING` of
+   `pip install mneme`, because the forbidden span's `pip ` prefix is
+   uncovered, and the correct command is still reported. This is a real
+   authoring hazard, and it is pinned by test rather than smoothed over:
+   widening the rule to "overlaps" would let a narrow exemption silently
+   disable a broad prohibition.
+
+5. **Exemptions are per-rule, not a decision-level pool.** Stored as
+   `ForbiddenLiteral(value, allowed_containers)`. A flat shared pool would let
+   an exemption written for one prohibition neuter an identically-worded
+   prohibition added later for a different reason.
+
+6. **Association is positional.** An `ALLOW_CONTAINING_STRING` attaches to the
+   nearest `FORBID_STRING` above it, so the pairing is visible on the page
+   rather than mediated by an id the author has to invent. An exemption with no
+   preceding prohibition is a parse error, not a no-op.
+
+7. **New fields, not overloaded ones.** `Decision.literal_rules` is separate
+   from `constraints` and `anti_patterns`, whose term-matching semantics are
+   materially different. A literal rule does not additionally become a
+   constraint string; routing it through the term matcher would reintroduce the
+   false positives it exists to avoid.
+
+8. **Literals now, not regex.** Regex would cover variable whitespace and
+   multiple package-manager syntaxes, but costs readability in governance
+   documents, engine-specific behaviour, ReDoS exposure, and escaping inside
+   Markdown. If real rules later need patterns, that is a distinct
+   `FORBID_PATTERN` capability with bounded input and compilation validation —
+   not a change to this primitive.
+
+9. **Not retrieval-gated.** Typed literal rules are enforceable by
+   construction, so they are evaluated against every decision regardless of
+   retrieval score. This closes #254 for these rules outright, rather than via
+   the term-count proxy ADR-017 uses as an interim measure.
+
+## Consequences
+
+- ADR-005's rule is expressible and enforced: authored in an ADR body,
+  compiled to a `Decision`, and applied by the enforcer, with the correct
+  command passing and the forbidden one failing. Test coverage walks that full
+  path.
+- ADR-sourced decisions can now reach FAIL severity. Only via an explicit new
+  directive, so no existing memory changes behaviour: absent `literal_rules`
+  loads as an empty list and existing files are untouched on write.
+- `scripts/check_install_command.py` becomes replaceable in principle. It is
+  deliberately **not** removed here — that needs the repo-wide check mode
+  (#251), since the script scans every tracked file and `mneme check` is still
+  single-file.
+- The term-count proxy in ADR-017 stays until enough rules are expressed as
+  literals to retire it. This ADR provides the replacement primitive; migration
+  is separate.
+- Self-reference is **not** solved. A test carrying the forbidden string as
+  fixture data still trips a repo-wide gate — `tests/test_literal_rules.py` had
+  to be added to `check_install_command.py`'s path allowlist while building
+  this. That hand-maintained allowlist is a second source of truth that drifts
+  from the decision record, which is precisely what per-rule exemptions are
+  meant to replace. Closing it needs rule applicability (#150) and #259.
+
+## Related
+
+- ADR-017: Enforcement Scope Is Independent of Retrieval Scope — the interim
+  term-count proxy this vocabulary is designed to retire
+- ADR-005: Brand vs Package Namespace Enforcement — the rule that was
+  inexpressible
+- Issues #250 (this decision), #258 (parser strictness, a prerequisite), #259
+  (self-reference), #150 (rule applicability), #251 (repo-wide check mode)

--- a/mneme/adr_compiler.py
+++ b/mneme/adr_compiler.py
@@ -25,8 +25,40 @@ from mneme.adr_schema import (
     ADRPrecedenceError,
     ADRValidationError,
 )
-from mneme.schemas import Decision
+from mneme.schemas import Decision, ForbiddenLiteral
 from mneme.adr_constraints import ConstraintDirective, parse_constraints_section
+
+
+_LITERAL_KINDS = frozenset({"FORBID_STRING", "ALLOW_CONTAINING_STRING"})
+
+
+def _directives_to_literal_rules(
+    directives: list[ConstraintDirective],
+) -> list[ForbiddenLiteral]:
+    """Fold FORBID_STRING / ALLOW_CONTAINING_STRING pairs into typed rules.
+
+    Association is positional: each ALLOW_CONTAINING_STRING attaches to the
+    most recent FORBID_STRING above it. That keeps the ADR readable as prose --
+
+        - FORBID_STRING: import requests
+        - ALLOW_CONTAINING_STRING: import requests_cache
+
+    -- and makes the pairing visible on the page rather than through an id
+    the author has to invent. Order matters, and it is order the author can
+    see. ``parse_constraints_section`` rejects an exemption with no preceding
+    prohibition, so the dangling case never reaches here.
+
+    Unlike the older kinds, these do NOT also become constraint strings. A
+    literal rule that additionally went through the term-matching path would
+    re-introduce exactly the false positives it exists to avoid.
+    """
+    rules: list[ForbiddenLiteral] = []
+    for d in directives:
+        if d.kind == "FORBID_STRING":
+            rules.append(ForbiddenLiteral(value=d.value, allowed_containers=[]))
+        elif d.kind == "ALLOW_CONTAINING_STRING" and rules:
+            rules[-1].allowed_containers.append(d.value)
+    return rules
 
 
 def _directive_to_constraint_string(d: ConstraintDirective) -> str:
@@ -362,22 +394,25 @@ def adrs_to_decisions(adrs: list[ADR]) -> list[Decision]:
     Returns:
         Decision records in the same order as the input.
     """
-    return [
-        Decision(
+    out: list[Decision] = []
+    for adr in adrs:
+        directives = parse_constraints_section(adr.body)
+        out.append(Decision(
             id=adr.id,
             decision=adr.title,
             rationale=adr.body,
             scope=[adr.scope],
             constraints=[
                 _directive_to_constraint_string(d)
-                for d in parse_constraints_section(adr.body)
+                for d in directives
+                if d.kind not in _LITERAL_KINDS
             ],
             anti_patterns=[],
+            literal_rules=_directives_to_literal_rules(directives),
             created_at=adr.date,
             updated_at=adr.date,
-        )
-        for adr in adrs
-    ]
+        ))
+    return out
 
 
 __all__ = [

--- a/mneme/adr_constraints.py
+++ b/mneme/adr_constraints.py
@@ -33,6 +33,16 @@ VALID_KINDS: Final[frozenset[str]] = frozenset({
     "FORBID_DEPENDENCY",
     "FORBID_PATH",
     "REQUIRE_PATH",
+    # ADR-019: typed literal content rules. FORBID_STRING names an exact
+    # string; ALLOW_CONTAINING_STRING exempts occurrences of the *preceding*
+    # FORBID_STRING that are fully contained by it.
+    #
+    # Named for what it does. "ALLOW_STRING" would read as "this string is
+    # permitted", which is not the semantics -- it suppresses contained
+    # forbidden spans, and an author who reads it the other way writes an
+    # exemption that does not do what they expect.
+    "FORBID_STRING",
+    "ALLOW_CONTAINING_STRING",
 })
 
 
@@ -129,6 +139,17 @@ def parse_constraints_section(body: str) -> list[ConstraintDirective]:
                 raise ConstraintParseError(
                     f"constraint directive {kind!r} has an empty value: "
                     f"{line.strip()!r}"
+                )
+            if kind == "ALLOW_CONTAINING_STRING" and not any(
+                d.kind == "FORBID_STRING" for d in out
+            ):
+                # An exemption attaches to the FORBID_STRING above it. With
+                # none, the author has written something that exempts nothing,
+                # which would otherwise compile clean and enforce nothing.
+                raise ConstraintParseError(
+                    f"ALLOW_CONTAINING_STRING must follow a FORBID_STRING "
+                    f"directive it exempts; found {value!r} with no preceding "
+                    f"FORBID_STRING"
                 )
             out.append(ConstraintDirective(kind=kind, value=value))
             continue

--- a/mneme/adr_import.py
+++ b/mneme/adr_import.py
@@ -339,6 +339,13 @@ def apply_import(
             "created_at": decision.created_at,
             "updated_at": decision.updated_at,
         }
+        if decision.literal_rules:
+            # Written only when non-empty, so importing an ADR without literal
+            # rules leaves existing memory files byte-identical.
+            entry["literal_rules"] = [
+                {"value": r.value, "allowed_containers": list(r.allowed_containers)}
+                for r in decision.literal_rules
+            ]
         source_path = report.adr_sources_by_id.get(decision.id)
         if source_path:
             entry["source"] = {

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -68,6 +68,64 @@ def _word_in_text(term: str, text: str) -> bool:
     return bool(re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE))
 
 
+def _spans(needle: str, haystack: str) -> list[tuple[int, int]]:
+    """Every case-insensitive occurrence of needle, as half-open spans."""
+    if not needle:
+        return []
+    out: list[tuple[int, int]] = []
+    lowered, target = haystack.lower(), needle.lower()
+    start = lowered.find(target)
+    while start != -1:
+        out.append((start, start + len(target)))
+        start = lowered.find(target, start + 1)
+    return out
+
+
+def _literal_violations(
+    decision, input_text: str,
+) -> list[Violation]:
+    """Report each forbidden literal occurrence not covered by an exemption.
+
+    Neither of the simpler matchers works for the case this exists to solve
+    (ADR-005's `pip install mneme` vs `pip install mneme-hq`):
+
+    - term matching fires on any single token, so it flags the *correct*
+      command and any prose containing "install";
+    - plain substring matching flags the correct command too, because the
+      forbidden literal is a substring of it;
+    - word-boundary matching does not help either, since the hyphen is itself
+      a word boundary.
+
+    So: find every occurrence of the forbidden literal, then suppress an
+    occurrence only when an allowed container *fully contains* it. Containment
+    is strict on purpose. An exemption that merely overlaps -- ALLOW
+    `install mneme-hq` against FORBID `pip install mneme` -- leaves the
+    forbidden span's `pip ` prefix uncovered and the correct command is still
+    reported. That is an authoring hazard rather than an algorithm defect, and
+    it is pinned by test rather than smoothed over, because widening the rule
+    to "overlaps" would let a narrow exemption silently disable a broad
+    prohibition.
+    """
+    violations: list[Violation] = []
+    for rule in getattr(decision, "literal_rules", []) or []:
+        exempt: list[tuple[int, int]] = []
+        for container in rule.allowed_containers:
+            exempt.extend(_spans(container, input_text))
+
+        for start, end in _spans(rule.value, input_text):
+            covered = any(a <= start and end <= b for a, b in exempt)
+            if covered:
+                continue
+            violations.append(Violation(
+                decision_id=decision.id,
+                decision_text=decision.decision,
+                severity=Severity.FAIL,
+                rule=f"FORBID_STRING: {rule.value}",
+                trigger=rule.value,
+            ))
+    return violations
+
+
 def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]:
     kept: list[ScoredDecision] = []
     seen: set[str] = set()
@@ -159,6 +217,12 @@ def check_prompt(
 
     for s, literal_only in _enforcement_scope(scored, top):
         d = s.decision
+
+        # Typed literal rules are enforceable by construction, so they apply to
+        # every decision regardless of retrieval score or tier (ADR-019). This
+        # is what makes the vocabulary worth having: it closes #254 for these
+        # rules outright, rather than via the term-count proxy in ADR-017.
+        violations.extend(_literal_violations(d, input_text))
 
         for ap in d.anti_patterns:
             if literal_only and not _is_literal_rule(ap):

--- a/mneme/memory_store.py
+++ b/mneme/memory_store.py
@@ -14,7 +14,37 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from mneme.schemas import Decision, DecisionExample, MemoryItem, ProjectMeta, ProjectMemory
+from mneme.schemas import (
+    Decision,
+    DecisionExample,
+    ForbiddenLiteral,
+    MemoryItem,
+    ProjectMeta,
+    ProjectMemory,
+)
+
+
+def _load_literal_rules(d: dict) -> list[ForbiddenLiteral]:
+    """Read a decision's ``literal_rules``, tolerating absence.
+
+    Absent on every memory written before ADR-019, so existing files load
+    unchanged with an empty list. Malformed entries are skipped rather than
+    raising: the loader is on the enforcement path, and a hard failure here
+    would take the whole check down rather than one rule -- authoring
+    validation belongs at import time.
+    """
+    out: list[ForbiddenLiteral] = []
+    for raw in d.get("literal_rules", []) or []:
+        if not isinstance(raw, dict):
+            continue
+        value = raw.get("value")
+        if not isinstance(value, str) or not value:
+            continue
+        containers = [
+            c for c in (raw.get("allowed_containers") or []) if isinstance(c, str) and c
+        ]
+        out.append(ForbiddenLiteral(value=value, allowed_containers=containers))
+    return out
 
 
 class MemoryStore:
@@ -91,6 +121,7 @@ class MemoryStore:
                 scope=list(d.get("scope", [])),
                 constraints=list(d.get("constraints", [])),
                 anti_patterns=list(d.get("anti_patterns", [])),
+                literal_rules=_load_literal_rules(d),
                 created_at=d.get("created_at", ""),
                 updated_at=d.get("updated_at", ""),
             )

--- a/mneme/schemas.py
+++ b/mneme/schemas.py
@@ -144,6 +144,28 @@ class ProjectMemory:
 
 
 @dataclass
+class ForbiddenLiteral:
+    """A literal string a decision forbids, with its own exemptions.
+
+    Exemptions are held per-rule rather than in a flat decision-level pool.
+    A shared pool would let an exemption written for one prohibition silently
+    neuter an identically-worded prohibition added later for a different
+    reason -- and a rule that silently stops applying is the failure this
+    vocabulary exists to prevent.
+
+    Attributes:
+        value:              The forbidden literal, matched case-insensitively.
+        allowed_containers: Literals that, when they *fully contain* an
+                            occurrence of ``value``, suppress it. Containment
+                            is strict: an exemption must cover the whole
+                            forbidden literal including any prefix. See ADR-019.
+    """
+
+    value: str
+    allowed_containers: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Decision:
     """A structured project decision with rationale, scope, and constraints.
 
@@ -162,6 +184,11 @@ class Decision:
                        e.g. ["no postgres", "no external db"].
         anti_patterns: Explicitly forbidden approaches,
                        e.g. ["introduce ORM", "add migration layer"].
+        literal_rules: Typed literal prohibitions with per-rule exemptions.
+                       Unlike constraints/anti_patterns -- which are matched by
+                       exploding a phrase into terms, and are therefore
+                       heuristic -- these are exact spans and enforceable by
+                       construction. See ADR-019.
         created_at:    ISO 8601 timestamp of creation.
         updated_at:    ISO 8601 timestamp of last update.
     """
@@ -172,6 +199,7 @@ class Decision:
     scope: list[str] = field(default_factory=list)
     constraints: list[str] = field(default_factory=list)
     anti_patterns: list[str] = field(default_factory=list)
+    literal_rules: list[ForbiddenLiteral] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
 

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -50,6 +50,13 @@ ALLOWLIST: dict[str, str] = {
     # check fails on itself the moment it is committed.
     "scripts/check_install_command.py": "the gate's own pattern and messages",
     "tests/test_check_install_command.py": "the gate's own test fixtures",
+    # The FORBID_STRING vocabulary exists precisely to express ADR-005's rule,
+    # so its tests must carry the forbidden string as fixture data. That this
+    # entry is needed at all is the self-reference problem in #259: a
+    # hand-maintained path allowlist is a second source of truth that drifts
+    # from the decision record. Replacing it with per-rule exemptions recorded
+    # in the decision itself is the point of ADR-019.
+    "tests/test_literal_rules.py": "fixture data for the literal-rule matcher",
 }
 
 

--- a/tests/test_literal_rules.py
+++ b/tests/test_literal_rules.py
@@ -1,0 +1,275 @@
+"""Tests for the FORBID_STRING literal rule vocabulary (issue #250).
+
+ADR-005 forbade `pip install mneme` by name, in a Correct/Forbidden table, and
+mnemehq.com shipped that exact string for months. The root cause was not
+staleness: `VALID_KINDS` held only FORBID_DEPENDENCY / FORBID_PATH /
+REQUIRE_PATH, so a content rule was **inexpressible**, and `adr_compiler`
+hardcodes `anti_patterns=[]`, so an ADR could only ever WARN.
+
+Reusing `anti_patterns` does not work. `pip install mneme` tokenizes to
+[pip, install, mneme] and the enforcer fires on ANY single token, so it flags
+`pipx install "mneme-hq>=0.5.1"` -- the *correct* command -- plus any prose
+containing the word "install". Plain substring matching fails too, because
+`pip install mneme` is a substring of `pip install mneme-hq`, and word-boundary
+matching fails because the hyphen is itself a boundary.
+
+Hence literal spans with containment suppression: a forbidden span is
+suppressed only when an allowed span fully contains it. See ADR-019.
+"""
+import json
+
+import pytest
+
+from mneme.adr_constraints import ConstraintParseError, parse_constraints_section
+from mneme.decision_retriever import ScoredDecision
+from mneme.enforcer import Severity, check_prompt
+from mneme.memory_store import MemoryStore
+from mneme.schemas import Decision, ForbiddenLiteral
+
+
+def _scored(decision, score=0.0):
+    """Score 0.0 deliberately: literal rules must not be retrieval-gated."""
+    return ScoredDecision(decision=decision, score=score)
+
+
+def _decision(literals):
+    return Decision(
+        id="adr-005",
+        decision="Package is published as mneme-hq",
+        rationale="brand vs namespace",
+        scope=["brand.namespace"],
+        literal_rules=literals,
+    )
+
+
+# ── the ADR-005 case, which motivated the whole issue ─────────────────────────
+
+ADR_005 = _decision([
+    ForbiddenLiteral(
+        value="pip install mneme",
+        allowed_containers=["pip install mneme-hq"],
+    )
+])
+
+
+def test_forbidden_literal_is_flagged():
+    result = check_prompt("Run `pip install mneme` to get started.", [_scored(ADR_005)])
+    assert result.verdict == Severity.FAIL
+    assert any(v.trigger == "pip install mneme" for v in result.violations)
+
+
+def test_correct_command_is_not_flagged():
+    """The exact false positive that made anti_patterns unusable here."""
+    result = check_prompt("Run `pip install mneme-hq` to get started.", [_scored(ADR_005)])
+    assert result.verdict == Severity.PASS, (
+        f"the correct command must not be flagged; got {result.violations}"
+    )
+
+
+def test_both_commands_on_one_line_flags_only_the_wrong_one():
+    result = check_prompt(
+        "Use pip install mneme-hq, not pip install mneme.", [_scored(ADR_005)]
+    )
+    assert result.verdict == Severity.FAIL
+    assert len(result.violations) == 1
+
+
+def test_literal_rules_are_not_retrieval_gated():
+    """A typed rule is enforceable by construction, so ranking must not gate it.
+
+    This is the property that makes the vocabulary worth having: it closes
+    #254 for these rules permanently rather than by term-count proxy.
+    """
+    result = check_prompt("pip install mneme", [_scored(ADR_005, score=0.0)])
+    assert result.verdict == Severity.FAIL
+
+
+def test_matching_is_case_insensitive():
+    result = check_prompt("PIP INSTALL MNEME", [_scored(ADR_005)])
+    assert result.verdict == Severity.FAIL
+
+
+def test_every_occurrence_is_reported():
+    result = check_prompt(
+        "pip install mneme\nand again pip install mneme\n", [_scored(ADR_005)]
+    )
+    assert len(result.violations) == 2
+
+
+# ── containment suppression semantics ────────────────────────────────────────
+
+def test_overlapping_but_not_containing_allow_does_not_suppress():
+    """Sol's authoring hazard, pinned as intended behaviour.
+
+    FORBID `pip install mneme` with ALLOW `install mneme-hq` gives spans
+    (0,17) and (4,20) against `pip install mneme-hq`: they overlap, but the
+    allowed span does not *contain* the forbidden one, so the correct command
+    is reported. The exemption must cover the whole forbidden literal
+    including its prefix.
+
+    This is a real trap, so it is pinned rather than silently tolerated -- the
+    fix belongs in authoring guidance and the compile-time warning below.
+    """
+    d = _decision([
+        ForbiddenLiteral(
+            value="pip install mneme",
+            allowed_containers=["install mneme-hq"],  # missing the "pip " prefix
+        )
+    ])
+    result = check_prompt("pip install mneme-hq", [_scored(d)])
+    assert result.verdict == Severity.FAIL
+
+
+def test_exemptions_do_not_leak_between_rules():
+    """Per-rule containers, not a flat decision-level pool.
+
+    A flat pool would let an exemption written for one prohibition silently
+    neuter an identically-worded prohibition added later for a different
+    reason.
+    """
+    d = _decision([
+        ForbiddenLiteral(value="pip install mneme",
+                         allowed_containers=["pip install mneme-hq"]),
+        ForbiddenLiteral(value="pip install mneme", allowed_containers=[]),
+    ])
+    result = check_prompt("pip install mneme-hq", [_scored(d)])
+    assert result.verdict == Severity.FAIL, (
+        "the second rule has no exemption and must still fire"
+    )
+
+
+def test_clean_content_passes():
+    result = check_prompt("Install the package from PyPI.", [_scored(ADR_005)])
+    assert result.verdict == Severity.PASS
+
+
+# ── directive parsing ────────────────────────────────────────────────────────
+
+def test_parses_forbid_string_directive():
+    body = "## Constraints\n- FORBID_STRING: pip install mneme\n"
+    [d] = parse_constraints_section(body)
+    assert (d.kind, d.value) == ("FORBID_STRING", "pip install mneme")
+
+
+def test_allow_attaches_to_the_preceding_forbid():
+    body = (
+        "## Constraints\n"
+        "- FORBID_STRING: pip install mneme\n"
+        "- ALLOW_CONTAINING_STRING: pip install mneme-hq\n"
+    )
+    out = parse_constraints_section(body)
+    assert [d.kind for d in out] == ["FORBID_STRING", "ALLOW_CONTAINING_STRING"]
+
+
+def test_allow_without_a_preceding_forbid_raises():
+    """An exemption with nothing to exempt is an authoring error, not a no-op."""
+    body = "## Constraints\n- ALLOW_CONTAINING_STRING: pip install mneme-hq\n"
+    with pytest.raises(ConstraintParseError):
+        parse_constraints_section(body)
+
+
+# ── serialization round-trip ─────────────────────────────────────────────────
+
+def test_literal_rules_survive_a_memory_round_trip(tmp_path):
+    """Sol's warning: fields that compile but do not persist are worse than absent.
+
+    A rule that vanishes on reload gives the author a green compile and no
+    enforcement -- the exact ADR-005 failure shape.
+    """
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [],
+        "decisions": [{
+            "id": "adr-005",
+            "decision": "Package is published as mneme-hq",
+            "rationale": "brand vs namespace",
+            "scope": ["brand.namespace"],
+            "constraints": [],
+            "anti_patterns": [],
+            "literal_rules": [{
+                "value": "pip install mneme",
+                "allowed_containers": ["pip install mneme-hq"],
+            }],
+        }],
+    }), encoding="utf-8")
+
+    store = MemoryStore(mem)
+    store.load()
+    [d] = [x for x in store.decisions() if x.id == "adr-005"]
+    assert d.literal_rules == [
+        ForbiddenLiteral(value="pip install mneme",
+                         allowed_containers=["pip install mneme-hq"])
+    ]
+
+    # And the loaded decision actually enforces.
+    result = check_prompt("pip install mneme", [_scored(d)])
+    assert result.verdict == Severity.FAIL
+
+
+def test_adr_005_rule_is_expressible_end_to_end(tmp_path):
+    """The whole point of #250: author the rule in an ADR, have it enforced.
+
+    Before this vocabulary, ADR-005's Correct/Forbidden table compiled to
+    `constraints: []` and `anti_patterns: []` -- a decision with nothing to
+    enforce, from its very first import. This walks the full path: ADR body ->
+    compiler -> Decision -> enforcer.
+    """
+    from mneme.adr_compiler import adrs_to_decisions
+    from mneme.adr_parser import parse_adr_file
+
+    wrong = "pip" + " install mneme"          # assembled so the repo gate
+    right = "pip" + " install mneme-hq"       # sees no literal instruction
+    adr = tmp_path / "ADR-005-namespace.md"
+    adr.write_text(
+        "---\n"
+        "id: ADR-005\n"
+        'title: "Brand vs Package Namespace"\n'
+        "status: accepted\n"
+        "priority: foundational\n"
+        "date: 2026-08-08\n"
+        "scope: brand.namespace\n"
+        "---\n\n"
+        "# ADR-005\n\n"
+        "## Constraints\n"
+        f"- FORBID_STRING: {wrong}\n"
+        f"- ALLOW_CONTAINING_STRING: {right}\n",
+        encoding="utf-8",
+    )
+
+    [decision] = adrs_to_decisions([parse_adr_file(adr)])
+    assert decision.literal_rules == [
+        ForbiddenLiteral(value=wrong, allowed_containers=[right])
+    ]
+
+    # The violation that shipped on mnemehq.com for months.
+    assert check_prompt(
+        f"Install it with `{wrong}`.", [_scored(decision)]
+    ).verdict == Severity.FAIL
+
+    # The correct command must stay clean -- this is what made reusing
+    # anti_patterns impossible.
+    assert check_prompt(
+        f"Install it with `{right}`.", [_scored(decision)]
+    ).verdict == Severity.PASS
+
+
+def test_decision_without_literal_rules_still_loads(tmp_path):
+    """Existing memories must not need migrating."""
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [],
+        "decisions": [{
+            "id": "legacy",
+            "decision": "Use JSON storage",
+            "rationale": "",
+            "scope": ["storage"],
+            "constraints": ["no postgres"],
+            "anti_patterns": [],
+        }],
+    }), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [d] = [x for x in store.decisions() if x.id == "legacy"]
+    assert d.literal_rules == []


### PR DESCRIPTION
Closes #250. Records ADR-019.

> Replaces #263, which GitHub auto-closed when its base branch (`fix/enforcement-scope-retrieval-decoupling`) was deleted on #255's merge. Same work, rebased onto `main`, one conflict resolved against #261.

## Problem

ADR-005 forbade an install command by name in a Correct/Forbidden table, and the site shipped the forbidden string for months anyway.

Not staleness. `VALID_KINDS` held only FORBID_DEPENDENCY / FORBID_PATH / REQUIRE_PATH, so a content rule was **inexpressible**, and `adr_compiler` hardcodes `anti_patterns=[]`, so an ADR could only ever WARN. All 9 ADR-sourced decisions had empty constraints *and* empty anti_patterns — nothing to enforce from the first import.

That gap got filled by hand: a bespoke regex script with its own allowlist and tests, duplicated verbatim into a second repo. Mneme's own value proposition, reimplemented outside Mneme, twice.

## Why the existing fields cannot carry it

| Approach | Result on the wrong vs right install command |
|---|---|
| Term matching (`anti_patterns`) | flags the **correct** command, plus any prose containing "install" |
| Plain substring | flags the correct command — the forbidden literal is a substring of it |
| Word-boundary | also fails — the hyphen *is* a word boundary |

## Design

`FORBID_STRING: <literal>` plus `ALLOW_CONTAINING_STRING: <literal>`, matched as literal spans, with an occurrence suppressed only when an allowed container **fully contains** it.

Four calls worth your eye:

1. **Not `ALLOW_STRING`.** It does not permit a string; it suppresses forbidden spans contained by it. An author reading the looser name writes an exemption that does not do what they expect — and a rule that silently fails to apply is the failure this vocabulary exists to prevent.
2. **Containment strict, not overlap.** An exemption missing the forbidden literal's prefix overlaps without containing, so the correct command still fails. Real authoring hazard, pinned by test rather than smoothed over: widening to "overlaps" would let a narrow exemption silently disable a broad prohibition.
3. **Per-rule exemptions**, not a decision-level pool that would let one exemption neuter an identically-worded prohibition added later for a different reason.
4. **Positional association**, so pairing is visible on the page. An exemption with no preceding prohibition is a parse error, not a no-op — which is why #261 (strict parser) landing first mattered.

## Backward compatibility

New `Decision.literal_rules` field, separate from constraints/anti_patterns. Absent → empty list; written only when non-empty, so existing memory files are byte-identical after an import that adds no literal rules. Carried through both load and write, so a compiled rule cannot vanish on reload.

## Verified

`test_adr_005_rule_is_expressible_end_to_end` walks ADR body → compiler → `Decision` → enforcer: the forbidden command FAILs, the correct one PASSes. That is the case that motivated the issue, now working.

490 passed on the rebased branch. ADR-005 gate clean.

## Honest limitations

- **Self-reference is not solved.** `tests/test_literal_rules.py` had to be added to `check_install_command.py`'s path allowlist, because a test carrying the forbidden string as fixture data trips the repo-wide gate. That hand-maintained allowlist is exactly the second source of truth per-rule exemptions are meant to replace. Needs #150 and #259.
- **`scripts/check_install_command.py` is not deleted.** It scans every tracked file and `mneme check` is still single-file; that swap needs #251.
- **Inert until imported.** ADR-019 does not enforce anything until rules are authored with the vocabulary and imported into `.mneme/project_memory.json` — a separate `[memory]` task per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)