### PR TITLE
feat: enforce typed rules by artifact path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,21 @@
   score, and human/JSON output identifies the rule type.
 - Retrieval-only import diagnostics for active ADRs that yield zero
   mechanically enforceable rules.
+- Explicit path applicability for typed rules. Structured ADR directives can
+  persist `include_paths` and `exclude_paths`; enforcement, conflict detection,
+  context output, and the Claude Code hook share deterministic, case-sensitive
+  selector semantics and emit per-rule applicability traces.
+- `mneme check --target-path` for checking temporary/materialized content
+  against the path of the artifact that will actually be changed. Unknown
+  scoped applicability is an operational failure in the CLI and an explicit
+  fail-open diagnostic in integrations.
 
 ### Compatibility
 
 - Existing `constraints` and `anti_patterns` retain their current matching and
   severity behavior. Memory files without `rules` continue to load unchanged.
+- Existing scalar typed rules remain global. Selector fields are additive and
+  the check JSON schema remains `mneme.check/v1` with additive fields.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -315,10 +315,18 @@ into `Decision` objects at load time; no changes needed to existing JSON files.
   "constraints": ["no postgres", "no external database"],
   "anti_patterns": ["introduce ORM", "add migration layer"],
   "rules": [
-    {"type": "FORBID_LITERAL", "value": "install legacy-package"}
+    {
+      "type": "FORBID_LITERAL",
+      "value": "install legacy-package",
+      "include_paths": ["docs/**", "**/*.md"],
+      "exclude_paths": ["docs/generated/**"]
+    }
   ]
 }
 ```
+
+Omitting `include_paths` keeps a typed rule global. A scoped rule requires a
+non-empty `include_paths`; matching `exclude_paths` take precedence.
 
 Add a top-level `"decisions"` array alongside `"items"` and `"examples"` in
 `project_memory.json`. All seven fields are optional except `id` and `decision`.
@@ -357,14 +365,21 @@ typed-rule violations **after** the call. It is a detector, not a blocker:
 
 ```python
 from mneme.conflict_detector import ConflictDetector
-conflicts = ConflictDetector().detect(response.content, injected_decisions)
+conflicts = ConflictDetector().detect(
+    response.content,
+    injected_decisions,
+    target_path="docs/guide.md",
+)
 # Conflict(violated_decision_id, reason, snippet) per match
 ```
 
 A term is only flagged when it appears **without** a negation signal nearby.
 `"Do not use Postgres"` is not a conflict. `"Switch to Postgres"` is.
 Typed `FORBID_LITERAL` rules do not use this heuristic: the exact literal is
-forbidden regardless of surrounding prose.
+forbidden regardless of surrounding prose. Pass `target_path` when injected
+decisions may contain scoped rules. `evaluate()` returns applicability traces
+and an `evaluation_complete` flag; the compatibility `detect()` helper raises
+when a scoped rule cannot be evaluated without a path.
 
 ### CLI
 
@@ -541,6 +556,13 @@ mneme check --memory project_memory.json \
        └── FAIL (exit 2)  → anti-pattern match — blocked
 ```
 
+Normally `--input` is also the artifact path used by scoped typed rules. When
+`--input` is a temporary file containing materialized or introduced content,
+pass the real artifact separately with `--target-path`. If a scoped rule cannot
+resolve that path relative to the policy root, the result is `INCOMPLETE` and
+the command exits 2 in either mode; JSON output sets
+`evaluation_complete: false` and includes the `UNKNOWN` applicability trace.
+
 **Try it with the included examples:**
 
 ```bash
@@ -708,6 +730,13 @@ include an optional `## Constraints` section with directives:
 ```markdown
 ## Constraints
 - FORBID_LITERAL: install legacy-package
+- FORBID_LITERAL:
+    value: install legacy-client
+    include_paths:
+      - "docs/**"
+      - "**/*.md"
+    exclude_paths:
+      - "docs/generated/**"
 - FORBID_DEPENDENCY: mongodb
 - FORBID_PATH: src/legacy/**
 - REQUIRE_PATH: billing/**
@@ -719,6 +748,14 @@ include an optional `## Constraints` section with directives:
 across the decision corpus, independent of retrieval score. Its declaring ADR
 source and canonical memory file are exempt so policy storage can state the
 literal it governs.
+
+The structured form scopes one typed rule to repository-relative paths.
+Selectors use forward slashes and case-sensitive matching: `*` stays within a
+single path segment, while a complete `**` segment spans zero or more segments.
+Absolute paths, backslashes, dot segments, negation, bracket syntax, `?`, and
+embedded `**` are rejected. For canonical `.mneme/project_memory.json`, the
+repository root is the parent of `.mneme`; custom memory files use their own
+parent directory as the policy root.
 
 `FORBID_DEPENDENCY` retains its legacy `WARN` behavior. `FORBID_PATH` and
 `REQUIRE_PATH` persist into Decisions for retrieval visibility but are not yet

--- a/docs/integrations/adr-import.md
+++ b/docs/integrations/adr-import.md
@@ -40,6 +40,13 @@ machine-readable directives:
 ```markdown
 ## Constraints
 - FORBID_LITERAL: install legacy-package
+- FORBID_LITERAL:
+    value: install legacy-client
+    include_paths:
+      - "docs/**"
+      - "**/*.md"
+    exclude_paths:
+      - "docs/generated/**"
 - FORBID_DEPENDENCY: mongodb
 - FORBID_PATH: src/legacy/billing/**
 - REQUIRE_PATH: billing/**
@@ -52,14 +59,15 @@ rather than being silently dropped -- a typo should not defeat governance.
 
 | Directive | Parsed and stored? | Enforced by `mneme check`? |
 |---|---|---|
-| `FORBID_LITERAL: text` | Yes, as a typed entry in `Decision.rules` | Yes -- exact, case-sensitive, boundary-aware match triggers FAIL |
+| `FORBID_LITERAL: text` | Yes, as a global typed entry in `Decision.rules` | Yes -- exact, case-sensitive, boundary-aware match triggers FAIL |
+| Structured `FORBID_LITERAL` with path selectors | Yes, including `include_paths` / `exclude_paths` | Yes when the artifact path is included and not excluded |
 | `FORBID_DEPENDENCY: X` | Yes, as `"no X"` in Decision.constraints | Yes -- triggers WARN |
 | `FORBID_PATH: glob` | Yes, as `"FORBID_PATH glob"` in Decision.constraints | No (stored for visibility) |
 | `REQUIRE_PATH: glob` | Yes, as `"REQUIRE_PATH glob"` in Decision.constraints | No (stored for visibility) |
 
-Glob-vs-changed-file enforcement for `FORBID_PATH` and `REQUIRE_PATH` is
-out of scope for the MVP -- the existing enforcer is a term-matcher, not a
-path-matcher. This is a follow-up capability.
+`FORBID_PATH` and `REQUIRE_PATH` remain retrieval-only directives. Path
+applicability is implemented only for typed `FORBID_LITERAL` rules; it does not
+give those legacy directive names new semantics.
 
 `FORBID_LITERAL` does not split prose into keywords. It checks the declared
 value directly and requires identifier/slug boundaries at identifier-like
@@ -68,6 +76,13 @@ passes. The comparison is case-sensitive. Typed rules are enforced regardless
 of retrieval score; retrieval still controls context injection only. When ADR
 source provenance is available, a rule is not applied to its own declaring ADR
 or canonical memory file, so policy storage can state the literal it governs.
+
+The scalar form remains global. The structured form requires a non-empty
+`include_paths` list; `exclude_paths` is optional and wins when both match.
+Patterns are repository-relative, forward-slash, and case-sensitive. `*`
+matches within one segment and a complete `**` segment matches zero or more
+segments. Absolute paths, backslashes, `.`, `..`, empty segments, negation,
+bracket syntax, `?`, and embedded `**` are rejected during compilation.
 
 An active ADR with no mechanically enforceable rules is still importable for
 retrieval, but preview prints a `Retrieval-only ADR warnings` diagnostic. A

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -9,9 +9,10 @@ reach your repository.
 ## The hook as the hero
 
 Every Edit, Write, or MultiEdit Claude Code attempts is intercepted by `mneme-hook`
-before it writes to disk. The hook reconstructs the full post-edit file content, checks
-it against your recorded decisions, and either allows the edit (exit 0) or blocks it
-with the violated decision id surfaced as feedback (exit 2).
+before it writes to disk. The hook reconstructs the edit, checks only the non-blank
+content it introduces, and passes the real edited-file path separately for typed-rule
+applicability. It either allows the edit (exit 0) or blocks it with the violated
+decision id surfaced as feedback (exit 2).
 
 Claude Code sees the block as an error message, can read the decision id and rule, and
 adjusts its approach without you having to intervene.
@@ -70,8 +71,11 @@ After installing, four slash commands are available in Claude Code:
 ## Retrieval: what the hook checks and what it misses
 
 The hook query is `"edit to <file_path>"` — tokens from the target file name determine
-which decisions are retrieved and checked. Decisions are scored by keyword overlap
-between the query and their `scope`, `id`, decision text, and anti-pattern fields.
+which decisions are retrieved for legacy heuristic checks. Typed
+`FORBID_LITERAL` rules are checked across the corpus independently of retrieval
+score, then filtered by their own path selectors when present. Decisions are
+scored by keyword overlap between the query and their `scope`, `id`, decision
+text, and anti-pattern fields.
 
 **What this means in practice:**
 
@@ -103,7 +107,7 @@ coverage on domains where file names are not self-describing.
 
 | Mode | Behaviour | Set via |
 |------|-----------|---------|
-| `strict` (default) | Block on any non-zero verdict from `mneme check` | `export MNEME_HOOK_MODE=strict` |
+| `strict` (default) | Block on a trusted, complete WARN or FAIL verdict | `export MNEME_HOOK_MODE=strict` |
 | `warn` | Surface warning to Claude, never block | `export MNEME_HOOK_MODE=warn` |
 
 Switch to `warn` while you're iterating on decisions to avoid friction:
@@ -121,8 +125,11 @@ The hook **never blocks** on execution errors. It exits 0 (allow) when:
 - The target file cannot be read (common for Write — the file doesn't exist yet)
 - `mneme check` times out (limit: 10 s)
 - Any other OS-level error occurs
+- A scoped typed rule's target path cannot be resolved against its policy root
 
-Only a real verdict returned by `mneme check` can cause a block.
+The last case emits an explicit applicability reason before failing open; an
+unknown path is never reported as `PASS`. Only a complete, trusted verdict
+returned by `mneme check` can cause a block.
 
 ---
 

--- a/mneme/adr_compiler.py
+++ b/mneme/adr_compiler.py
@@ -47,7 +47,12 @@ def _directive_to_constraint_string(d: ConstraintDirective) -> str:
 def _directive_to_rule(d: ConstraintDirective) -> Rule | None:
     """Compile a directive whose semantics are implemented as a typed rule."""
     if d.kind == "FORBID_LITERAL":
-        return Rule(type="FORBID_LITERAL", value=d.value)
+        return Rule(
+            type="FORBID_LITERAL",
+            value=d.value,
+            include_paths=d.include_paths,
+            exclude_paths=d.exclude_paths,
+        )
     return None
 
 

--- a/mneme/adr_constraints.py
+++ b/mneme/adr_constraints.py
@@ -10,6 +10,15 @@ machine-actionable directives, one per line, in the form::
     - FORBID_PATH: src/legacy/**
     - REQUIRE_PATH: billing/**
 
+Path-scoped typed rules use a structured mapping::
+
+    - FORBID_LITERAL:
+        value: install legacy-package
+        include_paths:
+          - docs/**
+        exclude_paths:
+          - docs/generated/**
+
 This module is a strict, deterministic parser. Unknown directive kinds raise,
 and so does a bullet that was evidently meant to be a directive but is
 malformed — wrong case, wrong separator, empty value, or a missing colon.
@@ -26,8 +35,14 @@ the section boundary is ignored, even if it looks like a directive.
 from __future__ import annotations
 
 import re
+import textwrap
 from dataclasses import dataclass
 from typing import Final
+
+import yaml
+from yaml.constructor import ConstructorError
+
+from mneme.path_selectors import validate_path_pattern
 
 
 VALID_KINDS: Final[frozenset[str]] = frozenset({
@@ -44,6 +59,8 @@ class ConstraintDirective:
 
     kind: str   # one of VALID_KINDS
     value: str  # raw value, trimmed
+    include_paths: tuple[str, ...] | None = None
+    exclude_paths: tuple[str, ...] = ()
 
 
 class ConstraintParseError(Exception):
@@ -53,6 +70,7 @@ class ConstraintParseError(Exception):
 _SECTION_HEADER = re.compile(r"^##\s+Constraints\s*$", re.MULTILINE)
 _NEXT_H2 = re.compile(r"^##\s+\S", re.MULTILINE)
 _DIRECTIVE_LINE = re.compile(r"^\s*-\s*([A-Z_]+)\s*:\s*(.+?)\s*$")
+_STRUCTURED_HEADER = re.compile(r"^(\s*)-\s*([A-Z_]+)\s*:\s*$")
 
 # A list bullet of any kind, with its content captured.
 _BULLET = re.compile(r"^\s*[-*]\s+(.*)$")
@@ -98,6 +116,116 @@ def _looks_like_directive(content: str) -> bool:
     return _normalise_kind(first) in VALID_KINDS
 
 
+class _UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeyLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _string_list(
+    mapping: dict[object, object],
+    key: str,
+    *,
+    required: bool,
+) -> tuple[str, ...]:
+    if key not in mapping:
+        if required:
+            raise ConstraintParseError(
+                f"structured FORBID_LITERAL requires {key!r}"
+            )
+        return ()
+    value = mapping[key]
+    if not isinstance(value, list) or (required and not value):
+        qualifier = "non-empty " if required else ""
+        raise ConstraintParseError(
+            f"structured FORBID_LITERAL {key!r} must be a {qualifier}list"
+        )
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ConstraintParseError(
+            f"structured FORBID_LITERAL {key!r} must contain non-empty strings"
+        )
+    patterns = tuple(item.strip() for item in value)
+    try:
+        for pattern in patterns:
+            validate_path_pattern(pattern)
+    except ValueError as exc:
+        raise ConstraintParseError(
+            f"invalid structured FORBID_LITERAL {key!r}: {exc}"
+        ) from exc
+    return patterns
+
+
+def _parse_structured_directive(
+    kind: str,
+    block_lines: list[str],
+) -> ConstraintDirective:
+    if kind not in VALID_KINDS:
+        raise ConstraintParseError(
+            f"unknown constraint directive {kind!r} "
+            f"(expected one of {sorted(VALID_KINDS)})"
+        )
+    if kind != "FORBID_LITERAL":
+        raise ConstraintParseError(
+            f"structured form is not supported for constraint directive {kind!r}"
+        )
+    try:
+        data = yaml.load(
+            textwrap.dedent("\n".join(block_lines)),
+            Loader=_UniqueKeyLoader,
+        )
+    except (yaml.YAMLError, TypeError) as exc:
+        raise ConstraintParseError(
+            f"invalid structured FORBID_LITERAL: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ConstraintParseError(
+            "structured FORBID_LITERAL body must be a mapping"
+        )
+    allowed = {"value", "include_paths", "exclude_paths"}
+    unknown = [key for key in data if key not in allowed]
+    if unknown:
+        raise ConstraintParseError(
+            "unknown structured FORBID_LITERAL fields: "
+            f"{sorted(unknown, key=str)!r}"
+        )
+    value = data.get("value")
+    if not isinstance(value, str) or not value.strip():
+        raise ConstraintParseError(
+            "structured FORBID_LITERAL requires a non-empty string 'value'"
+        )
+    include_paths = _string_list(data, "include_paths", required=True)
+    exclude_paths = _string_list(data, "exclude_paths", required=False)
+    return ConstraintDirective(
+        kind=kind,
+        value=value.strip(),
+        include_paths=include_paths,
+        exclude_paths=exclude_paths,
+    )
+
+
 def parse_constraints_section(body: str) -> list[ConstraintDirective]:
     """Extract directives from the first ``## Constraints`` section in body.
 
@@ -115,7 +243,34 @@ def parse_constraints_section(body: str) -> list[ConstraintDirective]:
     section_text = body[section_start:section_end]
 
     out: list[ConstraintDirective] = []
-    for line in section_text.splitlines():
+    lines = section_text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        structured = _STRUCTURED_HEADER.match(line)
+        if structured:
+            base_indent = len(structured.group(1))
+            kind = structured.group(2)
+            block_lines: list[str] = []
+            index += 1
+            while index < len(lines):
+                candidate = lines[index]
+                if not candidate.strip():
+                    block_lines.append(candidate)
+                    index += 1
+                    continue
+                indent = len(candidate) - len(candidate.lstrip())
+                if indent <= base_indent:
+                    break
+                block_lines.append(candidate)
+                index += 1
+            if not any(item.strip() for item in block_lines):
+                raise ConstraintParseError(
+                    f"constraint directive {kind!r} has an empty value"
+                )
+            out.append(_parse_structured_directive(kind, block_lines))
+            continue
+
         m = _DIRECTIVE_LINE.match(line)
         if m:
             kind, value = m.group(1), m.group(2).strip()
@@ -133,6 +288,7 @@ def parse_constraints_section(body: str) -> list[ConstraintDirective]:
                     f"{line.strip()!r}"
                 )
             out.append(ConstraintDirective(kind=kind, value=value))
+            index += 1
             continue
 
         # Not a well-formed directive. Before dropping it, decide whether it
@@ -147,6 +303,7 @@ def parse_constraints_section(body: str) -> list[ConstraintDirective]:
                 f"KIND and a non-empty value "
                 f"(expected one of {sorted(VALID_KINDS)})."
             )
+        index += 1
     return out
 
 

--- a/mneme/adr_import.py
+++ b/mneme/adr_import.py
@@ -30,7 +30,7 @@ from mneme.adr_compiler import (
     validate_corpus,
 )
 from mneme.adr_parser import parse_adr_directory
-from mneme.schemas import Decision
+from mneme.schemas import Decision, Rule
 
 # Note: mneme.adr_freshness is imported lazily inside ``apply_import`` to
 # avoid a module-init cycle (adr_freshness needs project_decision_graph
@@ -38,6 +38,18 @@ from mneme.schemas import Decision
 
 
 GraphStatus = Literal["active", "superseded", "deprecated", "inactive"]
+
+
+def _serialize_rule(rule: Rule) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "type": rule.type,
+        "value": rule.value,
+    }
+    if rule.include_paths is not None:
+        payload["include_paths"] = list(rule.include_paths)
+    if rule.exclude_paths:
+        payload["exclude_paths"] = list(rule.exclude_paths)
+    return payload
 
 
 @dataclass(frozen=True)
@@ -266,6 +278,14 @@ def format_preview(
         if decision:
             for rule in decision.rules:
                 lines.append(f"      rule: {rule.type} {rule.value}")
+                if rule.include_paths is not None:
+                    lines.append(
+                        f"        include_paths: {', '.join(rule.include_paths)}"
+                    )
+                if rule.exclude_paths:
+                    lines.append(
+                        f"        exclude_paths: {', '.join(rule.exclude_paths)}"
+                    )
             for c in decision.constraints:
                 lines.append(f"      constraint: {c}")
             if not decision.rules and not decision.constraints:
@@ -373,10 +393,7 @@ def apply_import(
             "scope": list(decision.scope),
             "constraints": list(decision.constraints),
             "anti_patterns": list(decision.anti_patterns),
-            "rules": [
-                {"type": rule.type, "value": rule.value}
-                for rule in decision.rules
-            ],
+            "rules": [_serialize_rule(rule) for rule in decision.rules],
             "created_at": decision.created_at,
             "updated_at": decision.updated_at,
         }

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -121,6 +121,10 @@ def _cmd_list(args: argparse.Namespace) -> int:
         if d.rules:
             for rule in d.rules:
                 print(f"    rule: {rule.type} {rule.value}")
+                if rule.include_paths is not None:
+                    print(f"      applies to: {', '.join(rule.include_paths)}")
+                if rule.exclude_paths:
+                    print(f"      except: {', '.join(rule.exclude_paths)}")
     return 0
 
 
@@ -203,6 +207,21 @@ def _check_payload(
         "schema": CHECK_JSON_SCHEMA,
         "verdict": result.verdict.value,
         "mode": mode,
+        "evaluation_complete": result.evaluation_complete,
+        "applicability": [
+            {
+                "decision_id": item.decision_id,
+                "rule_type": item.rule_type,
+                "rule_value": item.rule_value,
+                "rule_index": item.rule_index,
+                "path_scoped": item.path_scoped,
+                "input_path": item.input_path,
+                "outcome": item.outcome.value,
+                "selector": item.selector,
+                "reason": item.reason,
+            }
+            for item in result.applicability
+        ],
         "violations": [
             {
                 "decision_id": v.decision_id,
@@ -212,6 +231,8 @@ def _check_payload(
                 "trigger": v.trigger,
                 "kind": v.kind,
                 "rule_type": v.rule_type,
+                "input_path": v.input_path,
+                "selector": v.selector,
             }
             for v in result.violations
         ],
@@ -231,13 +252,21 @@ def _cmd_check(args: argparse.Namespace) -> int:
     retriever = DecisionRetriever(store.decisions())
     scored = retriever.retrieve(args.query)
 
-    result = check_prompt(input_text, scored, top=args.top, input_path=args.input)
+    target_path = args.target_path or args.input
+    result = check_prompt(
+        input_text,
+        scored,
+        top=args.top,
+        input_path=target_path,
+    )
 
     if getattr(args, "json", False):
         # Machine-readable mode: the payload must be the only thing on stdout,
         # so the human-readable violation and freshness blocks are suppressed.
         freshness = check_freshness(memory_path=args.memory, adr_dir=args.adr_dir)
         print(json.dumps(_check_payload(result, freshness, args.mode)))
+        if not result.evaluation_complete:
+            return 2
         return _EXIT_CODES_BY_MODE[args.mode][result.verdict]
 
     if result.violations:
@@ -248,6 +277,26 @@ def _cmd_check(args: argparse.Namespace) -> int:
                 f"{kind} \"{v.rule}\" -- trigger: {v.trigger}"
             )
             print(f"      {v.decision_text}")
+            if v.input_path:
+                selector = f" via {v.selector}" if v.selector else ""
+                print(f"      path: {v.input_path}{selector}")
+        print()
+
+    scoped_traces = [item for item in result.applicability if item.path_scoped]
+    if scoped_traces:
+        for item in scoped_traces:
+            if item.outcome.value == "UNKNOWN":
+                print(
+                    f"ERROR PATH_APPLICABILITY_UNKNOWN [{item.decision_id}] "
+                    f"{item.rule_type} {item.rule_value!r} -- {item.reason}"
+                )
+                continue
+            path = item.input_path or "(unknown)"
+            selector = f" via {item.selector}" if item.selector else ""
+            print(
+                f"PATH  {item.outcome.value:8} [{item.decision_id}] "
+                f"{path}{selector} -- {item.reason}"
+            )
         print()
 
     # ADR freshness diagnostics are warn-only: they print to stdout but
@@ -260,6 +309,9 @@ def _cmd_check(args: argparse.Namespace) -> int:
             _print_freshness_issue(issue)
         print()
 
+    if not result.evaluation_complete:
+        print("Result: INCOMPLETE")
+        return 2
     print(f"Result: {result.verdict.value}")
     return _EXIT_CODES_BY_MODE[args.mode][result.verdict]
 
@@ -433,6 +485,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check = sub.add_parser("check", help="Enforce decisions against an input prompt")
     p_check.add_argument("--memory", required=True, help="Path to project_memory.json")
     p_check.add_argument("--input", required=True, help="Path to input file to check")
+    p_check.add_argument(
+        "--target-path",
+        default=None,
+        help=(
+            "Artifact path used for typed-rule applicability when --input "
+            "contains materialized or introduced content from another file"
+        ),
+    )
     p_check.add_argument("--query", required=True, help="Context query for retrieval")
     p_check.add_argument(
         "--top", type=int, default=DEFAULT_MAX_DECISIONS,

--- a/mneme/conflict_detector.py
+++ b/mneme/conflict_detector.py
@@ -10,16 +10,22 @@ v1 matching is deliberately simple:
   - A violation fires when the phrase appears in the response AND the
     surrounding 10-word window is NOT dominated by negation signals.
 
-Upgrade path: swap ``_appears_recommended`` for a model-based classifier
-without changing the public API.
+Upgrade path: swap the legacy phrase classifier for a model-based classifier
+while preserving the structured conflict and applicability results.
 """
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Iterable
 
+from mneme.path_selectors import (
+    RuleEvaluation,
+    SelectorOutcome,
+    evaluate_path_selectors,
+)
 from mneme.rule_matcher import literal_in_text
 from mneme.schemas import Decision
 
@@ -46,6 +52,35 @@ class Conflict:
     violated_decision_id: str
     reason: str
     snippet: str
+
+
+@dataclass
+class ConflictDetectionResult:
+    conflicts: list[Conflict] = field(default_factory=list)
+    applicability: list[RuleEvaluation] = field(default_factory=list)
+
+    @property
+    def evaluation_complete(self) -> bool:
+        return not any(
+            item.outcome == SelectorOutcome.UNKNOWN
+            for item in self.applicability
+        )
+
+
+class PathApplicabilityUnknownError(RuntimeError):
+    """Raised when detect() cannot safely evaluate a scoped typed rule."""
+
+    def __init__(self, applicability: list[RuleEvaluation]) -> None:
+        self.applicability = applicability
+        reasons = sorted({
+            item.reason
+            for item in applicability
+            if item.outcome == SelectorOutcome.UNKNOWN
+        })
+        super().__init__(
+            "typed-rule path applicability could not be evaluated: "
+            + "; ".join(reasons)
+        )
 
 
 def _extract_candidate_phrases(decision: Decision) -> list[tuple[str, str]]:
@@ -84,23 +119,46 @@ def _window_is_negated(snippet: str) -> bool:
 class ConflictDetector:
     """Detects violations of injected decisions in LLM output."""
 
-    def detect(
+    def evaluate(
         self,
         response: str,
         decisions: Iterable[Decision],
-    ) -> list[Conflict]:
+        target_path: str | Path | None = None,
+    ) -> ConflictDetectionResult:
         """Return a list of Conflicts — empty if no violation detected.
 
         Args:
             response:  The LLM response text to audit.
             decisions: The Decisions that were injected into the call.
+            target_path: Artifact path the response is intended to modify.
         """
         conflicts: list[Conflict] = []
+        applicability: list[RuleEvaluation] = []
         seen: set[tuple[str, str]] = set()  # (decision_id, phrase)
 
         for d in decisions:
-            for rule in d.rules:
+            for rule_index, rule in enumerate(d.rules):
                 if rule.type != "FORBID_LITERAL":
+                    continue
+                selection = evaluate_path_selectors(
+                    include_paths=rule.include_paths,
+                    exclude_paths=rule.exclude_paths,
+                    input_path=target_path,
+                    memory_path=d.memory_path,
+                    policy_paths=(d.source_path, d.memory_path),
+                )
+                applicability.append(RuleEvaluation(
+                    decision_id=d.id,
+                    rule_type=rule.type,
+                    rule_value=rule.value,
+                    rule_index=rule_index,
+                    path_scoped=rule.is_path_scoped,
+                    outcome=selection.outcome,
+                    input_path=selection.input_path,
+                    selector=selection.selector,
+                    reason=selection.reason,
+                ))
+                if selection.outcome != SelectorOutcome.APPLIED:
                     continue
                 if not literal_in_text(rule.value, response):
                     continue
@@ -140,4 +198,27 @@ class ConflictDetector:
                     snippet=snippet,
                 ))
 
-        return conflicts
+        return ConflictDetectionResult(
+            conflicts=conflicts,
+            applicability=applicability,
+        )
+
+    def detect(
+        self,
+        response: str,
+        decisions: Iterable[Decision],
+        target_path: str | Path | None = None,
+    ) -> list[Conflict]:
+        """Return conflicts, raising if scoped applicability is unknown."""
+        result = self.evaluate(response, decisions, target_path=target_path)
+        if not result.evaluation_complete:
+            raise PathApplicabilityUnknownError(result.applicability)
+        return result.conflicts
+
+
+__all__ = [
+    "Conflict",
+    "ConflictDetectionResult",
+    "ConflictDetector",
+    "PathApplicabilityUnknownError",
+]

--- a/mneme/context_builder.py
+++ b/mneme/context_builder.py
@@ -188,6 +188,14 @@ def format_decisions(
             lines.append("  Typed rules:")
             for rule in d.rules:
                 lines.append(f"    - {rule.type}: {rule.value}")
+                if rule.include_paths is not None:
+                    lines.append(
+                        f"      Applies to: {', '.join(rule.include_paths)}"
+                    )
+                if rule.exclude_paths:
+                    lines.append(
+                        f"      Except: {', '.join(rule.exclude_paths)}"
+                    )
         blocks.append("\n".join(lines))
 
     return "\n\n".join(blocks)

--- a/mneme/cursor_generator.py
+++ b/mneme/cursor_generator.py
@@ -79,6 +79,14 @@ def generate_mdc(
             lines.append("**Typed rules:**")
             for rule in d.rules:
                 lines.append(f"- {rule.type}: {rule.value}")
+                if rule.include_paths is not None:
+                    lines.append(
+                        f"  - Applies to: {', '.join(rule.include_paths)}"
+                    )
+                if rule.exclude_paths:
+                    lines.append(
+                        f"  - Except: {', '.join(rule.exclude_paths)}"
+                    )
             lines.append("")
 
     return "\n".join(lines)

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -18,6 +18,7 @@ Severity semantics:
 
 Exit codes for the CLI:
     0 = PASS, 1 = WARN, 2 = FAIL
+    Path applicability UNKNOWN is an operational exit 2, not a policy verdict.
 """
 
 from __future__ import annotations
@@ -28,6 +29,11 @@ from enum import Enum
 from pathlib import Path
 
 from mneme.decision_retriever import ScoredDecision
+from mneme.path_selectors import (
+    RuleEvaluation,
+    SelectorOutcome,
+    evaluate_path_selectors,
+)
 from mneme.rule_matcher import literal_in_text
 
 
@@ -46,12 +52,22 @@ class Violation:
     trigger: str  # the specific term found in the input
     kind: str = "legacy"
     rule_type: str | None = None
+    input_path: str | None = None
+    selector: str | None = None
 
 
 @dataclass
 class EnforcementResult:
     verdict: Severity
     violations: list[Violation] = field(default_factory=list)
+    applicability: list[RuleEvaluation] = field(default_factory=list)
+
+    @property
+    def evaluation_complete(self) -> bool:
+        return not any(
+            item.outcome == SelectorOutcome.UNKNOWN
+            for item in self.applicability
+        )
 
 
 # Words that appear frequently in rule descriptions but carry no domain signal.
@@ -71,24 +87,6 @@ def _rule_terms(text: str, min_len: int = 3) -> list[str]:
 def _word_in_text(term: str, text: str) -> bool:
     """True if term appears as a whole word (case-insensitive) in text."""
     return bool(re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE))
-
-
-def _is_policy_source(
-    input_path: str | Path | None,
-    *policy_paths: str,
-) -> bool:
-    """Return whether the input stores or declares the decision's policy."""
-    if input_path is None:
-        return False
-    for policy_path in policy_paths:
-        if not policy_path:
-            continue
-        try:
-            if Path(input_path).resolve() == Path(policy_path).resolve():
-                return True
-        except OSError:
-            continue
-    return False
 
 
 def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]:
@@ -183,24 +181,46 @@ def check_prompt(
         EnforcementResult with verdict and list of Violations.
     """
     violations: list[Violation] = []
+    applicability: list[RuleEvaluation] = []
 
     for s, literal_only in _enforcement_scope(scored, top):
         d = s.decision
 
-        if not _is_policy_source(input_path, d.source_path, d.memory_path):
-            for rule in d.rules:
-                if rule.type == "FORBID_LITERAL" and literal_in_text(
-                    rule.value, input_text
-                ):
-                    violations.append(Violation(
-                        decision_id=d.id,
-                        decision_text=d.decision,
-                        severity=Severity.FAIL,
-                        rule=rule.value,
-                        trigger=rule.value,
-                        kind="typed_rule",
-                        rule_type=rule.type,
-                    ))
+        for rule_index, rule in enumerate(d.rules):
+            selection = evaluate_path_selectors(
+                include_paths=rule.include_paths,
+                exclude_paths=rule.exclude_paths,
+                input_path=input_path,
+                memory_path=d.memory_path,
+                policy_paths=(d.source_path, d.memory_path),
+            )
+            applicability.append(RuleEvaluation(
+                decision_id=d.id,
+                rule_type=rule.type,
+                rule_value=rule.value,
+                rule_index=rule_index,
+                path_scoped=rule.is_path_scoped,
+                outcome=selection.outcome,
+                input_path=selection.input_path,
+                selector=selection.selector,
+                reason=selection.reason,
+            ))
+            if (
+                selection.outcome == SelectorOutcome.APPLIED
+                and rule.type == "FORBID_LITERAL"
+                and literal_in_text(rule.value, input_text)
+            ):
+                violations.append(Violation(
+                    decision_id=d.id,
+                    decision_text=d.decision,
+                    severity=Severity.FAIL,
+                    rule=rule.value,
+                    trigger=rule.value,
+                    kind="typed_rule",
+                    rule_type=rule.type,
+                    input_path=selection.input_path,
+                    selector=selection.selector,
+                ))
 
         for ap in d.anti_patterns:
             if literal_only and not _is_literal_rule(ap):
@@ -244,4 +264,8 @@ def check_prompt(
     else:
         verdict = Severity.PASS
 
-    return EnforcementResult(verdict=verdict, violations=violations)
+    return EnforcementResult(
+        verdict=verdict,
+        violations=violations,
+        applicability=applicability,
+    )

--- a/mneme/integrations/claude_code/hook.py
+++ b/mneme/integrations/claude_code/hook.py
@@ -243,9 +243,10 @@ def parse_verdict(stdout: str) -> Optional[Dict[str, Any]]:
 
 
 def _is_stale_runtime(child_stderr: str) -> bool:
-    """True when the child CLI is too old to understand ``--json``."""
-    return "unrecognized arguments" in (child_stderr or "") and "--json" in (
-        child_stderr or ""
+    """True when the child CLI lacks required machine/path-aware options."""
+    return "unrecognized arguments" in (child_stderr or "") and any(
+        option in (child_stderr or "")
+        for option in ("--json", "--target-path")
     )
 
 
@@ -266,6 +267,24 @@ def format_reason(payload: Dict[str, Any]) -> str:
         )
         if v.get("decision_text"):
             lines.append(f"      {v['decision_text']}")
+        if v.get("input_path"):
+            selector = f" via {v.get('selector')}" if v.get("selector") else ""
+            lines.append(f"      path: {v['input_path']}{selector}")
+    return "\n".join(lines)
+
+
+def format_applicability_reason(payload: Dict[str, Any]) -> str:
+    """Render scoped-rule UNKNOWN traces for fail-open diagnostics."""
+    traces = [
+        item for item in (payload.get("applicability") or [])
+        if isinstance(item, dict) and item.get("outcome") == "UNKNOWN"
+    ]
+    lines = ["mneme-hook: typed-rule path applicability is unknown; failing open."]
+    for item in traces:
+        lines.append(
+            f"  [{item.get('decision_id')}] {item.get('rule_type')} "
+            f"{item.get('rule_value')!r}: {item.get('reason')}"
+        )
     return "\n".join(lines)
 
 
@@ -307,16 +326,22 @@ def _run_check(
 
     try:
         rel = event.file_path or "(unknown)"
+        target_path = event.file_path
+        if target_path and not Path(target_path).is_absolute() and event.cwd:
+            target_path = str(Path(event.cwd) / target_path)
+        command = [
+            sys.executable, "-m", "mneme", "check",
+            "--memory", str(memory),
+            "--input", input_path,
+            "--query", f"edit to {rel}",
+            "--mode", mode,
+            "--json",
+        ]
+        if target_path:
+            command.extend(["--target-path", target_path])
         try:
             proc = subprocess.run(
-                [
-                    sys.executable, "-m", "mneme", "check",
-                    "--memory", str(memory),
-                    "--input", input_path,
-                    "--query", f"edit to {rel}",
-                    "--mode", mode,
-                    "--json",
-                ],
+                command,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -342,9 +367,9 @@ def _run_check(
                 # Silence here would mean enforcement is off with nobody told.
                 print(
                     "mneme-hook: the installed mneme CLI does not support "
-                    "--json, so no edit can be checked and ENFORCEMENT IS "
-                    "INACTIVE. Upgrade with: pipx install --force "
-                    "\"mneme-hq>=0.5.1\"",
+                    "the required JSON/path-aware check options, so no edit "
+                    "can be checked and ENFORCEMENT IS "
+                    "INACTIVE. Upgrade with: pipx upgrade mneme-hq",
                     file=stderr,
                 )
                 return 0
@@ -358,6 +383,9 @@ def _run_check(
             return 0
 
         verdict = payload["verdict"]
+        if payload.get("evaluation_complete") is False:
+            print(format_applicability_reason(payload), file=stderr)
+            return 0
         if verdict == "PASS":
             return 0
 

--- a/mneme/memory_store.py
+++ b/mneme/memory_store.py
@@ -50,6 +50,26 @@ def _resolve_source_path(
     return str((memory_path.parent / raw_path).resolve())
 
 
+def _load_rule(record: object) -> Rule:
+    if not isinstance(record, dict):
+        raise ValueError("rule record must be an object")
+    include_paths: tuple[str, ...] | None = None
+    if "include_paths" in record:
+        raw_include = record["include_paths"]
+        if not isinstance(raw_include, list):
+            raise ValueError("rule include_paths must be a list")
+        include_paths = tuple(raw_include)
+    raw_exclude = record.get("exclude_paths", [])
+    if not isinstance(raw_exclude, list):
+        raise ValueError("rule exclude_paths must be a list")
+    return Rule(
+        type=record["type"],
+        value=record["value"],
+        include_paths=include_paths,
+        exclude_paths=tuple(raw_exclude),
+    )
+
+
 class MemoryStore:
     """Loads project memory from a JSON file and exposes typed accessors.
 
@@ -125,7 +145,7 @@ class MemoryStore:
                 constraints=list(d.get("constraints", [])),
                 anti_patterns=list(d.get("anti_patterns", [])),
                 rules=[
-                    Rule(type=rule["type"], value=rule["value"])
+                    _load_rule(rule)
                     for rule in d.get("rules", [])
                 ],
                 source_path=_resolve_source_path(

--- a/mneme/path_selectors.py
+++ b/mneme/path_selectors.py
@@ -1,0 +1,277 @@
+"""Deterministic path applicability for typed Mneme rules.
+
+ADR-020 deliberately defines a smaller grammar than gitignore or shell globs:
+
+* paths and patterns are repository-relative and use forward slashes;
+* a single star matches characters within one path segment;
+* a complete double-star segment matches zero or more path segments;
+* matching is case-sensitive on every operating system.
+
+Keeping the matcher here, independent of rule types, lets schema validation,
+the pre-flight enforcer, and post-generation conflict detection share exactly
+the same applicability semantics.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+
+class SelectorOutcome(str, Enum):
+    """Result of evaluating one rule's artifact applicability."""
+
+    APPLIED = "APPLIED"
+    EXCLUDED = "EXCLUDED"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class PathSelection:
+    """Path-only applicability result before rule metadata is added."""
+
+    outcome: SelectorOutcome
+    input_path: str | None
+    selector: str | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class RuleEvaluation:
+    """Auditable applicability trace for one typed rule."""
+
+    decision_id: str
+    rule_type: str
+    rule_value: str
+    rule_index: int
+    path_scoped: bool
+    outcome: SelectorOutcome
+    input_path: str | None
+    selector: str | None = None
+    reason: str = ""
+
+
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:/")
+
+
+def validate_path_pattern(pattern: object) -> str:
+    """Validate and return one ADR-020 selector unchanged."""
+    if not isinstance(pattern, str) or not pattern:
+        raise ValueError("path selector must be a non-empty string")
+    if "\\" in pattern:
+        raise ValueError(
+            f"path selector {pattern!r} must use forward slashes"
+        )
+    if pattern.startswith("/") or _WINDOWS_ABSOLUTE.match(pattern):
+        raise ValueError(f"path selector {pattern!r} must be repository-relative")
+    if pattern.startswith("!"):
+        raise ValueError(f"path selector {pattern!r} cannot use negation")
+    if any(token in pattern for token in ("?", "[", "]")):
+        raise ValueError(
+            f"path selector {pattern!r} uses unsupported glob syntax"
+        )
+
+    segments = pattern.split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise ValueError(
+            f"path selector {pattern!r} contains an empty or dot segment"
+        )
+    if any("**" in segment and segment != "**" for segment in segments):
+        raise ValueError(
+            f"path selector {pattern!r} may use ** only as a complete segment"
+        )
+    return pattern
+
+
+def path_matches(pattern: str, relative_path: str) -> bool:
+    """Return whether a normalized relative path matches pattern."""
+    validate_path_pattern(pattern)
+    if (
+        not isinstance(relative_path, str)
+        or not relative_path
+        or "\\" in relative_path
+        or relative_path.startswith("/")
+        or _WINDOWS_ABSOLUTE.match(relative_path)
+    ):
+        raise ValueError(
+            f"relative path {relative_path!r} is not normalized"
+        )
+    path_segments = relative_path.split("/")
+    if any(segment in ("", ".", "..") for segment in path_segments):
+        raise ValueError(
+            f"relative path {relative_path!r} contains an empty or dot segment"
+        )
+    pattern_segments = pattern.split("/")
+
+    @lru_cache(maxsize=None)
+    def matches(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern_segments):
+            return path_index == len(path_segments)
+
+        segment = pattern_segments[pattern_index]
+        if segment == "**":
+            return (
+                matches(pattern_index + 1, path_index)
+                or (
+                    path_index < len(path_segments)
+                    and matches(pattern_index, path_index + 1)
+                )
+            )
+
+        return (
+            path_index < len(path_segments)
+            and fnmatch.fnmatchcase(path_segments[path_index], segment)
+            and matches(pattern_index + 1, path_index + 1)
+        )
+
+    return matches(0, 0)
+
+
+def policy_root(memory_path: str | Path) -> Path:
+    """Derive the policy root defined by ADR-020."""
+    memory = Path(memory_path).resolve()
+    if memory.name == "project_memory.json" and memory.parent.name == ".mneme":
+        return memory.parent.parent
+    return memory.parent
+
+
+def normalize_input_path(
+    input_path: str | Path,
+    memory_path: str | Path,
+) -> str:
+    """Return the case-preserving, policy-root-relative input path."""
+    try:
+        resolved_input = Path(input_path).resolve()
+        root = policy_root(memory_path)
+        relative = resolved_input.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(
+            f"input path {str(input_path)!r} is outside or cannot be "
+            f"resolved against policy root"
+        ) from exc
+
+    normalized = relative.as_posix()
+    if normalized in ("", "."):
+        raise ValueError("input path resolves to the policy root, not an artifact")
+    return normalized
+
+
+def _same_resolved_path(
+    input_path: str | Path | None,
+    policy_paths: Iterable[str | Path],
+) -> bool:
+    if input_path is None:
+        return False
+    try:
+        resolved_input = Path(input_path).resolve()
+    except (OSError, RuntimeError):
+        return False
+    for candidate in policy_paths:
+        if not candidate:
+            continue
+        try:
+            if resolved_input == Path(candidate).resolve():
+                return True
+        except (OSError, RuntimeError):
+            continue
+    return False
+
+
+def evaluate_path_selectors(
+    *,
+    include_paths: tuple[str, ...] | None,
+    exclude_paths: tuple[str, ...],
+    input_path: str | Path | None,
+    memory_path: str | Path | None,
+    policy_paths: Iterable[str | Path] = (),
+) -> PathSelection:
+    """Evaluate canonical exemptions and optional path selectors."""
+    if _same_resolved_path(input_path, policy_paths):
+        normalized: str | None = None
+        if input_path is not None and memory_path:
+            try:
+                normalized = normalize_input_path(input_path, memory_path)
+            except ValueError:
+                pass
+        return PathSelection(
+            outcome=SelectorOutcome.EXCLUDED,
+            input_path=normalized,
+            selector="<canonical-policy-source>",
+            reason="the input is this rule's declaring ADR or policy memory",
+        )
+
+    # Existing unscoped rules remain global and never depend on path metadata.
+    if include_paths is None:
+        normalized = None
+        if input_path is not None and memory_path:
+            try:
+                normalized = normalize_input_path(input_path, memory_path)
+            except ValueError:
+                pass
+        return PathSelection(
+            outcome=SelectorOutcome.APPLIED,
+            input_path=normalized,
+            reason="the rule has global applicability",
+        )
+
+    if input_path is None:
+        return PathSelection(
+            outcome=SelectorOutcome.UNKNOWN,
+            input_path=None,
+            reason="a scoped rule requires an input path",
+        )
+    if not memory_path:
+        return PathSelection(
+            outcome=SelectorOutcome.UNKNOWN,
+            input_path=None,
+            reason="a scoped rule requires its policy memory path",
+        )
+
+    try:
+        normalized = normalize_input_path(input_path, memory_path)
+    except ValueError as exc:
+        return PathSelection(
+            outcome=SelectorOutcome.UNKNOWN,
+            input_path=None,
+            reason=str(exc),
+        )
+
+    for selector in exclude_paths:
+        if path_matches(selector, normalized):
+            return PathSelection(
+                outcome=SelectorOutcome.EXCLUDED,
+                input_path=normalized,
+                selector=selector,
+                reason="an exclude selector matched",
+            )
+
+    for selector in include_paths:
+        if path_matches(selector, normalized):
+            return PathSelection(
+                outcome=SelectorOutcome.APPLIED,
+                input_path=normalized,
+                selector=selector,
+                reason="an include selector matched",
+            )
+
+    return PathSelection(
+        outcome=SelectorOutcome.EXCLUDED,
+        input_path=normalized,
+        reason="no include selector matched",
+    )
+
+
+__all__ = [
+    "PathSelection",
+    "RuleEvaluation",
+    "SelectorOutcome",
+    "evaluate_path_selectors",
+    "normalize_input_path",
+    "path_matches",
+    "policy_root",
+    "validate_path_pattern",
+]

--- a/mneme/pipeline.py
+++ b/mneme/pipeline.py
@@ -23,6 +23,7 @@ from mneme.context_builder import DEFAULT_MAX_DECISIONS, format_decisions
 from mneme.decision_retriever import DecisionRetriever, ScoredDecision
 from mneme.llm_adapter import LLMAdapter
 from mneme.memory_store import MemoryStore
+from mneme.path_selectors import RuleEvaluation, SelectorOutcome
 from mneme.schemas import Decision, LLMResponse
 
 
@@ -45,6 +46,14 @@ class PipelineResult:
     system_prompt: str
     response: LLMResponse
     conflicts: list[Conflict] = field(default_factory=list)
+    applicability: list[RuleEvaluation] = field(default_factory=list)
+
+    @property
+    def evaluation_complete(self) -> bool:
+        return not any(
+            item.outcome == SelectorOutcome.UNKNOWN
+            for item in self.applicability
+        )
 
 
 class Pipeline:
@@ -93,6 +102,7 @@ class Pipeline:
         self,
         query: str,
         _override_response: str | None = None,
+        target_path: str | Path | None = None,
     ) -> PipelineResult:
         """Execute the full pipeline for one query.
 
@@ -134,7 +144,11 @@ class Pipeline:
                 user=query, system=system_prompt or None
             )
 
-        conflicts = self.detector.detect(response.content, injected)
+        detection = self.detector.evaluate(
+            response.content,
+            injected,
+            target_path=target_path,
+        )
 
         result = PipelineResult(
             query=query,
@@ -142,11 +156,15 @@ class Pipeline:
             injected_decisions=injected,
             system_prompt=system_prompt,
             response=response,
-            conflicts=conflicts,
+            conflicts=detection.conflicts,
+            applicability=detection.applicability,
         )
 
-        if self.enforcement_mode == "strict" and conflicts:
+        if self.enforcement_mode == "strict" and detection.conflicts:
             from mneme.schemas import MnemeConflictError
-            raise MnemeConflictError(conflicts=conflicts, result=result)
+            raise MnemeConflictError(
+                conflicts=detection.conflicts,
+                result=result,
+            )
 
         return result

--- a/mneme/schemas.py
+++ b/mneme/schemas.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from mneme.path_selectors import validate_path_pattern
+
 
 # ── Type aliases ─────────────────────────────────────────────────────────────
 
@@ -140,12 +142,16 @@ class Rule:
     semantics before joining ``VALID_RULE_TYPES``.
 
     Attributes:
-        type:  One of ``VALID_RULE_TYPES``.
-        value: Non-empty literal value consumed by the rule matcher.
+        type:          One of ``VALID_RULE_TYPES``.
+        value:         Non-empty literal value consumed by the rule matcher.
+        include_paths: Optional non-empty selector tuple. ``None`` is global.
+        exclude_paths: Selector tuple that overrides matching includes.
     """
 
     type: RuleType
     value: str
+    include_paths: tuple[str, ...] | None = None
+    exclude_paths: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.type not in VALID_RULE_TYPES:
@@ -155,6 +161,27 @@ class Rule:
             )
         if not isinstance(self.value, str) or not self.value.strip():
             raise ValueError("rule value must be a non-empty string")
+        if self.include_paths is not None:
+            if (
+                not isinstance(self.include_paths, tuple)
+                or not self.include_paths
+            ):
+                raise ValueError(
+                    "include_paths must be a non-empty tuple when provided"
+                )
+            for pattern in self.include_paths:
+                validate_path_pattern(pattern)
+        if not isinstance(self.exclude_paths, tuple):
+            raise ValueError("exclude_paths must be a tuple")
+        if self.exclude_paths and self.include_paths is None:
+            raise ValueError("exclude_paths require include_paths")
+        for pattern in self.exclude_paths:
+            validate_path_pattern(pattern)
+
+    @property
+    def is_path_scoped(self) -> bool:
+        """Whether this rule requires an artifact path for applicability."""
+        return self.include_paths is not None
 
 
 @dataclass

--- a/tests/integrations/claude_code/test_hook_verdict.py
+++ b/tests/integrations/claude_code/test_hook_verdict.py
@@ -252,6 +252,51 @@ def test_check_is_invoked_with_json_flag(tmp_path):
     assert "--json" in mrun.call_args.args[0]
 
 
+def test_check_receives_real_edit_target_for_path_applicability(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    fake = MagicMock(
+        returncode=0,
+        stdout=_payload("PASS", violations=[]),
+        stderr="",
+    )
+    with patch(
+        "mneme.integrations.claude_code.hook.subprocess.run",
+        return_value=fake,
+    ) as mrun:
+        main(
+            stdin=io.StringIO(_edit_envelope(tmp_path, target)),
+            stderr=io.StringIO(),
+            stdout=io.StringIO(),
+        )
+    command = mrun.call_args.args[0]
+    index = command.index("--target-path")
+    assert Path(command[index + 1]) == target
+
+
+def test_unknown_path_applicability_fails_open_with_reason(tmp_path):
+    mem, target = _project_with_memory(tmp_path)
+    payload = json.loads(_payload("PASS", violations=[]))
+    payload["evaluation_complete"] = False
+    payload["applicability"] = [{
+        "decision_id": "ADR-020",
+        "rule_type": "FORBID_LITERAL",
+        "rule_value": "install legacy-client",
+        "outcome": "UNKNOWN",
+        "reason": "a scoped rule requires an input path",
+    }]
+    rc, err, out = _run(
+        tmp_path,
+        target,
+        returncode=2,
+        stdout=json.dumps(payload),
+    )
+    assert rc == 0
+    assert out == ""
+    assert "failing open" in err
+    assert "ADR-020" in err
+    assert "requires an input path" in err
+
+
 # ── reason formatting ────────────────────────────────────────────────────────
 
 def test_format_reason_includes_rule_and_trigger():

--- a/tests/test_adr_compile_integration.py
+++ b/tests/test_adr_compile_integration.py
@@ -140,3 +140,29 @@ def test_adrs_to_decisions_compiles_forbid_literal_as_typed_rule():
     assert rule.value == "pip install mneme"
     assert decision.constraints == []
     assert Path(decision.source_path).name == "ADR-201-forbid-install-command.md"
+
+
+def test_adrs_to_decisions_compiles_structured_path_selectors():
+    from mneme.adr_schema import ADR
+
+    adr = ADR(
+        id="ADR-020",
+        title="Scope typed rules",
+        status="accepted",
+        priority="normal",
+        date="2026-08-11",
+        scope="",
+        body=(
+            "## Constraints\n"
+            "- FORBID_LITERAL:\n"
+            "    value: install legacy-client\n"
+            "    include_paths:\n"
+            "      - docs/**\n"
+            "    exclude_paths:\n"
+            "      - docs/generated/**\n"
+        ),
+    )
+    [decision] = adrs_to_decisions([adr])
+    [rule] = decision.rules
+    assert rule.include_paths == ("docs/**",)
+    assert rule.exclude_paths == ("docs/generated/**",)

--- a/tests/test_adr_constraints.py
+++ b/tests/test_adr_constraints.py
@@ -2,6 +2,8 @@
 """Tests for the ## Constraints body directive parser."""
 from __future__ import annotations
 
+import pytest
+
 from mneme.adr_constraints import (
     ConstraintDirective,
     ConstraintParseError,
@@ -26,6 +28,67 @@ def test_parse_forbid_literal_directive():
     assert parse_constraints_section(body) == [
         ConstraintDirective(kind="FORBID_LITERAL", value="pip install mneme")
     ]
+
+
+def test_parse_structured_path_scoped_forbid_literal():
+    body = """## Constraints
+- FORBID_LITERAL:
+    value: install legacy-client
+    include_paths:
+      - "**/*.md"
+      - "docs/**"
+    exclude_paths:
+      - "docs/generated/**"
+"""
+    assert parse_constraints_section(body) == [ConstraintDirective(
+        kind="FORBID_LITERAL",
+        value="install legacy-client",
+        include_paths=("**/*.md", "docs/**"),
+        exclude_paths=("docs/generated/**",),
+    )]
+
+
+@pytest.mark.parametrize("body,match", [
+    (
+        "## Constraints\n- FORBID_LITERAL:\n    value: bad\n",
+        "include_paths",
+    ),
+    (
+        "## Constraints\n- FORBID_LITERAL:\n"
+        "    value: bad\n    include_paths: []\n",
+        "non-empty",
+    ),
+    (
+        "## Constraints\n- FORBID_LITERAL:\n"
+        "    value: bad\n    include_paths: docs/**\n",
+        "list",
+    ),
+    (
+        "## Constraints\n- FORBID_LITERAL:\n"
+        "    value: bad\n    include_paths:\n      - ../docs/**\n",
+        "invalid",
+    ),
+    (
+        "## Constraints\n- FORBID_LITERAL:\n"
+        "    value: bad\n    include_paths:\n      - docs/**\n"
+        "    unknown: value\n",
+        "unknown",
+    ),
+    (
+        "## Constraints\n- FORBID_LITERAL:\n"
+        "    value: first\n    value: second\n"
+        "    include_paths:\n      - docs/**\n",
+        "duplicate",
+    ),
+    (
+        "## Constraints\n- FORBID_DEPENDENCY:\n"
+        "    value: mongodb\n    include_paths:\n      - docs/**\n",
+        "not supported",
+    ),
+])
+def test_structured_directive_validation_is_strict(body, match):
+    with pytest.raises(ConstraintParseError, match=match):
+        parse_constraints_section(body)
 
 
 def test_parse_multiple_directives_in_order():
@@ -91,9 +154,6 @@ def test_directive_value_strips_whitespace():
 #
 # This matters most right before a new directive vocabulary lands (#250), when
 # authors are typing names they have never typed before.
-
-import pytest
-
 
 @pytest.mark.parametrize("line,reason", [
     ("- forbid_dependency: mongodb", "lowercase kind"),

--- a/tests/test_adr_import.py
+++ b/tests/test_adr_import.py
@@ -260,6 +260,41 @@ def test_apply_import_persists_typed_rules(tmp_path):
     }]
 
 
+def test_apply_import_persists_typed_rule_path_selectors(tmp_path):
+    from mneme.adr_import import ImportReport, apply_import
+    from mneme.schemas import Decision, Rule
+
+    target = tmp_path / "project_memory.json"
+    target.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "items": [], "examples": [], "decisions": [],
+    }), encoding="utf-8")
+    node = DecisionNode(id="ADR-020", status="active")
+    report = ImportReport(
+        active_nodes=[node],
+        all_nodes=[node],
+        decisions=[Decision(
+            id="ADR-020",
+            decision="Scope the rule",
+            rules=[Rule(
+                type="FORBID_LITERAL",
+                value="install legacy-client",
+                include_paths=("docs/**",),
+                exclude_paths=("docs/generated/**",),
+            )],
+        )],
+        diagnostics=[],
+    )
+    apply_import(report, target_path=target)
+    persisted = json.loads(target.read_text(encoding="utf-8"))
+    assert persisted["decisions"][0]["rules"] == [{
+        "type": "FORBID_LITERAL",
+        "value": "install legacy-client",
+        "include_paths": ["docs/**"],
+        "exclude_paths": ["docs/generated/**"],
+    }]
+
+
 def test_apply_import_refuses_overwrite_without_allow_update(tmp_path):
     """Same-id collision must block apply unless allow_update=True."""
     from mneme.adr_import import apply_import, compile_for_import

--- a/tests/test_check_json.py
+++ b/tests/test_check_json.py
@@ -90,6 +90,86 @@ def test_json_identifies_typed_rule(tmp_path, capsys):
     assert violation["rule_type"] == "FORBID_LITERAL"
 
 
+def _scoped_memory(tmp_path):
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir()
+    mem.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Scope the install rule",
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+                "exclude_paths": ["docs/generated/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+    return mem
+
+
+def test_json_target_path_controls_scoped_rule_applicability(tmp_path, capsys):
+    mem = _scoped_memory(tmp_path)
+    introduced = _input(tmp_path, "install legacy-client")
+    target = tmp_path / "docs" / "guide.md"
+    code = main([
+        "check", "--memory", str(mem), "--input", str(introduced),
+        "--target-path", str(target), "--query", "edit docs", "--json",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert payload["evaluation_complete"] is True
+    assert payload["applicability"] == [{
+        "decision_id": "ADR-020",
+        "rule_type": "FORBID_LITERAL",
+        "rule_value": "install legacy-client",
+        "rule_index": 0,
+        "path_scoped": True,
+        "input_path": "docs/guide.md",
+        "outcome": "APPLIED",
+        "selector": "docs/**",
+        "reason": "an include selector matched",
+    }]
+    assert payload["violations"][0]["input_path"] == "docs/guide.md"
+
+
+def test_json_unknown_applicability_is_operational_failure_even_warn_mode(
+    tmp_path,
+    capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mem = _scoped_memory(repo)
+    introduced = _input(repo, "install legacy-client")
+    outside = tmp_path / "outside" / "guide.md"
+    code = main([
+        "check", "--memory", str(mem), "--input", str(introduced),
+        "--target-path", str(outside), "--query", "edit docs",
+        "--mode", "warn", "--json",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert payload["verdict"] == "PASS"
+    assert payload["evaluation_complete"] is False
+    assert payload["applicability"][0]["outcome"] == "UNKNOWN"
+
+
+def test_human_output_includes_scoped_applicability_trace(tmp_path, capsys):
+    mem = _scoped_memory(tmp_path)
+    introduced = _input(tmp_path, "safe text")
+    target = tmp_path / "docs" / "generated" / "guide.md"
+    code = main([
+        "check", "--memory", str(mem), "--input", str(introduced),
+        "--target-path", str(target), "--query", "edit docs",
+    ])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "PATH  EXCLUDED" in out
+    assert "docs/generated/guide.md via docs/generated/**" in out
+    assert "Result: PASS" in out
+
+
 # ── exit codes are unchanged by --json ───────────────────────────────────────
 
 def test_json_preserves_strict_exit_codes(tmp_path, capsys):

--- a/tests/test_conflict_detector.py
+++ b/tests/test_conflict_detector.py
@@ -1,5 +1,11 @@
 """Post-response conflict detection against injected decisions."""
-from mneme.conflict_detector import ConflictDetector, Conflict
+import pytest
+
+from mneme.conflict_detector import (
+    Conflict,
+    ConflictDetector,
+    PathApplicabilityUnknownError,
+)
 from mneme.schemas import Decision, Rule
 
 
@@ -81,3 +87,41 @@ def test_typed_literal_does_not_match_longer_slug():
         rules=[Rule(type="FORBID_LITERAL", value="pip install mneme")],
     )
     assert ConflictDetector().detect("pip install mneme-hq", [decision]) == []
+
+
+def _scoped_decision(tmp_path):
+    return Decision(
+        id="ADR-020",
+        decision="Scope the rule",
+        rules=[Rule(
+            type="FORBID_LITERAL",
+            value="install legacy-client",
+            include_paths=("docs/**",),
+        )],
+        memory_path=str(tmp_path / ".mneme" / "project_memory.json"),
+    )
+
+
+def test_scoped_conflict_detection_accepts_target_path(tmp_path):
+    decision = _scoped_decision(tmp_path)
+    detector = ConflictDetector()
+    assert len(detector.detect(
+        "install legacy-client",
+        [decision],
+        target_path=tmp_path / "docs" / "guide.md",
+    )) == 1
+    assert detector.detect(
+        "install legacy-client",
+        [decision],
+        target_path=tmp_path / "src" / "app.py",
+    ) == []
+
+
+def test_text_only_scoped_conflict_detection_reports_non_evaluation(tmp_path):
+    decision = _scoped_decision(tmp_path)
+    detector = ConflictDetector()
+    result = detector.evaluate("install legacy-client", [decision])
+    assert not result.evaluation_complete
+    assert result.applicability[0].outcome.value == "UNKNOWN"
+    with pytest.raises(PathApplicabilityUnknownError, match="input path"):
+        detector.detect("install legacy-client", [decision])

--- a/tests/test_context_builder_decisions.py
+++ b/tests/test_context_builder_decisions.py
@@ -56,6 +56,19 @@ def test_output_shows_typed_rules():
     assert "FORBID_LITERAL: pip install mneme" in out
 
 
+def test_output_shows_typed_rule_path_scope():
+    scored = [_scored("d1", 2.0)]
+    scored[0].decision.rules.append(Rule(
+        type="FORBID_LITERAL",
+        value="install legacy-client",
+        include_paths=("docs/**",),
+        exclude_paths=("docs/generated/**",),
+    ))
+    out = format_decisions(scored)
+    assert "Applies to: docs/**" in out
+    assert "Except: docs/generated/**" in out
+
+
 def test_empty_input_returns_empty_string():
     assert format_decisions([], max_items=3) == ""
 

--- a/tests/test_cursor_generate.py
+++ b/tests/test_cursor_generate.py
@@ -155,6 +155,23 @@ def test_generate_mdc_contains_typed_rules():
     assert "FORBID_LITERAL: pip install mneme" in result
 
 
+def test_generate_mdc_contains_typed_rule_path_scope():
+    scored = _scored_decisions()
+    scored[0].decision.rules.append(Rule(
+        type="FORBID_LITERAL",
+        value="install legacy-client",
+        include_paths=("docs/**",),
+        exclude_paths=("docs/generated/**",),
+    ))
+    result = generate_mdc(
+        scored,
+        query="docs",
+        memory_path="memory.json",
+    )
+    assert "Applies to: docs/**" in result
+    assert "Except: docs/generated/**" in result
+
+
 def test_generate_mdc_contains_warning():
     scored = _scored_decisions()
     result = generate_mdc(

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -599,3 +599,79 @@ def test_typed_rule_does_not_flag_its_policy_memory_file(tmp_path):
         input_path=memory,
     )
     assert result.verdict == Severity.PASS
+
+
+def test_scoped_typed_rule_applies_only_to_included_paths(tmp_path):
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    rule = Rule(
+        type="FORBID_LITERAL",
+        value="install legacy-client",
+        include_paths=("docs/**",),
+    )
+    decision = Decision(
+        id="ADR-020",
+        decision="Scope the rule",
+        rules=[rule],
+        memory_path=str(memory),
+    )
+
+    applied = check_prompt(
+        "install legacy-client",
+        [_scored(decision, score=0.0)],
+        input_path=tmp_path / "docs" / "guide.md",
+    )
+    excluded = check_prompt(
+        "install legacy-client",
+        [_scored(decision, score=0.0)],
+        input_path=tmp_path / "src" / "app.py",
+    )
+
+    assert applied.verdict == Severity.FAIL
+    assert applied.evaluation_complete
+    assert applied.applicability[0].outcome.value == "APPLIED"
+    assert applied.applicability[0].selector == "docs/**"
+    assert excluded.verdict == Severity.PASS
+    assert excluded.applicability[0].outcome.value == "EXCLUDED"
+
+
+def test_scoped_typed_rule_exclude_overrides_include(tmp_path):
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    decision = Decision(
+        id="ADR-020",
+        decision="Scope the rule",
+        rules=[Rule(
+            type="FORBID_LITERAL",
+            value="install legacy-client",
+            include_paths=("docs/**",),
+            exclude_paths=("docs/generated/**",),
+        )],
+        memory_path=str(memory),
+    )
+    result = check_prompt(
+        "install legacy-client",
+        [_scored(decision, score=0.0)],
+        input_path=tmp_path / "docs" / "generated" / "guide.md",
+    )
+    assert result.verdict == Severity.PASS
+    assert result.applicability[0].outcome.value == "EXCLUDED"
+    assert result.applicability[0].selector == "docs/generated/**"
+
+
+def test_scoped_typed_rule_missing_path_reports_unknown():
+    decision = Decision(
+        id="ADR-020",
+        decision="Scope the rule",
+        rules=[Rule(
+            type="FORBID_LITERAL",
+            value="install legacy-client",
+            include_paths=("docs/**",),
+        )],
+        memory_path="project_memory.json",
+    )
+    result = check_prompt(
+        "install legacy-client",
+        [_scored(decision, score=0.0)],
+    )
+    assert result.verdict == Severity.PASS
+    assert not result.evaluation_complete
+    assert result.applicability[0].outcome.value == "UNKNOWN"

--- a/tests/test_memory_store_decisions.py
+++ b/tests/test_memory_store_decisions.py
@@ -86,6 +86,53 @@ def test_unknown_typed_rule_fails_loudly(tmp_path):
         MemoryStore(memory_path).load()
 
 
+def test_loads_path_scoped_typed_rule(tmp_path):
+    memory_path = tmp_path / ".mneme" / "project_memory.json"
+    memory_path.parent.mkdir()
+    memory_path.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Scope the rule",
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+                "exclude_paths": ["docs/generated/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+
+    [decision] = MemoryStore(memory_path).load().decisions
+    [rule] = decision.rules
+    assert rule.include_paths == ("docs/**",)
+    assert rule.exclude_paths == ("docs/generated/**",)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("include_paths", "docs/**"),
+    ("exclude_paths", "tests/**"),
+])
+def test_memory_rejects_non_list_selector_fields(tmp_path, field, value):
+    memory_path = tmp_path / "project_memory.json"
+    record = {
+        "type": "FORBID_LITERAL",
+        "value": "bad",
+        "include_paths": ["docs/**"],
+        field: value,
+    }
+    memory_path.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "bad",
+            "decision": "Bad rule",
+            "rules": [record],
+        }],
+    }), encoding="utf-8")
+    with pytest.raises(ValueError, match=field):
+        MemoryStore(memory_path).load()
+
+
 def test_mismatched_adr_source_name_cannot_create_rule_exemption(tmp_path):
     memory_path = tmp_path / "project_memory.json"
     memory_path.write_text(json.dumps({

--- a/tests/test_path_selectors.py
+++ b/tests/test_path_selectors.py
@@ -1,0 +1,117 @@
+import pytest
+
+from mneme.path_selectors import (
+    SelectorOutcome,
+    evaluate_path_selectors,
+    normalize_input_path,
+    path_matches,
+    policy_root,
+    validate_path_pattern,
+)
+
+
+@pytest.mark.parametrize("pattern", [
+    "README.md",
+    "docs/*.md",
+    "docs/**",
+    "**/*.md",
+    "src/test_*.py",
+])
+def test_selector_grammar_accepts_supported_patterns(pattern):
+    assert validate_path_pattern(pattern) == pattern
+
+
+@pytest.mark.parametrize("pattern", [
+    "",
+    "/docs/*.md",
+    "C:/docs/*.md",
+    "docs\\*.md",
+    "docs//*.md",
+    "./docs/*.md",
+    "docs/../*.md",
+    "!docs/*.md",
+    "docs/file?.md",
+    "docs/[ab].md",
+    "docs/**.md",
+    "docs/a**b.md",
+])
+def test_selector_grammar_rejects_unsupported_patterns(pattern):
+    with pytest.raises(ValueError):
+        validate_path_pattern(pattern)
+
+
+@pytest.mark.parametrize("pattern,path", [
+    ("docs/*.md", "docs/guide.md"),
+    ("docs/**", "docs/guide.md"),
+    ("docs/**", "docs/reference/guide.md"),
+    ("docs/**/guide.md", "docs/guide.md"),
+    ("**/*.md", "README.md"),
+    ("**/*.md", "docs/README.md"),
+])
+def test_selector_matching(pattern, path):
+    assert path_matches(pattern, path)
+
+
+def test_selector_matching_is_case_sensitive():
+    assert not path_matches("docs/*.md", "Docs/guide.md")
+
+
+def test_policy_root_for_canonical_and_custom_memory(tmp_path):
+    canonical = tmp_path / ".mneme" / "project_memory.json"
+    custom = tmp_path / "policy" / "memory.json"
+    assert policy_root(canonical) == tmp_path.resolve()
+    assert policy_root(custom) == custom.parent.resolve()
+
+
+def test_normalize_input_path_rejects_outside_policy_root(tmp_path):
+    memory = tmp_path / "repo" / ".mneme" / "project_memory.json"
+    outside = tmp_path / "other" / "file.md"
+    with pytest.raises(ValueError, match="outside"):
+        normalize_input_path(outside, memory)
+
+
+def test_exclude_selector_overrides_include(tmp_path):
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    target = tmp_path / "docs" / "generated" / "guide.md"
+    selection = evaluate_path_selectors(
+        include_paths=("docs/**",),
+        exclude_paths=("docs/generated/**",),
+        input_path=target,
+        memory_path=memory,
+    )
+    assert selection.outcome == SelectorOutcome.EXCLUDED
+    assert selection.input_path == "docs/generated/guide.md"
+    assert selection.selector == "docs/generated/**"
+
+
+def test_scoped_rule_without_path_is_unknown(tmp_path):
+    selection = evaluate_path_selectors(
+        include_paths=("docs/**",),
+        exclude_paths=(),
+        input_path=None,
+        memory_path=tmp_path / ".mneme" / "project_memory.json",
+    )
+    assert selection.outcome == SelectorOutcome.UNKNOWN
+
+
+def test_global_rule_does_not_require_path_metadata():
+    selection = evaluate_path_selectors(
+        include_paths=None,
+        exclude_paths=(),
+        input_path=None,
+        memory_path=None,
+    )
+    assert selection.outcome == SelectorOutcome.APPLIED
+
+
+def test_canonical_policy_source_is_excluded(tmp_path):
+    source = tmp_path / "docs" / "adr" / "ADR-020.md"
+    selection = evaluate_path_selectors(
+        include_paths=("docs/**",),
+        exclude_paths=(),
+        input_path=source,
+        memory_path=tmp_path / ".mneme" / "project_memory.json",
+        policy_paths=(source,),
+    )
+    assert selection.outcome == SelectorOutcome.EXCLUDED
+    assert selection.selector == "<canonical-policy-source>"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 """End-to-end pipeline: load -> score -> inject top-N -> call LLM -> detect conflicts."""
+import json
 from pathlib import Path
 
 from mneme.pipeline import Pipeline, PipelineResult
@@ -38,6 +39,40 @@ def test_pipeline_runs_conflict_detection_after_response():
     assert any(
         "postgres" in c.snippet.lower() for c in result.conflicts
     ), f"expected a postgres conflict, got {result.conflicts!r}"
+
+
+def test_pipeline_reports_scoped_rule_non_evaluation_and_accepts_target(tmp_path):
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    memory.parent.mkdir()
+    memory.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Legacy client documentation",
+            "scope": ["docs"],
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+    pipeline = Pipeline(memory_path=memory, dry_run=True)
+
+    unknown = pipeline.run(
+        "update docs",
+        _override_response="install legacy-client",
+    )
+    applied = pipeline.run(
+        "update docs",
+        _override_response="install legacy-client",
+        target_path=tmp_path / "docs" / "guide.md",
+    )
+
+    assert not unknown.evaluation_complete
+    assert unknown.conflicts == []
+    assert applied.evaluation_complete
+    assert len(applied.conflicts) == 1
 
 
 def test_top_n_respected_even_when_more_match():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -53,6 +53,38 @@ def test_typed_rule_validates_type_and_value():
         Rule(type="FORBID_LITERAL", value="   ")
 
 
+def test_typed_rule_accepts_valid_path_scope():
+    rule = Rule(
+        type="FORBID_LITERAL",
+        value="install legacy-client",
+        include_paths=("docs/**",),
+        exclude_paths=("docs/generated/**",),
+    )
+    assert rule.is_path_scoped
+    assert rule.include_paths == ("docs/**",)
+
+
+def test_typed_rule_path_scope_is_strict_and_immutable():
+    with pytest.raises(ValueError, match="non-empty tuple"):
+        Rule(
+            type="FORBID_LITERAL",
+            value="bad",
+            include_paths=(),
+        )
+    with pytest.raises(ValueError, match="require include_paths"):
+        Rule(
+            type="FORBID_LITERAL",
+            value="bad",
+            exclude_paths=("tests/**",),
+        )
+    with pytest.raises(ValueError, match="forward slashes"):
+        Rule(
+            type="FORBID_LITERAL",
+            value="bad",
+            include_paths=("docs\\**",),
+        )
+
+
 def test_mneme_conflict_error_carries_conflicts_and_result():
     from mneme.schemas import MnemeConflictError
 


### PR DESCRIPTION
## What changed

- add ADR-020 path selectors to typed rules with a strict repository-relative grammar and deterministic case-sensitive matcher
- compile structured ADR directives and preserve selectors through import, memory loading, context, and Cursor output
- apply selectors in pre-flight enforcement and post-response conflict detection with APPLIED, EXCLUDED, and UNKNOWN audit traces
- add `mneme check --target-path` so temporary introduced-content files are evaluated against the real artifact path
- pass the real edit target through the Claude Code hook; unknown applicability remains fail-open but is explicitly reported
- document the contract and add focused unit, integration, CLI, pipeline, and hook regressions

## Why

ADR-020 separates rule matching from artifact applicability. Global typed rules keep their existing behavior, while scoped rules now enforce only where their include/exclude selectors say they apply. Unknown paths cannot silently become PASS.

This deliberately leaves occurrence-aware escapes and broader legacy heuristic behavior outside the change (GitHub issues 150 and 259).

## Compatibility

- scalar typed rules remain global
- existing memory files without selector fields load unchanged
- the JSON schema remains `mneme.check/v1` with additive fields
- canonical ADR and policy-memory exemptions remain exact

## Validation

- `python -m pytest -q`: 571 passed, 5 skipped, 52 existing benchmark-fixture fallback warnings
- `python -m compileall -q mneme`
- `git diff --check`
- ADR corpus compile: 13 active ADRs
- ADR freshness: 0 issues
- `python scripts/check_install_command.py`: pass
- warn-mode governance run completed across every changed tracked file; intentional ADR-005 literal examples in documentation/tests produced the expected content diagnostics
