### PR TITLE
fix: align gitignore with repository boundary policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ instance/
 .DS_Store
 Thumbs.db
 
-# Flask
+# Logs
 *.log
+!docs/validation/artifacts/**/*.log
 .worktrees/
 
 # Internal/private strategy files — must live in mneme-internal repo
@@ -61,5 +62,6 @@ case studies/
 # Tools / internal MCP servers (ADR-002 — private repo only)
 tools/
 
-# Internal planning docs (ADR-002 — private repo only)
-docs/plans/
+# Planning documents are classified by ADR-002 content, not directory.
+# Product, architecture, benchmark, and validation plans may be public;
+# internal/GTM/operational plans belong in private repositories.


### PR DESCRIPTION
Aligns \.gitignore\ with the repository's actual ADR-002 boundary policy.

Changes:

* keeps the general \*.log\ ignore rule while explicitly allowing validation-artifact logs that are deliberately retained as benchmark evidence;
* removes the blanket \docs/plans/\ ignore rule so planning documents are classified by content rather than directory;
* replaces the stale Flask comment.

Validation:

* \git ls-files -i -c --exclude-standard\ → empty
* 571 passed, 5 skipped
* encoding check PASS
* install-command check PASS
* Mneme governance check PASS

No tracked files, product code, ADRs, governance memory, validation artifacts, or workflows changed.