### PR TITLE
docs: correct stale top-K enforcement references

### DIFF
--- a/docs/architecture/current-phase.md
+++ b/docs/architecture/current-phase.md
@@ -14,7 +14,7 @@ Layer 1 is local-repo, single-developer, project-scoped architectural governance
 Pinned at commit [`e73ff7d`](https://github.com/TheoV823/mneme/commit/e73ff7d) and documented in [layer1-freeze-e73ff7d.md](./layer1-freeze-e73ff7d.md):
 
 - **Retrieval mechanics** — deterministic bag-of-tokens scoring with fixed weights, stopword floor, insertion-order tiebreak.
-- **Enforcement semantics** — `anti_patterns` → FAIL, `"no X"` constraints → WARN, top-K-only, word-boundary matching.
+- **Enforcement semantics** — `anti_patterns` → FAIL, `"no X"` constraints → WARN, word-boundary matching. Frozen at `e73ff7d` as top-K-only (enforcement bounded by the retrieval top-N); [ADR-017](../adr/ADR-017-enforcement-scope-vs-retrieval-scope.md) subsequently separated enforcement scope from retrieval scope, so enforcement now evaluates the full decision corpus (literal rules corpus-wide, multi-term rules still retrieval-gated), with typed-rule semantics under [ADR-019](../adr/ADR-019-typed-literal-rule-contract.md)/[ADR-020](../adr/ADR-020-explicit-path-applicability-for-typed-rules.md).
 - **Benchmark methodology** — two-layer scoring (retrieval vs. enforcement), structured-fixture path with TXT fallback, five-verdict semantics, K=3 canonical.
 - **Charter principles** — deterministic > clever, auditable > autonomous, prevention before review, no passive ingestion, no auto-learning, no hidden vector magic.
 - **Scope wedge** — local-repo, single-developer, project-scoped. Multi-repo / team / org sync is Layer 2.

--- a/mneme/benchmark.py
+++ b/mneme/benchmark.py
@@ -188,10 +188,12 @@ class Layer1Score:
     """Retrieval score for one scenario, ignoring enforcement.
 
     `retrieved_ids` is the ordered list of decision IDs in the runner's top-K
-    (positive-score, matching what the enforcer actually sees via
-    enforcer._top_nonzero). Recall and precision are computed against that
-    set; `irrelevant_injection` flips True when at least one retrieved ID is
-    neither expected nor explicitly acceptable.
+    (positive-score) — the same selection the injection surface applies
+    (context_builder.format_decisions / Pipeline.injected_decisions). It is
+    not "what the enforcer sees": since ADR-017, enforcement evaluates the
+    full corpus independent of retrieval score. Recall and precision are
+    computed against that set; `irrelevant_injection` flips True when at
+    least one retrieved ID is neither expected nor explicitly acceptable.
     """
 
     k: int

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -252,8 +252,10 @@ def test_layer1_irrelevant_injection_false_when_only_expected_retrieved():
 def test_layer1_excludes_zero_score_decisions():
     """Zero-score (or negative) decisions never count as retrieved.
 
-    Mirrors enforcer._top_nonzero so Layer 1 retrieval matches what the
-    enforcer actually sees.
+    Mirrors the injection-side top-K selection (context_builder.format_decisions /
+    Pipeline.injected_decisions), so Layer 1 measures what retrieval actually
+    injects. Since ADR-017 this is not "what the enforcer sees" — enforcement
+    evaluates the full corpus independent of retrieval score.
     """
     scored = _scored(("d1", 5.0), ("zero", 0.0), ("d2", 0.0))
     s = score_layer1(scored, expected_ids=["d1", "d2"], acceptable_ids=[], k=5)


### PR DESCRIPTION
﻿Documentation-accuracy fix only — no executable code changed.

Three current-surface references still described pre-ADR-017 reality:

* `mneme/benchmark.py` Layer1Score docstring claimed the top-K set matches "what the enforcer actually sees via enforcer._top_nonzero" — false since ADR-017 separated enforcement scope from retrieval scope. Now references the injection surface (context_builder.format_decisions / Pipeline.injected_decisions).
* `tests/test_benchmark.py` same stale claim in a test docstring — corrected.
* `docs/architecture/current-phase.md` said current enforcement is "top-K-only" — now states the frozen-at-e73ff7d baseline explicitly and points to ADR-017 (scope separation) and ADR-019/020 (typed rules).

The historical freeze record `layer1-freeze-e73ff7d.md` is intentionally untouched: its top-K statement describes what was frozen at that commit.

Non-behavioral per CONTRIBUTING.md (only behavioral changes to frozen semantics require charter amendment).

**Validation:**

* full suite 579 passed, 5 skipped
* benchmark suite re-run live: 7/7 PASS, identical per-scenario verdicts and metrics
* encoding check PASS, install-command check PASS, Mneme governance check PASS
