### PR TITLE
fix: sync runtime __version__ with declared package version

### DIFF
--- a/mneme/__init__.py
+++ b/mneme/__init__.py
@@ -16,4 +16,4 @@ Typical usage::
 See demo.py in the repo root for a full end-to-end example.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.5.1"

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -68,6 +68,18 @@ def test_pyproject_declares_no_unexpected_console_scripts():
     assert set(_load_pyproject()["project"]["scripts"]) == set(EXPECTED_SCRIPTS)
 
 
+def test_runtime_version_matches_declared_version():
+    # mneme.__version__ is the runtime-exported version string. It must
+    # track pyproject's declared version so `import mneme` never reports
+    # a stale release number (drifted 0.1.0 vs 0.5.1 across v0.4.0-v0.5.1).
+    import mneme
+
+    assert mneme.__version__ == _declared_version(), (
+        f"mneme.__version__ = {mneme.__version__!r} does not match "
+        f"pyproject version {_declared_version()!r}"
+    )
+
+
 # ── Layer 2: built-artifact contract ─────────────────────────────────────────
 #
 # Skipped unless a matching build is present under dist/ (release flow):


### PR DESCRIPTION
﻿**Finding (confirmed):** `mneme.__version__` reported `0.1.0` while `pyproject.toml` declared `0.5.1`. The drift persisted across v0.4.0-v0.5.1 because RELEASING.md's checklist never touches `__init__.py` and no test asserted the pair; nothing in the architecture designates the runtime string as intentionally stale.

**Change (two logical edits):**

* `mneme/__init__.py`: `__version__` 0.1.0 -> 0.5.1
* `tests/test_packaging_contract.py`: new source-layer assertion pinning `mneme.__version__` to `_declared_version()`, so future drift is an immediate local/CI failure

**Validation:**

* targeted packaging-contract tests: 3 passed, 5 skipped (build-artifact layer skipped, no dist/)
* full suite: 572 passed, 5 skipped
* encoding check PASS, install-command check PASS
* Mneme governance check PASS
