### PR TITLE
fix: remove BOM from validation artifact

### DIFF
--- a/docs/validation/artifacts/pre-generation-guidance-live-ab-2026-08-13/invalidations/api-1__treatment__r2__rate-limit-01/INVALIDATION.md
+++ b/docs/validation/artifacts/pre-generation-guidance-live-ab-2026-08-13/invalidations/api-1__treatment__r2__rate-limit-01/INVALIDATION.md
@@ -1,4 +1,4 @@
-﻿# Technical invalidation
+# Technical invalidation
 
 Run slot: `api-1 treatment r2`
 


### PR DESCRIPTION
Removes the UTF-8 BOM prefix from \docs/validation/artifacts/pre-generation-guidance-live-ab-2026-08-13/invalidations/api-1__treatment__r2__rate-limit-01/INVALIDATION.md\.

Textual content is unchanged — only the 3 BOM bytes were removed (byte-level operation, no rewrite). This is the single remaining hit of the \encoding check\ workflow, which has been red on \main\ since 2026-08-19.

No validation artifacts removed or relocated. No product code, ADRs, governance memory, or workflows changed.

Validation:

* \python scripts/check_encoding.py\ — OK (1604 files scanned), previously FAIL on this file
* \pytest -q\ — 571 passed, 5 skipped
* diff is exactly one file, one line, BOM-only change