### PR TITLE
feat: add typed ADR literal enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## Unreleased
 
-_Nothing yet._
+### Added
+
+- Typed ADR enforcement with `FORBID_LITERAL`. ADR import now persists
+  explicit typed rules, `mneme check` applies them independently of retrieval
+  score, and human/JSON output identifies the rule type.
+- Retrieval-only import diagnostics for active ADRs that yield zero
+  mechanically enforceable rules.
+
+### Compatibility
+
+- Existing `constraints` and `anti_patterns` retain their current matching and
+  severity behavior. Memory files without `rules` continue to load unchanged.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,10 @@ into `Decision` objects at load time; no changes needed to existing JSON files.
   "rationale": "Avoid infra complexity and keep local-first.",
   "scope": ["storage", "backend"],
   "constraints": ["no postgres", "no external database"],
-  "anti_patterns": ["introduce ORM", "add migration layer"]
+  "anti_patterns": ["introduce ORM", "add migration layer"],
+  "rules": [
+    {"type": "FORBID_LITERAL", "value": "install legacy-package"}
+  ]
 }
 ```
 
@@ -349,8 +352,8 @@ print(result.injected_decisions)  # list[Decision] actually sent
 
 ### Conflict detection
 
-`ConflictDetector` scans the LLM response for constraint and anti-pattern
-violations **after** the call. It is a detector, not a blocker:
+`ConflictDetector` scans the LLM response for constraint, anti-pattern, and
+typed-rule violations **after** the call. It is a detector, not a blocker:
 
 ```python
 from mneme.conflict_detector import ConflictDetector
@@ -360,6 +363,8 @@ conflicts = ConflictDetector().detect(response.content, injected_decisions)
 
 A term is only flagged when it appears **without** a negation signal nearby.
 `"Do not use Postgres"` is not a conflict. `"Switch to Postgres"` is.
+Typed `FORBID_LITERAL` rules do not use this heuristic: the exact literal is
+forbidden regardless of surrounding prose.
 
 ### CLI
 
@@ -574,6 +579,7 @@ Result: PASS
 | `PASS`  | No violations in top-N decisions | 0 | 0 |
 | `WARN`  | Input mentions a term forbidden by a `"no X"` constraint | 1 | 0 |
 | `FAIL`  | Input contains a term from a decision's `anti_patterns` list | 2 | 0 |
+| `FAIL`  | Input matches a typed `FORBID_LITERAL` rule | 2 | 0 |
 
 Detection is deterministic — no ML, no LLM, no external calls. Same input
 always returns the same verdict.
@@ -681,7 +687,9 @@ mneme adr import docs/adr --memory .mneme/project_memory.json --dry-run
 
 The default is dry-run: the preview shows the active set, the projected
 graph status of every ADR, the constraints that would be persisted, and
-any conflicts. Apply when you're satisfied:
+any conflicts or retrieval-only ADR warnings. A dry-run returns exit 1 when
+an active ADR has no mechanically enforceable rules. Apply when you're
+satisfied:
 
 ```bash
 mneme adr import docs/adr --memory .mneme/project_memory.json --apply
@@ -699,15 +707,21 @@ include an optional `## Constraints` section with directives:
 
 ```markdown
 ## Constraints
+- FORBID_LITERAL: install legacy-package
 - FORBID_DEPENDENCY: mongodb
 - FORBID_PATH: src/legacy/**
 - REQUIRE_PATH: billing/**
 ```
 
-Only `FORBID_DEPENDENCY` is currently end-to-end enforced (via
-`mneme check`); `FORBID_PATH` and `REQUIRE_PATH` persist into Decisions
-for retrieval visibility but glob-vs-changed-file enforcement is a
-follow-up.
+`FORBID_LITERAL` is persisted as a typed rule and produces `FAIL` through
+`mneme check`. Matching is case-sensitive and boundary-aware, so
+`pip install mneme` does not match `pip install mneme-hq`. The rule is checked
+across the decision corpus, independent of retrieval score. Its declaring ADR
+source is exempt so the policy document can state the literal it governs.
+
+`FORBID_DEPENDENCY` retains its legacy `WARN` behavior. `FORBID_PATH` and
+`REQUIRE_PATH` persist into Decisions for retrieval visibility but are not yet
+enforced against changed-file paths.
 
 See [docs/integrations/adr-import.md](docs/integrations/adr-import.md)
 for the full reference.

--- a/README.md
+++ b/README.md
@@ -717,7 +717,8 @@ include an optional `## Constraints` section with directives:
 `mneme check`. Matching is case-sensitive and boundary-aware, so
 `pip install mneme` does not match `pip install mneme-hq`. The rule is checked
 across the decision corpus, independent of retrieval score. Its declaring ADR
-source is exempt so the policy document can state the literal it governs.
+source and canonical memory file are exempt so policy storage can state the
+literal it governs.
 
 `FORBID_DEPENDENCY` retains its legacy `WARN` behavior. `FORBID_PATH` and
 `REQUIRE_PATH` persist into Decisions for retrieval visibility but are not yet

--- a/docs/integrations/adr-import.md
+++ b/docs/integrations/adr-import.md
@@ -39,6 +39,7 @@ machine-readable directives:
 
 ```markdown
 ## Constraints
+- FORBID_LITERAL: install legacy-package
 - FORBID_DEPENDENCY: mongodb
 - FORBID_PATH: src/legacy/billing/**
 - REQUIRE_PATH: billing/**
@@ -51,6 +52,7 @@ rather than being silently dropped -- a typo should not defeat governance.
 
 | Directive | Parsed and stored? | Enforced by `mneme check`? |
 |---|---|---|
+| `FORBID_LITERAL: text` | Yes, as a typed entry in `Decision.rules` | Yes -- exact, case-sensitive, boundary-aware match triggers FAIL |
 | `FORBID_DEPENDENCY: X` | Yes, as `"no X"` in Decision.constraints | Yes -- triggers WARN |
 | `FORBID_PATH: glob` | Yes, as `"FORBID_PATH glob"` in Decision.constraints | No (stored for visibility) |
 | `REQUIRE_PATH: glob` | Yes, as `"REQUIRE_PATH glob"` in Decision.constraints | No (stored for visibility) |
@@ -58,6 +60,20 @@ rather than being silently dropped -- a typo should not defeat governance.
 Glob-vs-changed-file enforcement for `FORBID_PATH` and `REQUIRE_PATH` is
 out of scope for the MVP -- the existing enforcer is a term-matcher, not a
 path-matcher. This is a follow-up capability.
+
+`FORBID_LITERAL` does not split prose into keywords. It checks the declared
+value directly and requires identifier/slug boundaries at identifier-like
+edges. For example, `pip install mneme` fails while `pip install mneme-hq`
+passes. The comparison is case-sensitive. Typed rules are enforced regardless
+of retrieval score; retrieval still controls context injection only. When ADR
+source provenance is available, a rule is not applied to its own declaring ADR
+so the source can state the literal it governs.
+
+An active ADR with no mechanically enforceable rules is still importable for
+retrieval, but preview prints a `Retrieval-only ADR warnings` diagnostic. A
+dry-run with that warning exits 1 so CI cannot mistake a toothless import for a
+clean enforcement payload. `--apply` may still persist the decision and exits 0
+when the write succeeds.
 
 ---
 
@@ -85,7 +101,7 @@ mneme adr import docs/adr --memory .mneme/project_memory.json --apply --approve-
 | Code | Meaning |
 |:---:|---|
 | 0 | Clean preview or successful apply |
-| 1 | Dry-run: diagnostics present (active-active contradiction or collisions). Useful as a CI signal. |
+| 1 | Dry-run: diagnostics present (including retrieval-only ADRs, active-active contradictions, or collisions). Useful as a CI signal. |
 | 2 | Apply refused (unresolved diagnostics or invalid input path) |
 
 ---
@@ -197,14 +213,18 @@ These are deliberate exclusions, not gaps:
    files. The enforcer is a term-matcher; path enforcement is a separate
    design problem.
 
-4. **Anti-pattern modelling via `## Constraints`.**
+4. **Automatic Correct/Forbidden table inference.** Tables remain human
+   documentation. Authors must declare `FORBID_LITERAL` explicitly; the
+   compiler does not guess which table cells are executable policy.
+
+5. **Anti-pattern modelling via `## Constraints`.**
    `Decision.anti_patterns` stays empty for ADR-derived records in v1.
 
-5. **`mneme adr suggest`.** A future augmentation layer for drafting ADRs
+6. **`mneme adr suggest`.** A future augmentation layer for drafting ADRs
    from existing code patterns. The import flow is its foundation, not its
    replacement.
 
-6. **Modifying `.mneme/project_memory.json` as part of this feature.** Per the
+7. **Modifying `.mneme/project_memory.json` as part of this feature.** Per the
    repo's governance rules, editing the canonical memory file requires a
    separate `[memory]`-tagged PR.
 
@@ -212,11 +232,10 @@ These are deliberate exclusions, not gaps:
 
 ## Integration with existing pipeline
 
-Imported decisions enter the existing
-`MemoryStore -> DecisionRetriever -> check_prompt` pipeline without any
-changes to those modules. Once persisted, they are retrieved by relevance,
-injected into context, and enforced by `mneme check` exactly like manually
-authored decisions.
+Imported decisions enter the
+`MemoryStore -> DecisionRetriever -> check_prompt` pipeline. Legacy constraints
+retain their historical behavior; typed rules are loaded separately and
+enforced deterministically by `mneme check`.
 
 ```python
 # Example: import then check in one session

--- a/docs/integrations/adr-import.md
+++ b/docs/integrations/adr-import.md
@@ -67,7 +67,7 @@ edges. For example, `pip install mneme` fails while `pip install mneme-hq`
 passes. The comparison is case-sensitive. Typed rules are enforced regardless
 of retrieval score; retrieval still controls context injection only. When ADR
 source provenance is available, a rule is not applied to its own declaring ADR
-so the source can state the literal it governs.
+or canonical memory file, so policy storage can state the literal it governs.
 
 An active ADR with no mechanically enforceable rules is still importable for
 retrieval, but preview prints a `Retrieval-only ADR warnings` diagnostic. A

--- a/mneme/adr_compiler.py
+++ b/mneme/adr_compiler.py
@@ -25,23 +25,30 @@ from mneme.adr_schema import (
     ADRPrecedenceError,
     ADRValidationError,
 )
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 from mneme.adr_constraints import ConstraintDirective, parse_constraints_section
 
 
 def _directive_to_constraint_string(d: ConstraintDirective) -> str:
     """Render a directive as a Decision.constraint string.
 
-    FORBID_DEPENDENCY is rendered in the ``"no X"`` form so the existing
-    enforcer (mneme.enforcer.check_prompt) triggers a WARN when the
+    FORBID_LITERAL is routed to ``_directive_to_rule`` before this helper is
+    called. FORBID_DEPENDENCY is rendered in the ``"no X"`` form so the
+    existing enforcer (mneme.enforcer.check_prompt) triggers a WARN when the
     forbidden term appears in a checked input. FORBID_PATH and REQUIRE_PATH
-    persist verbatim -- they're stored for retrieval visibility, but glob-
-    vs-changed-file enforcement is not implemented (out of scope for the
-    import MVP; the enforcer is a term-matcher, not a path-matcher).
+    persist verbatim -- they're stored for retrieval visibility, but glob-vs-
+    changed-file enforcement is not implemented.
     """
     if d.kind == "FORBID_DEPENDENCY":
         return f"no {d.value}"
     return f"{d.kind} {d.value}"
+
+
+def _directive_to_rule(d: ConstraintDirective) -> Rule | None:
+    """Compile a directive whose semantics are implemented as a typed rule."""
+    if d.kind == "FORBID_LITERAL":
+        return Rule(type="FORBID_LITERAL", value=d.value)
+    return None
 
 
 # ── Validation ────────────────────────────────────────────────────────────────
@@ -351,9 +358,10 @@ def adrs_to_decisions(adrs: list[ADR]) -> list[Decision]:
         ADR.scope   -> Decision.scope (wrapped in a single-element list)
         ADR.date    -> Decision.created_at and Decision.updated_at
 
-    ``Decision.constraints`` is populated from the ADR body's optional
-    ``## Constraints`` section via ``parse_constraints_section`` and the
-    ``_directive_to_constraint_string`` bridge. ``Decision.anti_patterns``
+    ``Decision.constraints`` and ``Decision.rules`` are populated from the
+    ADR body's optional ``## Constraints`` section via
+    ``parse_constraints_section`` and the typed/legacy directive bridges.
+    ``Decision.anti_patterns``
     is left empty for v1 — anti-pattern modelling stays in manual memory.
 
     Args:
@@ -362,22 +370,30 @@ def adrs_to_decisions(adrs: list[ADR]) -> list[Decision]:
     Returns:
         Decision records in the same order as the input.
     """
-    return [
-        Decision(
+    out: list[Decision] = []
+    for adr in adrs:
+        directives = parse_constraints_section(adr.body)
+        constraints: list[str] = []
+        rules: list[Rule] = []
+        for directive in directives:
+            rule = _directive_to_rule(directive)
+            if rule is not None:
+                rules.append(rule)
+            else:
+                constraints.append(_directive_to_constraint_string(directive))
+        out.append(Decision(
             id=adr.id,
             decision=adr.title,
             rationale=adr.body,
             scope=[adr.scope],
-            constraints=[
-                _directive_to_constraint_string(d)
-                for d in parse_constraints_section(adr.body)
-            ],
+            constraints=constraints,
             anti_patterns=[],
+            rules=rules,
+            source_path=adr.source_path,
             created_at=adr.date,
             updated_at=adr.date,
-        )
-        for adr in adrs
-    ]
+        ))
+    return out
 
 
 __all__ = [

--- a/mneme/adr_constraints.py
+++ b/mneme/adr_constraints.py
@@ -5,6 +5,7 @@ Mneme ADR bodies may include an optional ``## Constraints`` section listing
 machine-actionable directives, one per line, in the form::
 
     ## Constraints
+    - FORBID_LITERAL: install legacy-package
     - FORBID_DEPENDENCY: mongodb
     - FORBID_PATH: src/legacy/**
     - REQUIRE_PATH: billing/**
@@ -30,6 +31,7 @@ from typing import Final
 
 
 VALID_KINDS: Final[frozenset[str]] = frozenset({
+    "FORBID_LITERAL",
     "FORBID_DEPENDENCY",
     "FORBID_PATH",
     "REQUIRE_PATH",

--- a/mneme/adr_freshness.py
+++ b/mneme/adr_freshness.py
@@ -41,7 +41,8 @@ diagnostics (silently passes -- there is no hash to compare).
 
 The checker reads the memory file raw (json.load) rather than via
 MemoryStore so the ``source`` block survives the round-trip; the
-Decision dataclass intentionally does not carry source provenance.
+runtime Decision model carries only the resolved source path needed to avoid
+self-enforcement, not the stored hash needed for freshness comparison.
 """
 from __future__ import annotations
 

--- a/mneme/adr_import.py
+++ b/mneme/adr_import.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json as _json
 import os
+import re
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -94,6 +95,7 @@ def project_decision_graph(adrs: list[ADR]) -> list[DecisionNode]:
 
 
 DiagnosticKind = Literal[
+    "no_enforceable_rules",
     "active_active_contradiction",  # same-scope tie the compiler couldn't break
     "same_id",                      # incoming id collides with existing memory id
     "validation_error",             # malformed ADR — shown but doesn't raise
@@ -125,6 +127,16 @@ class ImportReport:
     decisions: list[Decision]
     diagnostics: list[ImportDiagnostic]
     adr_sources_by_id: dict[str, str] = field(default_factory=dict)
+
+
+def _has_mechanically_enforceable_rule(decision: Decision) -> bool:
+    """Return whether the current runtime can enforce any payload."""
+    if decision.rules or decision.anti_patterns:
+        return True
+    return any(
+        re.match(r"^no\s+.+$", constraint.strip(), re.IGNORECASE)
+        for constraint in decision.constraints
+    )
 
 
 def compile_for_import(adr_dir: str | Path) -> ImportReport:
@@ -162,6 +174,19 @@ def compile_for_import(adr_dir: str | Path) -> ImportReport:
     active_ids = {a.id for a in active_adrs}
     active_nodes = [n for n in all_nodes if n.id in active_ids]
     decisions = adrs_to_decisions(active_adrs)
+    for decision in decisions:
+        if not _has_mechanically_enforceable_rule(decision):
+            diagnostics.append(ImportDiagnostic(
+                kind="no_enforceable_rules",
+                adr_id=decision.id,
+                existing_in="",
+                message=(
+                    f"{decision.id} yields 0 mechanically enforceable rules; "
+                    f"it will be imported for retrieval only. Add an "
+                    f"enforceable directive such as FORBID_LITERAL under "
+                    f"## Constraints to make enforcement explicit."
+                ),
+            ))
     adr_sources_by_id = {a.id: a.source_path for a in active_adrs if a.source_path}
 
     return ImportReport(
@@ -239,10 +264,12 @@ def format_preview(
         lines.append(f"  [{node.id}] status={node.status}")
         decision = next((d for d in report.decisions if d.id == node.id), None)
         if decision:
+            for rule in decision.rules:
+                lines.append(f"      rule: {rule.type} {rule.value}")
             for c in decision.constraints:
                 lines.append(f"      constraint: {c}")
-            if not decision.constraints:
-                lines.append("      (no ## Constraints directives)")
+            if not decision.rules and not decision.constraints:
+                lines.append("      (no supported ## Constraints directives)")
     lines.append("")
 
     # Section: full corpus (graph view)
@@ -271,6 +298,16 @@ def format_preview(
             "  To proceed despite the contradiction, re-run with "
             "--approve-conflicts."
         )
+        lines.append("")
+
+    unenforceable_diags = [
+        d for d in report.diagnostics
+        if d.kind == "no_enforceable_rules"
+    ]
+    if unenforceable_diags:
+        lines.append("Retrieval-only ADR warnings:")
+        for d in unenforceable_diags:
+            lines.append(f"  - {d.message}")
         lines.append("")
 
     # Section: collisions vs existing memory
@@ -336,6 +373,10 @@ def apply_import(
             "scope": list(decision.scope),
             "constraints": list(decision.constraints),
             "anti_patterns": list(decision.anti_patterns),
+            "rules": [
+                {"type": rule.type, "value": rule.value}
+                for rule in decision.rules
+            ],
             "created_at": decision.created_at,
             "updated_at": decision.updated_at,
         }

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -118,6 +118,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
             print(f"    constraints: {', '.join(d.constraints)}")
         if d.anti_patterns:
             print(f"    avoid: {', '.join(d.anti_patterns)}")
+        if d.rules:
+            for rule in d.rules:
+                print(f"    rule: {rule.type} {rule.value}")
     return 0
 
 
@@ -207,6 +210,8 @@ def _check_payload(
                 "severity": v.severity.value,
                 "rule": v.rule,
                 "trigger": v.trigger,
+                "kind": v.kind,
+                "rule_type": v.rule_type,
             }
             for v in result.violations
         ],
@@ -226,7 +231,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
     retriever = DecisionRetriever(store.decisions())
     scored = retriever.retrieve(args.query)
 
-    result = check_prompt(input_text, scored, top=args.top)
+    result = check_prompt(input_text, scored, top=args.top, input_path=args.input)
 
     if getattr(args, "json", False):
         # Machine-readable mode: the payload must be the only thing on stdout,
@@ -237,8 +242,11 @@ def _cmd_check(args: argparse.Namespace) -> int:
 
     if result.violations:
         for v in result.violations:
-            kind = "anti_pattern" if v.severity == Severity.FAIL else "constraint"
-            print(f"{v.severity.value:4}  [{v.decision_id}] {kind} \"{v.rule}\" -- trigger: {v.trigger}")
+            kind = v.rule_type or v.kind
+            print(
+                f"{v.severity.value:4}  [{v.decision_id}] "
+                f"{kind} \"{v.rule}\" -- trigger: {v.trigger}"
+            )
             print(f"      {v.decision_text}")
         print()
 
@@ -336,8 +344,8 @@ def _cmd_adr_import(args: argparse.Namespace) -> int:
 
     Exit codes:
         0 = success (preview shown in dry-run, or write completed in apply)
-        1 = diagnostics present (active-active contradiction or collisions)
-            in dry-run mode (informational; CI can use this to fail the PR)
+        1 = diagnostics present (retrieval-only ADR, active-active
+            contradiction, or collision) in dry-run mode
         2 = apply failed (refused due to unresolved diagnostics)
     """
     import sys

--- a/mneme/conflict_detector.py
+++ b/mneme/conflict_detector.py
@@ -20,6 +20,7 @@ import re
 from dataclasses import dataclass
 from typing import Iterable
 
+from mneme.rule_matcher import literal_in_text
 from mneme.schemas import Decision
 
 
@@ -98,6 +99,23 @@ class ConflictDetector:
         seen: set[tuple[str, str]] = set()  # (decision_id, phrase)
 
         for d in decisions:
+            for rule in d.rules:
+                if rule.type != "FORBID_LITERAL":
+                    continue
+                if not literal_in_text(rule.value, response):
+                    continue
+                key = (d.id, f"{rule.type}:{rule.value}")
+                if key in seen:
+                    continue
+                seen.add(key)
+                conflicts.append(Conflict(
+                    violated_decision_id=d.id,
+                    reason=(
+                        f"response contains {rule.type} value {rule.value!r}"
+                    ),
+                    snippet=_find_snippet(response, rule.value) or rule.value,
+                ))
+
             for phrase, field_label in _extract_candidate_phrases(d):
                 # Pick the most content-bearing word as the search anchor.
                 words = _content_words(phrase)

--- a/mneme/context_builder.py
+++ b/mneme/context_builder.py
@@ -184,6 +184,10 @@ def format_decisions(
             lines.append("  Avoid:")
             for a in d.anti_patterns:
                 lines.append(f"    - {a}")
+        if d.rules:
+            lines.append("  Typed rules:")
+            for rule in d.rules:
+                lines.append(f"    - {rule.type}: {rule.value}")
         blocks.append("\n".join(lines))
 
     return "\n\n".join(blocks)

--- a/mneme/cursor_generator.py
+++ b/mneme/cursor_generator.py
@@ -18,7 +18,7 @@ def generate_mdc(
 
     Filters to top-N scored decisions (score > 0). Returns a file with YAML
     frontmatter, a warning header, and one section per decision containing its
-    constraints and anti-patterns.
+    constraints, anti-patterns, and typed rules.
     """
     kept: list[ScoredDecision] = []
     seen: set[str] = set()
@@ -74,6 +74,11 @@ def generate_mdc(
             lines.append("**Avoid:**")
             for a in d.anti_patterns:
                 lines.append(f"- {a}")
+            lines.append("")
+        if d.rules:
+            lines.append("**Typed rules:**")
+            for rule in d.rules:
+                lines.append(f"- {rule.type}: {rule.value}")
             lines.append("")
 
     return "\n".join(lines)

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -11,6 +11,7 @@ wrong, because a violation does not stop being a violation when the filename
 happens to share no token with the decision's scope. See ADR-017.
 
 Severity semantics:
+    A typed FORBID_LITERAL match is a FAIL.
     FAIL  — input contains a term from a decision's anti_patterns list.
     WARN  — input mentions a term that a "no X" constraint forbids.
     PASS  — no violations found.
@@ -24,8 +25,10 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 
 from mneme.decision_retriever import ScoredDecision
+from mneme.rule_matcher import literal_in_text
 
 
 class Severity(str, Enum):
@@ -41,6 +44,8 @@ class Violation:
     severity: Severity
     rule: str     # the constraint or anti_pattern string that triggered
     trigger: str  # the specific term found in the input
+    kind: str = "legacy"
+    rule_type: str | None = None
 
 
 @dataclass
@@ -66,6 +71,16 @@ def _rule_terms(text: str, min_len: int = 3) -> list[str]:
 def _word_in_text(term: str, text: str) -> bool:
     """True if term appears as a whole word (case-insensitive) in text."""
     return bool(re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE))
+
+
+def _is_declaring_source(input_path: str | Path | None, source_path: str) -> bool:
+    """Return whether an input is the ADR that declared this decision."""
+    if input_path is None or not source_path:
+        return False
+    try:
+        return Path(input_path).resolve() == Path(source_path).resolve()
+    except OSError:
+        return False
 
 
 def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]:
@@ -137,6 +152,7 @@ def check_prompt(
     input_text: str,
     scored: list[ScoredDecision],
     top: int = 3,
+    input_path: str | Path | None = None,
 ) -> EnforcementResult:
     """Check input_text against the decision corpus.
 
@@ -151,6 +167,9 @@ def check_prompt(
         top:        Size of the retrieval-gated tier. This bounds how many
                     decisions have their *multi-term* rules applied; it never
                     limits which decisions are enforced.
+        input_path: Optional checked-file path. A typed rule does not enforce
+                    against its own declaring ADR source, which must be able to
+                    contain the literal it defines.
 
     Returns:
         EnforcementResult with verdict and list of Violations.
@@ -159,6 +178,21 @@ def check_prompt(
 
     for s, literal_only in _enforcement_scope(scored, top):
         d = s.decision
+
+        if not _is_declaring_source(input_path, d.source_path):
+            for rule in d.rules:
+                if rule.type == "FORBID_LITERAL" and literal_in_text(
+                    rule.value, input_text
+                ):
+                    violations.append(Violation(
+                        decision_id=d.id,
+                        decision_text=d.decision,
+                        severity=Severity.FAIL,
+                        rule=rule.value,
+                        trigger=rule.value,
+                        kind="typed_rule",
+                        rule_type=rule.type,
+                    ))
 
         for ap in d.anti_patterns:
             if literal_only and not _is_literal_rule(ap):
@@ -171,6 +205,7 @@ def check_prompt(
                         severity=Severity.FAIL,
                         rule=ap,
                         trigger=term,
+                        kind="anti_pattern",
                     ))
                     break  # one violation per anti_pattern entry
 
@@ -190,6 +225,7 @@ def check_prompt(
                         severity=Severity.WARN,
                         rule=constraint,
                         trigger=term,
+                        kind="constraint",
                     ))
                     break
 

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -73,14 +73,22 @@ def _word_in_text(term: str, text: str) -> bool:
     return bool(re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE))
 
 
-def _is_declaring_source(input_path: str | Path | None, source_path: str) -> bool:
-    """Return whether an input is the ADR that declared this decision."""
-    if input_path is None or not source_path:
+def _is_policy_source(
+    input_path: str | Path | None,
+    *policy_paths: str,
+) -> bool:
+    """Return whether the input stores or declares the decision's policy."""
+    if input_path is None:
         return False
-    try:
-        return Path(input_path).resolve() == Path(source_path).resolve()
-    except OSError:
-        return False
+    for policy_path in policy_paths:
+        if not policy_path:
+            continue
+        try:
+            if Path(input_path).resolve() == Path(policy_path).resolve():
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]:
@@ -168,8 +176,8 @@ def check_prompt(
                     decisions have their *multi-term* rules applied; it never
                     limits which decisions are enforced.
         input_path: Optional checked-file path. A typed rule does not enforce
-                    against its own declaring ADR source, which must be able to
-                    contain the literal it defines.
+                    against its declaring ADR or policy-memory source, both of
+                    which must be able to contain the literal it defines.
 
     Returns:
         EnforcementResult with verdict and list of Violations.
@@ -179,7 +187,7 @@ def check_prompt(
     for s, literal_only in _enforcement_scope(scored, top):
         d = s.decision
 
-        if not _is_declaring_source(input_path, d.source_path):
+        if not _is_policy_source(input_path, d.source_path, d.memory_path):
             for rule in d.rules:
                 if rule.type == "FORBID_LITERAL" and literal_in_text(
                     rule.value, input_text

--- a/mneme/memory_store.py
+++ b/mneme/memory_store.py
@@ -133,6 +133,7 @@ class MemoryStore:
                     d.get("source"),
                     d["id"],
                 ),
+                memory_path=str(self.path.resolve()),
                 created_at=d.get("created_at", ""),
                 updated_at=d.get("updated_at", ""),
             )

--- a/mneme/memory_store.py
+++ b/mneme/memory_store.py
@@ -14,7 +14,40 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from mneme.schemas import Decision, DecisionExample, MemoryItem, ProjectMeta, ProjectMemory
+from mneme.schemas import (
+    Decision,
+    DecisionExample,
+    MemoryItem,
+    ProjectMeta,
+    ProjectMemory,
+    Rule,
+)
+
+
+def _resolve_source_path(
+    memory_path: Path,
+    source: object,
+    decision_id: str,
+) -> str:
+    """Resolve an imported ADR provenance path for runtime comparisons.
+
+    Older and hand-authored decisions have no ``source`` block. Malformed
+    optional provenance is ignored here because freshness validation owns its
+    diagnostics; loading enforcement memory must remain backward compatible.
+    """
+    if not isinstance(source, dict) or source.get("type") != "adr":
+        return ""
+    raw_path = source.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return ""
+    source_name = Path(raw_path).name
+    if Path(source_name).suffix.lower() != ".md":
+        return ""
+    if source_name != f"{decision_id}.md" and not source_name.startswith(
+        f"{decision_id}-"
+    ):
+        return ""
+    return str((memory_path.parent / raw_path).resolve())
 
 
 class MemoryStore:
@@ -91,6 +124,15 @@ class MemoryStore:
                 scope=list(d.get("scope", [])),
                 constraints=list(d.get("constraints", [])),
                 anti_patterns=list(d.get("anti_patterns", [])),
+                rules=[
+                    Rule(type=rule["type"], value=rule["value"])
+                    for rule in d.get("rules", [])
+                ],
+                source_path=_resolve_source_path(
+                    self.path,
+                    d.get("source"),
+                    d["id"],
+                ),
                 created_at=d.get("created_at", ""),
                 updated_at=d.get("updated_at", ""),
             )

--- a/mneme/rule_matcher.py
+++ b/mneme/rule_matcher.py
@@ -1,0 +1,28 @@
+"""Deterministic matching primitives for typed Mneme rules."""
+from __future__ import annotations
+
+import re
+
+
+_LITERAL_CONTINUATION = re.compile(r"[A-Za-z0-9_-]")
+
+
+def literal_in_text(literal: str, text: str) -> bool:
+    """Match a case-sensitive literal without matching a longer identifier.
+
+    A boundary is required only when the corresponding edge of the literal is
+    identifier-like. This makes ``install legacy-package`` match the
+    standalone command but not the longer name
+    ``install legacy-package-next``.
+    """
+    if not literal:
+        return False
+    pattern = re.escape(literal)
+    if _LITERAL_CONTINUATION.fullmatch(literal[0]):
+        pattern = r"(?<![A-Za-z0-9_-])" + pattern
+    if _LITERAL_CONTINUATION.fullmatch(literal[-1]):
+        pattern += r"(?![A-Za-z0-9_-])"
+    return bool(re.search(pattern, text))
+
+
+__all__ = ["literal_in_text"]

--- a/mneme/schemas.py
+++ b/mneme/schemas.py
@@ -198,6 +198,9 @@ class Decision:
         source_path:    Resolved ADR source path when provenance is available.
                        Runtime-only; persisted under the existing ``source``
                        block rather than as a top-level Decision field.
+        memory_path:    Resolved policy-memory path that loaded this decision.
+                       Runtime-only; permits a typed rule to be represented in
+                       its own canonical storage file without self-enforcement.
         created_at:    ISO 8601 timestamp of creation.
         updated_at:    ISO 8601 timestamp of last update.
     """
@@ -212,6 +215,7 @@ class Decision:
     updated_at: str = ""
     rules: list[Rule] = field(default_factory=list)
     source_path: str = ""
+    memory_path: str = ""
 
 
 # ── Pipeline models ───────────────────────────────────────────────────────────

--- a/mneme/schemas.py
+++ b/mneme/schemas.py
@@ -46,6 +46,10 @@ MemoryItemType = Literal[
 
 Priority = Literal["high", "medium", "low"]
 
+RuleType = Literal["FORBID_LITERAL"]
+
+VALID_RULE_TYPES: frozenset[str] = frozenset({"FORBID_LITERAL"})
+
 PRIORITY_WEIGHT: dict[str, float] = {
     "high": 1.5,
     "medium": 1.0,
@@ -126,6 +130,33 @@ class DecisionExample:
     tags: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class Rule:
+    """A mechanically enforceable rule with explicit runtime semantics.
+
+    ``FORBID_LITERAL`` is intentionally the first and only rule type. Its
+    value is matched as an exact, case-sensitive token sequence by the
+    deterministic enforcer. New rule types must define equally precise
+    semantics before joining ``VALID_RULE_TYPES``.
+
+    Attributes:
+        type:  One of ``VALID_RULE_TYPES``.
+        value: Non-empty literal value consumed by the rule matcher.
+    """
+
+    type: RuleType
+    value: str
+
+    def __post_init__(self) -> None:
+        if self.type not in VALID_RULE_TYPES:
+            raise ValueError(
+                f"unknown rule type {self.type!r} "
+                f"(expected one of {sorted(VALID_RULE_TYPES)})"
+            )
+        if not isinstance(self.value, str) or not self.value.strip():
+            raise ValueError("rule value must be a non-empty string")
+
+
 @dataclass
 class ProjectMemory:
     """The full memory store for one project.
@@ -162,6 +193,11 @@ class Decision:
                        e.g. ["no postgres", "no external db"].
         anti_patterns: Explicitly forbidden approaches,
                        e.g. ["introduce ORM", "add migration layer"].
+        rules:          Mechanically enforceable typed rules. Unlike legacy
+                       constraint prose, each type has exact semantics.
+        source_path:    Resolved ADR source path when provenance is available.
+                       Runtime-only; persisted under the existing ``source``
+                       block rather than as a top-level Decision field.
         created_at:    ISO 8601 timestamp of creation.
         updated_at:    ISO 8601 timestamp of last update.
     """
@@ -174,6 +210,8 @@ class Decision:
     anti_patterns: list[str] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    rules: list[Rule] = field(default_factory=list)
+    source_path: str = ""
 
 
 # ── Pipeline models ───────────────────────────────────────────────────────────

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -45,11 +45,11 @@ ALLOWLIST: dict[str, str] = {
     # Dated historical planning records. Rewriting them would falsify the
     # archive; they are not user-facing install instructions.
     "docs/plans/": "historical planning records, not user instructions",
-    # The gate itself must name the forbidden form to detect and explain it,
-    # and its tests must use it as fixture data. Without these entries the
-    # check fails on itself the moment it is committed.
+    # The gate itself must name the forbidden form to detect and explain it.
+    # Tests may also use forbidden literals as fixture data; they are not
+    # user-facing install instructions.
     "scripts/check_install_command.py": "the gate's own pattern and messages",
-    "tests/test_check_install_command.py": "the gate's own test fixtures",
+    "tests/": "test fixtures and assertions, not user instructions",
 }
 
 

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -29,6 +29,13 @@ VIOLATION = re.compile(
     r"\b(?:pip|pipx|uv pip)\s+install\s+(?P<flags>(?:-[\w-]+\s+)*)mneme(?!-hq)(?![\w-])"
 )
 
+# A typed rule's declaring ADR must be able to state the literal it forbids.
+# Keep this exemption line-scoped and exact: it does not allow prose or other
+# files containing the same install command.
+TYPED_LITERAL_DIRECTIVE = re.compile(
+    r"^\s*-\s+FORBID_LITERAL:\s+(?P<value>.+?)\s*$"
+)
+
 # `pip install -e mneme` / `--editable mneme` takes a *local directory path*,
 # not a PyPI distribution name, so it never resolves to the wrong package.
 # Installing a source checkout that happens to live in a folder called `mneme`
@@ -60,6 +67,14 @@ def is_allowlisted(path: str) -> str | None:
     return None
 
 
+def is_declaring_typed_rule(path: str, line: str, match: re.Match[str]) -> bool:
+    """Return whether an ADR directive declares exactly this matched literal."""
+    if not path.startswith("docs/adr/"):
+        return False
+    directive = TYPED_LITERAL_DIRECTIVE.match(line)
+    return bool(directive and directive.group("value") == match.group(0))
+
+
 def tracked_files() -> list[str]:
     out = subprocess.run(
         ["git", "ls-files"], capture_output=True, text=True, check=True
@@ -82,6 +97,8 @@ def scan(paths: list[str]) -> list[tuple[str, int, str]]:
                 continue
             flags = match.group("flags").split()
             if any(f in EDITABLE_FLAGS for f in flags):
+                continue
+            if is_declaring_typed_rule(path, line, match):
                 continue
             # A line that names both the correct and the forbidden form is a
             # correct-vs-wrong comparison (as in ADR-005's own table), not an

--- a/scripts/check_install_command.py
+++ b/scripts/check_install_command.py
@@ -57,6 +57,9 @@ ALLOWLIST: dict[str, str] = {
     # user-facing install instructions.
     "scripts/check_install_command.py": "the gate's own pattern and messages",
     "tests/": "test fixtures and assertions, not user instructions",
+    ".mneme/project_memory.json": (
+        "canonical policy storage may contain the literals it enforces"
+    ),
 }
 
 

--- a/tests/fixtures/adrs_literal/ADR-201-forbid-install-command.md
+++ b/tests/fixtures/adrs_literal/ADR-201-forbid-install-command.md
@@ -1,0 +1,16 @@
+---
+id: ADR-201
+title: Use the published distribution name
+status: accepted
+priority: foundational
+date: 2026-08-11
+scope: packaging
+---
+
+## Decision
+
+Install Mneme from its published distribution name.
+
+## Constraints
+
+- FORBID_LITERAL: pip install mneme

--- a/tests/test_adr_compile_integration.py
+++ b/tests/test_adr_compile_integration.py
@@ -129,3 +129,14 @@ def test_adrs_to_decisions_no_constraints_section_yields_empty_constraints():
     decisions = adrs_to_decisions(compile_adrs(FIXTURES / "adrs_e2e_clean"))
     for d in decisions:
         assert d.constraints == []
+        assert d.rules == []
+
+
+def test_adrs_to_decisions_compiles_forbid_literal_as_typed_rule():
+    decisions = adrs_to_decisions(compile_adrs(FIXTURES / "adrs_literal"))
+    [decision] = decisions
+    [rule] = decision.rules
+    assert rule.type == "FORBID_LITERAL"
+    assert rule.value == "pip install mneme"
+    assert decision.constraints == []
+    assert Path(decision.source_path).name == "ADR-201-forbid-install-command.md"

--- a/tests/test_adr_constraints.py
+++ b/tests/test_adr_constraints.py
@@ -21,6 +21,13 @@ Do not use mongo.
     assert out == [ConstraintDirective(kind="FORBID_DEPENDENCY", value="mongodb")]
 
 
+def test_parse_forbid_literal_directive():
+    body = "## Constraints\n- FORBID_LITERAL: pip install mneme\n"
+    assert parse_constraints_section(body) == [
+        ConstraintDirective(kind="FORBID_LITERAL", value="pip install mneme")
+    ]
+
+
 def test_parse_multiple_directives_in_order():
     body = """## Constraints
 - FORBID_PATH: src/legacy/billing/**

--- a/tests/test_adr_import.py
+++ b/tests/test_adr_import.py
@@ -110,10 +110,22 @@ def test_compile_for_import_surfaces_precedence_ambiguity_as_diagnostic():
 def test_compile_for_import_clean_corpus_has_no_diagnostics():
     from mneme.adr_import import compile_for_import
 
-    report = compile_for_import(FIXTURES / "adrs_import_basic")
+    report = compile_for_import(FIXTURES / "adrs_literal")
     assert report.diagnostics == []
     active_ids = {n.id for n in report.active_nodes}
-    assert active_ids == {"ADR-101", "ADR-102"}
+    assert active_ids == {"ADR-201"}
+
+
+def test_compile_for_import_warns_when_active_adr_is_retrieval_only():
+    from mneme.adr_import import compile_for_import
+
+    report = compile_for_import(FIXTURES / "adrs_import_basic")
+    warnings = [
+        d for d in report.diagnostics
+        if d.kind == "no_enforceable_rules"
+    ]
+    assert [d.adr_id for d in warnings] == ["ADR-102"]
+    assert "0 mechanically enforceable rules" in warnings[0].message
 
 
 def test_format_preview_lists_active_nodes_and_constraints():
@@ -134,6 +146,16 @@ def test_format_preview_lists_active_nodes_and_constraints():
     # ADR-103 is superseded -> shown but flagged
     assert "ADR-103" in out
     assert "superseded" in out
+    assert "Retrieval-only ADR warnings" in out
+    assert "ADR-102" in out
+
+
+def test_format_preview_lists_typed_rules():
+    from mneme.adr_import import compile_for_import, format_preview
+
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    out = format_preview(report, collisions=[])
+    assert "rule: FORBID_LITERAL pip install mneme" in out
 
 
 def test_format_preview_includes_collision_diagnostics():
@@ -217,6 +239,25 @@ def test_apply_import_writes_source_provenance_block(tmp_path):
         resolved = (target.parent / source["path"]).resolve()
         expected = hashlib.sha256(resolved.read_bytes()).hexdigest()
         assert source["sha256"] == expected
+
+
+def test_apply_import_persists_typed_rules(tmp_path):
+    from mneme.adr_import import apply_import, compile_for_import
+
+    target = tmp_path / "project_memory.json"
+    target.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "items": [], "examples": [], "decisions": [],
+    }), encoding="utf-8")
+
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    apply_import(report, target_path=target)
+
+    persisted = json.loads(target.read_text(encoding="utf-8"))
+    assert persisted["decisions"][0]["rules"] == [{
+        "type": "FORBID_LITERAL",
+        "value": "pip install mneme",
+    }]
 
 
 def test_apply_import_refuses_overwrite_without_allow_update(tmp_path):

--- a/tests/test_adr_import_e2e.py
+++ b/tests/test_adr_import_e2e.py
@@ -60,3 +60,55 @@ def test_mneme_check_warn_mode_against_imported_memory(tmp_path):
         "--mode", "warn",
     ])
     assert rc == 0  # warn mode -> always exit 0
+
+
+def test_imported_forbid_literal_fails_and_allows_longer_distribution(tmp_path):
+    target = tmp_path / "project_memory.json"
+    _seed(target)
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    apply_import(report, target_path=target)
+
+    store = MemoryStore(target)
+    store.load()
+    scored = DecisionRetriever(store.decisions()).retrieve("edit to README.md")
+
+    violating = check_prompt("pip install mneme\n", scored, top=3)
+    compliant = check_prompt("pip install mneme-hq\n", scored, top=3)
+    assert violating.verdict == Severity.FAIL
+    assert compliant.verdict == Severity.PASS
+
+
+def test_imported_literal_rule_exempts_its_source_adr(tmp_path):
+    target = tmp_path / "project_memory.json"
+    _seed(target)
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    apply_import(report, target_path=target)
+
+    store = MemoryStore(target)
+    store.load()
+    [decision] = store.decisions()
+    scored = DecisionRetriever([decision]).retrieve("edit to ADR-201.md")
+    source = Path(decision.source_path)
+    result = check_prompt(
+        source.read_text(encoding="utf-8"),
+        scored,
+        input_path=source,
+    )
+    assert result.verdict == Severity.PASS
+
+
+def test_mneme_check_exempts_imported_literal_rule_source(tmp_path):
+    target = tmp_path / "project_memory.json"
+    _seed(target)
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    apply_import(report, target_path=target)
+    [decision] = MemoryStore(target).load().decisions
+
+    rc = cli_main([
+        "check",
+        "--memory", str(target),
+        "--input", decision.source_path,
+        "--query", "edit to ADR-201.md",
+        "--mode", "strict",
+    ])
+    assert rc == 0

--- a/tests/test_adr_import_e2e.py
+++ b/tests/test_adr_import_e2e.py
@@ -112,3 +112,19 @@ def test_mneme_check_exempts_imported_literal_rule_source(tmp_path):
         "--mode", "strict",
     ])
     assert rc == 0
+
+
+def test_mneme_check_exempts_policy_memory_file(tmp_path):
+    target = tmp_path / "project_memory.json"
+    _seed(target)
+    report = compile_for_import(FIXTURES / "adrs_literal")
+    apply_import(report, target_path=target)
+
+    rc = cli_main([
+        "check",
+        "--memory", str(target),
+        "--input", str(target),
+        "--query", "update project memory",
+        "--mode", "strict",
+    ])
+    assert rc == 0

--- a/tests/test_check_install_command.py
+++ b/tests/test_check_install_command.py
@@ -71,6 +71,11 @@ def test_allowlist_does_not_cover_user_docs():
     assert gate.is_allowlisted("docs/qa-glossary.md") is None
 
 
+def test_allowlist_covers_test_fixtures():
+    assert gate.is_allowlisted("tests/test_enforcer.py")
+    assert gate.is_allowlisted("tests/fixtures/adrs_literal/ADR-201.md")
+
+
 def test_allowlist_covers_the_gate_itself():
     """The gate must name the forbidden form to detect and explain it.
 

--- a/tests/test_check_install_command.py
+++ b/tests/test_check_install_command.py
@@ -76,6 +76,21 @@ def test_allowlist_covers_test_fixtures():
     assert gate.is_allowlisted("tests/fixtures/adrs_literal/ADR-201.md")
 
 
+def test_exact_typed_rule_declaration_is_exempt_only_in_adr_sources():
+    line = "- FORBID_LITERAL: pip install mneme"
+    match = gate.VIOLATION.search(line)
+    assert match is not None
+    assert gate.is_declaring_typed_rule("docs/adr/ADR-005.md", line, match)
+    assert not gate.is_declaring_typed_rule("README.md", line, match)
+
+
+def test_typed_rule_declaration_must_match_the_entire_value():
+    line = "- FORBID_LITERAL: pip install mneme in tutorials"
+    match = gate.VIOLATION.search(line)
+    assert match is not None
+    assert not gate.is_declaring_typed_rule("docs/adr/ADR-005.md", line, match)
+
+
 def test_allowlist_covers_the_gate_itself():
     """The gate must name the forbidden form to detect and explain it.
 

--- a/tests/test_check_install_command.py
+++ b/tests/test_check_install_command.py
@@ -76,6 +76,12 @@ def test_allowlist_covers_test_fixtures():
     assert gate.is_allowlisted("tests/fixtures/adrs_literal/ADR-201.md")
 
 
+def test_allowlist_covers_only_the_canonical_policy_memory_file():
+    assert gate.is_allowlisted(".mneme/project_memory.json")
+    assert gate.is_allowlisted("examples/project_memory.json") is None
+    assert gate.is_allowlisted(".mneme/other.json") is None
+
+
 def test_exact_typed_rule_declaration_is_exempt_only_in_adr_sources():
     line = "- FORBID_LITERAL: pip install mneme"
     match = gate.VIOLATION.search(line)

--- a/tests/test_check_json.py
+++ b/tests/test_check_json.py
@@ -65,6 +65,31 @@ def test_json_violations_carry_decision_and_rule(tmp_path, capsys):
     assert v["rule"] and v["trigger"] and v["decision_text"]
 
 
+def test_json_identifies_typed_rule(tmp_path, capsys):
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-201",
+            "decision": "Use the published distribution name",
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "pip install mneme",
+            }],
+        }],
+    }), encoding="utf-8")
+    inp = _input(tmp_path, "pip install mneme")
+    code = main([
+        "check", "--memory", str(mem), "--input", str(inp),
+        "--query", "edit to README.md", "--json",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    [violation] = payload["violations"]
+    assert violation["kind"] == "typed_rule"
+    assert violation["rule_type"] == "FORBID_LITERAL"
+
+
 # ── exit codes are unchanged by --json ───────────────────────────────────────
 
 def test_json_preserves_strict_exit_codes(tmp_path, capsys):

--- a/tests/test_cli_adr_import.py
+++ b/tests/test_cli_adr_import.py
@@ -31,7 +31,7 @@ def test_adr_import_dry_run_prints_preview_and_does_not_write(tmp_path, capsys):
         "--dry-run",
     ])
 
-    assert rc == 0
+    assert rc == 1
     out = capsys.readouterr().out
     assert "ADR import preview" in out
     assert "ADR-101" in out
@@ -52,7 +52,7 @@ def test_adr_import_default_is_dry_run(tmp_path):
         "--memory", str(target),
     ])
 
-    assert rc == 0
+    assert rc == 1
     assert target.read_text(encoding="utf-8") == before
 
 

--- a/tests/test_conflict_detector.py
+++ b/tests/test_conflict_detector.py
@@ -1,6 +1,6 @@
 """Post-response conflict detection against injected decisions."""
 from mneme.conflict_detector import ConflictDetector, Conflict
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 
 
 def _decisions():
@@ -58,3 +58,26 @@ def test_snippet_contains_surrounding_context():
     conflicts = ConflictDetector().detect(response, _decisions())
     # Snippet must contain the triggering phrase.
     assert any("postgres" in c.snippet.lower() for c in conflicts)
+
+
+def test_detects_typed_literal_without_heuristic_negation():
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+    )
+    conflicts = ConflictDetector().detect(
+        "Do not run pip install mneme; use the published package instead.",
+        [decision],
+    )
+    assert len(conflicts) == 1
+    assert "FORBID_LITERAL" in conflicts[0].reason
+
+
+def test_typed_literal_does_not_match_longer_slug():
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+    )
+    assert ConflictDetector().detect("pip install mneme-hq", [decision]) == []

--- a/tests/test_context_builder_decisions.py
+++ b/tests/test_context_builder_decisions.py
@@ -1,7 +1,7 @@
 """Top-N decision injection in ContextBuilder."""
 from mneme.context_builder import format_decisions, DEFAULT_MAX_DECISIONS
 from mneme.decision_retriever import ScoredDecision
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 
 
 def _scored(decision_id: str, score: float) -> ScoredDecision:
@@ -45,6 +45,15 @@ def test_output_shows_decision_constraints_and_anti_patterns():
     assert "Decision a" in out
     assert "constraint-a" in out
     assert "anti-a" in out
+
+
+def test_output_shows_typed_rules():
+    scored = [_scored("a", score=5.0)]
+    scored[0].decision.rules.append(
+        Rule(type="FORBID_LITERAL", value="pip install mneme")
+    )
+    out = format_decisions(scored, max_items=3)
+    assert "FORBID_LITERAL: pip install mneme" in out
 
 
 def test_empty_input_returns_empty_string():

--- a/tests/test_cursor_generate.py
+++ b/tests/test_cursor_generate.py
@@ -7,7 +7,7 @@ import pytest
 from mneme.cli import main
 from mneme.cursor_generator import generate_mdc
 from mneme.decision_retriever import DecisionRetriever, ScoredDecision
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 
 
 # ── fixtures ─────────────────────────────────────────────────────────────────
@@ -138,6 +138,21 @@ def test_generate_mdc_contains_anti_patterns():
         timestamp="2026-04-24T12:00:00Z",
     )
     assert "introduce ORM" in result
+
+
+def test_generate_mdc_contains_typed_rules():
+    scored = _scored_decisions()
+    scored[0].decision.rules.append(
+        Rule(type="FORBID_LITERAL", value="pip install mneme")
+    )
+    result = generate_mdc(
+        scored=scored,
+        query="storage layer",
+        memory_path="examples/project_memory.json",
+        top=3,
+        timestamp="2026-04-24T12:00:00Z",
+    )
+    assert "FORBID_LITERAL: pip install mneme" in result
 
 
 def test_generate_mdc_contains_warning():

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -582,3 +582,20 @@ def test_typed_rule_does_not_flag_its_declaring_adr(tmp_path):
         input_path=source,
     )
     assert result.verdict == Severity.PASS
+
+
+def test_typed_rule_does_not_flag_its_policy_memory_file(tmp_path):
+    memory = tmp_path / "project_memory.json"
+    memory.write_text('"value": "pip install mneme"\n', encoding="utf-8")
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+        memory_path=str(memory),
+    )
+    result = check_prompt(
+        memory.read_text(encoding="utf-8"),
+        [_scored(decision, score=0.0)],
+        input_path=memory,
+    )
+    assert result.verdict == Severity.PASS

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -8,7 +8,7 @@ from mneme.cli import main
 from mneme.decision_retriever import DecisionRetriever, ScoredDecision
 from mneme.enforcer import EnforcementResult, Severity, Violation, check_prompt
 from mneme.memory_store import MemoryStore
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 
 EXAMPLE_MEMORY = Path(__file__).parent.parent / "examples" / "project_memory.json"
 
@@ -520,3 +520,65 @@ def test_check_cmd_reads_input_from_file(tmp_path):
         "--query", "storage",
     ])
     assert exit_code == 2
+
+
+# --- typed deterministic rules (#250) ---
+
+def test_forbid_literal_fails_even_when_decision_scores_zero():
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+    )
+    result = check_prompt(
+        "pip install mneme\n",
+        [_scored(decision, score=0.0)],
+    )
+    assert result.verdict == Severity.FAIL
+    [violation] = result.violations
+    assert violation.kind == "typed_rule"
+    assert violation.rule_type == "FORBID_LITERAL"
+    assert violation.trigger == "pip install mneme"
+
+
+def test_forbid_literal_does_not_match_longer_slug():
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+    )
+    result = check_prompt(
+        "pip install mneme-hq\n",
+        [_scored(decision, score=0.0)],
+    )
+    assert result.verdict == Severity.PASS
+
+
+def test_forbid_literal_is_case_sensitive():
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+    )
+    result = check_prompt(
+        "PIP INSTALL MNEME\n",
+        [_scored(decision, score=0.0)],
+    )
+    assert result.verdict == Severity.PASS
+
+
+def test_typed_rule_does_not_flag_its_declaring_adr(tmp_path):
+    source = tmp_path / "ADR-201.md"
+    source.write_text("- FORBID_LITERAL: pip install mneme\n", encoding="utf-8")
+    decision = Decision(
+        id="ADR-201",
+        decision="Use the published distribution name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
+        source_path=str(source),
+    )
+    result = check_prompt(
+        source.read_text(encoding="utf-8"),
+        [_scored(decision, score=0.0)],
+        input_path=source,
+    )
+    assert result.verdict == Severity.PASS

--- a/tests/test_memory_store_decisions.py
+++ b/tests/test_memory_store_decisions.py
@@ -68,6 +68,7 @@ def test_loads_typed_rules_and_resolves_adr_source(tmp_path):
     [decision] = MemoryStore(memory_path).load().decisions
     assert decision.rules[0].value == "pip install mneme"
     assert Path(decision.source_path) == adr.resolve()
+    assert Path(decision.memory_path) == memory_path.resolve()
 
 
 def test_unknown_typed_rule_fails_loudly(tmp_path):

--- a/tests/test_memory_store_decisions.py
+++ b/tests/test_memory_store_decisions.py
@@ -1,5 +1,8 @@
 """Tests for MemoryStore loading Decision records (native + legacy migration)."""
 from pathlib import Path
+import json
+
+import pytest
 
 from mneme.memory_store import MemoryStore
 
@@ -42,6 +45,62 @@ def test_decisions_accessor():
     store.load()
     assert len(store.decisions()) == 1
     assert store.decisions()[0].id == "mneme_001"
+
+
+def test_loads_typed_rules_and_resolves_adr_source(tmp_path):
+    adr = tmp_path / "docs" / "adr" / "ADR-001.md"
+    adr.parent.mkdir(parents=True)
+    adr.write_text("# ADR-001\n", encoding="utf-8")
+    memory_path = tmp_path / ".mneme" / "project_memory.json"
+    memory_path.parent.mkdir()
+    memory_path.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-001",
+            "decision": "Forbid bad install command",
+            "rules": [
+                {"type": "FORBID_LITERAL", "value": "pip install mneme"}
+            ],
+            "source": {"type": "adr", "path": "../docs/adr/ADR-001.md"},
+        }],
+    }), encoding="utf-8")
+
+    [decision] = MemoryStore(memory_path).load().decisions
+    assert decision.rules[0].value == "pip install mneme"
+    assert Path(decision.source_path) == adr.resolve()
+
+
+def test_unknown_typed_rule_fails_loudly(tmp_path):
+    memory_path = tmp_path / "project_memory.json"
+    memory_path.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "bad",
+            "decision": "Bad rule",
+            "rules": [{"type": "FORBID_REGEX", "value": ".*"}],
+        }],
+    }), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown rule type"):
+        MemoryStore(memory_path).load()
+
+
+def test_mismatched_adr_source_name_cannot_create_rule_exemption(tmp_path):
+    memory_path = tmp_path / "project_memory.json"
+    memory_path.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-001",
+            "decision": "Forbid bad install command",
+            "rules": [
+                {"type": "FORBID_LITERAL", "value": "pip install mneme"}
+            ],
+            "source": {"type": "adr", "path": "../README.md"},
+        }],
+    }), encoding="utf-8")
+
+    [decision] = MemoryStore(memory_path).load().decisions
+    assert decision.source_path == ""
 
 
 def test_legacy_anti_pattern_migration_does_not_dump_content_into_anti_patterns():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,5 +1,7 @@
 """Tests for the new Decision dataclass."""
-from mneme.schemas import Decision
+import pytest
+
+from mneme.schemas import Decision, Rule
 
 
 def test_decision_minimal_construction():
@@ -10,6 +12,7 @@ def test_decision_minimal_construction():
     assert d.scope == []
     assert d.constraints == []
     assert d.anti_patterns == []
+    assert d.rules == []
 
 
 def test_decision_full_construction():
@@ -34,6 +37,19 @@ def test_decision_defaults_are_independent_lists():
     b = Decision(id="b", decision="y")
     a.scope.append("storage")
     assert b.scope == []
+
+
+def test_typed_rule_validates_type_and_value():
+    rule = Rule(type="FORBID_LITERAL", value="pip install mneme")
+    assert rule.type == "FORBID_LITERAL"
+    assert rule.value == "pip install mneme"
+
+    with pytest.raises(ValueError, match="unknown rule type"):
+        Rule(type="FORBID_REGEX", value="mneme")
+    with pytest.raises(ValueError, match="non-empty"):
+        Rule(type="FORBID_LITERAL", value="")
+    with pytest.raises(ValueError, match="non-empty"):
+        Rule(type="FORBID_LITERAL", value="   ")
 
 
 def test_mneme_conflict_error_carries_conflicts_and_result():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -13,6 +13,7 @@ def test_decision_minimal_construction():
     assert d.constraints == []
     assert d.anti_patterns == []
     assert d.rules == []
+    assert d.memory_path == ""
 
 
 def test_decision_full_construction():


### PR DESCRIPTION
Supersedes #266 after renaming the branch to follow the repository naming policy.

## What changed

- adds a validated `Rule` model and `FORBID_LITERAL` ADR directive
- persists and loads typed rules through ADR import and project memory
- enforces typed literals case-sensitively with identifier-aware boundaries, independent of retrieval score
- exempts a rule's declaring ADR and canonical policy memory file from self-enforcement
- aligns the legacy install-command gate with those policy-source exemptions
- exposes typed-rule details in human, JSON, context, Cursor, and conflict-detection output
- warns when an active ADR produces no mechanically enforceable payload
- documents the behavior and adds unit, integration, CLI, and regression coverage

## Why

Issue #250 showed that ADR-sourced decisions could be retrievable but mechanically toothless, and that the existing directive vocabulary could not express content-string constraints. This introduces explicit runtime semantics instead of inferring policy from prose or tables.

ADR-005 adoption in `.mneme/project_memory.json` is intentionally excluded because repository policy requires a separate `[memory]` PR.

## Compatibility

Existing `constraints` and `anti_patterns` retain their existing matching and severity behavior. Memory files without `rules` continue to load unchanged.

## Validation

- `python -m pytest -q` — 497 passed, 5 skipped
- `python -m compileall -q mneme`
- `git diff --check`
- `python scripts/check_install_command.py`
- repository `mneme check --mode warn` dogfood run

Addresses the capability and silent-import portions of #250.