### PR TITLE
fix: clean missing-path errors in CLI instead of tracebacks

### DIFF
--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -53,6 +53,18 @@ def _utc_now() -> str:
     return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _error_exit(message: str) -> int:
+    """Report a pre-execution user-input error and return the usage exit code.
+
+    Missing files and bad paths print ``ERROR: ...`` to stderr and exit 2
+    with empty stdout, so machine consumers (``--json``, the Claude Code
+    hook) see no verdict payload and fail open. Verdict exit codes 0/1/2
+    are reserved for actual enforcement results.
+    """
+    print(f"ERROR: {message}", file=sys.stderr, flush=True)
+    return 2
+
+
 # ── Subcommand: init ─────────────────────────────────────────────────────────
 
 DEFAULT_MEMORY_PATH = ".mneme/project_memory.json"
@@ -104,6 +116,9 @@ def _cmd_init(args: argparse.Namespace) -> int:
 # ── Subcommand: list_decisions ───────────────────────────────────────────────
 
 def _cmd_list(args: argparse.Namespace) -> int:
+    memory_path = Path(args.memory)
+    if not memory_path.exists():
+        return _error_exit(f"memory file {memory_path} does not exist")
     store = MemoryStore(args.memory)
     store.load()
     decisions = store.decisions()
@@ -132,6 +147,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
 
 def _cmd_add(args: argparse.Namespace) -> int:
     path = Path(args.memory)
+    if not path.exists():
+        return _error_exit(f"memory file {path} does not exist")
     data = json.loads(path.read_text(encoding="utf-8"))
     data.setdefault("decisions", [])
 
@@ -159,6 +176,9 @@ def _cmd_add(args: argparse.Namespace) -> int:
 # ── Subcommand: test_query ───────────────────────────────────────────────────
 
 def _cmd_test(args: argparse.Namespace) -> int:
+    memory_path = Path(args.memory)
+    if not memory_path.exists():
+        return _error_exit(f"memory file {memory_path} does not exist")
     store = MemoryStore(args.memory)
     store.load()
     retriever = DecisionRetriever(store.decisions())
@@ -245,7 +265,13 @@ def _check_payload(
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
-    input_text = Path(args.input).read_text(encoding="utf-8")
+    input_path = Path(args.input)
+    if not input_path.exists():
+        return _error_exit(f"input file {input_path} does not exist")
+    memory_path = Path(args.memory)
+    if not memory_path.exists():
+        return _error_exit(f"memory file {memory_path} does not exist")
+    input_text = input_path.read_text(encoding="utf-8")
 
     store = MemoryStore(args.memory)
     store.load()
@@ -330,6 +356,9 @@ def _print_freshness_issue(issue: FreshnessIssue) -> None:
 # ── Subcommand: cursor generate ──────────────────────────────────────────────
 
 def _cmd_cursor_generate(args: argparse.Namespace) -> int:
+    memory_path = Path(args.memory)
+    if not memory_path.exists():
+        return _error_exit(f"memory file {memory_path} does not exist")
     store = MemoryStore(args.memory)
     store.load()
     retriever = DecisionRetriever(store.decisions())

--- a/tests/test_cli_missing_paths.py
+++ b/tests/test_cli_missing_paths.py
@@ -1,0 +1,102 @@
+"""Missing-path handling for the mneme CLI.
+
+Ordinary user errors (missing --memory / --input paths) must produce a
+clean ``ERROR: ...`` message on stderr and exit 2 — never a raw traceback.
+Exit 2 for usage errors follows argparse's own convention; verdict exit
+codes 0/1/2 remain reserved for actual enforcement results.
+
+The hook contract is exercised directly: a failed invocation must yield
+*no valid verdict payload* (empty stdout), so ``hook.parse_verdict``
+returns None and the Claude Code integration fails open exactly as it
+does today.
+"""
+import json
+
+import pytest
+
+from mneme.cli import main
+from mneme.integrations.claude_code.hook import parse_verdict
+
+
+MEMORY_ARGS = ["--memory", "no_such_memory.json"]
+
+
+def _run(capsys, argv):
+    code = main(argv)
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+@pytest.mark.parametrize("argv", [
+    ["list_decisions", *MEMORY_ARGS],
+    ["add_decision", *MEMORY_ARGS, "--id", "x1", "--decision", "d"],
+    ["test_query", *MEMORY_ARGS, "--query", "q"],
+    ["cursor", "generate", *MEMORY_ARGS, "--query", "q"],
+])
+def test_missing_memory_is_clean_error(capsys, argv):
+    code, out, err = _run(capsys, argv)
+    assert code == 2
+    assert "ERROR:" in err
+    assert "no_such_memory.json" in err
+    assert "Traceback" not in err
+    assert out == ""
+
+
+def test_check_missing_input_is_clean_error(capsys, tmp_path):
+    memory = tmp_path / "project_memory.json"
+    memory.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [], "decisions": [],
+    }), encoding="utf-8")
+    code, out, err = _run(capsys, [
+        "check",
+        "--memory", str(memory),
+        "--input", "does_not_exist.txt",
+        "--query", "storage",
+        "--mode", "strict",
+    ])
+    assert code == 2
+    assert "ERROR:" in err
+    assert "does_not_exist.txt" in err
+    assert "Traceback" not in err
+    assert out == ""
+
+
+def test_check_missing_memory_is_clean_error(capsys, tmp_path):
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("hello", encoding="utf-8")
+    code, out, err = _run(capsys, [
+        "check",
+        "--memory", str(tmp_path / "absent.json"),
+        "--input", str(prompt),
+        "--query", "storage",
+        "--mode", "strict",
+    ])
+    assert code == 2
+    assert "ERROR:" in err
+    assert "absent.json" in err
+    assert "Traceback" not in err
+    assert out == ""
+
+
+def test_check_json_missing_path_yields_no_verdict_payload(capsys, tmp_path):
+    """Hook fail-open contract: a failed check must not emit a payload.
+
+    The Claude Code hook trusts only parseable ``mneme.check/v1`` output;
+    empty stdout must therefore parse to None so the hook fails open,
+    exactly as it does against today's crash tracebacks.
+    """
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("hello", encoding="utf-8")
+    code, out, err = _run(capsys, [
+        "check",
+        "--memory", str(tmp_path / "absent.json"),
+        "--input", str(prompt),
+        "--query", "storage",
+        "--mode", "strict",
+        "--json",
+    ])
+    assert code == 2
+    assert out == ""
+    assert "ERROR:" in err
+    assert parse_verdict(out) is None


### PR DESCRIPTION
﻿**Finding (confirmed):** six CLI commands (`check`, `list_decisions`, `add_decision`, `test_query`, `cursor generate`) crashed with raw `FileNotFoundError` tracebacks on ordinary user errors (missing `--memory` / `--input` paths), exiting 1 — indistinguishable from a strict-mode WARN verdict for exit-code consumers. Sibling commands (`adr import`, `benchmark`) already handled bad paths cleanly; this applies the same convention.

**Change:**

* tiny `_error_exit` helper + per-handler existence guards in `mneme/cli.py`
* missing paths -> `ERROR: ...` on stderr, exit 2, empty stdout
* verdict exit codes 0/1/2 unchanged for actual enforcement results
* no hook, enforcement, retrieval, benchmark, ADR, or memory changes

**Hook contract preserved and proven:** new test asserts `parse_verdict(stdout) is None` for a failed invocation, so the Claude Code integration fails open exactly as before.

**Validation:**

* 7 new regression tests pass; full suite 579 passed, 5 skipped
* encoding check PASS, install-command check PASS, Mneme governance check PASS
