### PR TITLE
ci: add pytest workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+# Runs the canonical pytest suite (pyproject [tool.pytest.ini_options]
+# testpaths = ["tests"]) on every PR to main and on direct pushes to main.
+#
+# CONTRIBUTING.md requires all tests to pass before a pull request can be
+# merged; this workflow makes that requirement enforceable in CI. The
+# benchmark suite is intentionally not invoked here — it is a separate
+# charter instrument (see CONTRIBUTING.md and the Layer 1 freeze docs).
+#
+# Python 3.11 is the declared minimum (requires-python >= 3.11).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install package with dev dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run test suite
+        run: python -m pytest


### PR DESCRIPTION
﻿**Finding (confirmed):** CONTRIBUTING.md requires all tests to pass before merge (`pytest tests/ -v`), and `.mneme/project_memory.json` `workflow-001` requires CI enforcement for governance changes — but no workflow executed the test suite. The gap is acknowledged in `docs/releases/v0.5.1.md` ("CI does not currently run pytest").

**Change:** adds `.github/workflows/tests.yml` — checkout, Python 3.11 (declared minimum), `pip install -e ".[dev]"`, `python -m pytest` on PRs to `main` and pushes to `main`.

**Scope notes:**

* benchmark suite intentionally not invoked here — separate charter instrument per CONTRIBUTING.md / Layer 1 freeze docs
* no ADR, memory, dependency, or other workflow changes
* single Python version; matrix deferred to the packaging/compatibility finding

**Validation:**

* local `pip install -e ".[dev]"` + `python -m pytest`: 571 passed, 5 skipped
* encoding check PASS, install-command check PASS
* Mneme governance check: PASS (six pre-existing ADR_CHANGED warnings unchanged)
