### PR TITLE
feat: publish the Mneme Claude plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "mneme",
+  "owner": {
+    "name": "Mneme HQ"
+  },
+  "description": "Claude Code plugins for architectural governance with Mneme.",
+  "plugins": [
+    {
+      "name": "mneme",
+      "source": "./integrations/claude-code-plugin",
+      "description": "Enforce architectural decisions and engineering standards before Claude Code writes changes."
+    }
+  ]
+}

--- a/integrations/claude-code-plugin/README.md
+++ b/integrations/claude-code-plugin/README.md
@@ -44,10 +44,15 @@ claude --plugin-dir /path/to/mneme/integrations/claude-code-plugin
 
 After changes, reload in-session with `/reload-plugins`.
 
-**From a marketplace:** not yet available. The plugin has not been submitted to
-the Claude Code community catalog, so `--plugin-dir` above is currently the
-only installation path. Once it is listed, enabling it from Claude Code's
-plugin UI will prompt for the **enforcement mode** (`strict` or `warn`).
+**From the Mneme marketplace:**
+
+```text
+/plugin marketplace add MnemeHQ/mneme
+/plugin install mneme@mneme
+```
+
+On enable, Claude Code prompts for the **enforcement mode** (`strict` or
+`warn`).
 
 ## How enforcement works
 


### PR DESCRIPTION
## Summary

- add a repository-level Claude Code marketplace catalog for the existing Mneme plugin
- document the marketplace add and plugin install commands
- preserve the current `mneme-hq>=0.5.1` runtime requirement and hook safety guidance

## Why

This makes the existing Claude Code plugin discoverable and installable from the public `MnemeHQ/mneme` repository and prepares it for submission to Claude's community plugin directory.

## User impact

After this lands, users can add `MnemeHQ/mneme` as a marketplace and install `mneme@mneme` from Claude Code instead of relying only on `--plugin-dir`.

## Validation

- `claude plugin validate . --strict`
- `claude plugin validate integrations/claude-code-plugin --strict`
- `python -m pytest tests/integrations/claude_code tests/test_packaging_contract.py -q` — 85 passed, 5 skipped
- registered the checkout as a local Claude marketplace and installed `mneme@mneme` in strict mode
- direct hook smoke test: violating content exited 2; compliant content exited 0
