### PR TITLE
fix: remove obsolete requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-anthropic>=0.25.0
-python-dotenv>=1.0.0
-fastapi>=0.111.0
-uvicorn>=0.29.0


### PR DESCRIPTION
﻿**Finding (confirmed):** `requirements.txt` was an orphaned second dependency manifest that had drifted from `pyproject.toml`: it omitted `PyYAML` (hard runtime dep for the ADR parser/constraints chain) and flattened the `[api]` extra (`fastapi`, `uvicorn`) into core installs. Zero tracked consumers — every documented install path (README, CONTRIBUTING, CI, RELEASING) installs from `pyproject.toml`.

**Change:** single deletion of `requirements.txt`. No other file touched.

**Validation:**

* fresh grep: no tracked reference to `requirements.txt`
* `pip install -e .` and `pip install -e ".[dev]"` both succeed
* targeted ADR/YAML check: `yaml` import + `adr_parser` + `parse_constraints_section` round-trip OK
* full suite: 572 passed, 5 skipped
* encoding check PASS, install-command check PASS, Mneme governance check PASS
