### PR TITLE
feat: adoption surfaces for the Claude Agent SDK integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Claude Agent SDK integration (`mneme.integrations.agent_sdk`). Reuses the
+  existing retrieval and enforcement semantics: relevant decisions are
+  injected before agent work via `UserPromptSubmit`, and proposed
+  Write/Edit/MultiEdit calls are evaluated by `mneme check` before
+  execution via `PreToolUse`, returning allow/deny with Mneme's reason.
+  Warn-mode and unevaluated outcomes are surfaced as visible context, never
+  silently converted to PASS. A runnable governed-loop demo lives under
+  `examples/claude-agent-sdk/`.
 - Typed ADR enforcement with `FORBID_LITERAL`. ADR import now persists
   explicit typed rules, `mneme check` applies them independently of retrieval
   score, and human/JSON output identifies the rule type.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,23 @@ print(response.content)
 
 ## Works with
 
+**Explicitly integrated (hook-level enforcement):**
+
+- **Claude Agent SDK** - relevant decisions injected before agent work;
+  proposed file mutations deterministically evaluated before execution.
+  See [docs/integrations/agent-sdk.md](docs/integrations/agent-sdk.md)
+  and the runnable governed-loop example under
+  [examples/claude-agent-sdk/](examples/claude-agent-sdk/).
+- **Claude Code** - `PreToolUse` hook blocks violating Edit/Write/MultiEdit
+  calls before they reach disk. See below.
+- **Cursor** - rules compiled from the same decision corpus. See below.
+
+**Reached through the Python API or generated rules:**
+
 - Direct LLM API integrations
-- IDE coding assistants (Cursor, Copilot, Cline)
-- Agent frameworks (LangChain, CrewAI, AutoGen)
+- Other IDE coding assistants (Copilot, Cline)
+- Agent frameworks (LangChain, CrewAI, AutoGen) via
+  `MemoryStore` / `DecisionRetriever` / `Pipeline`
 - Managed agent platforms
 - Internal prompt pipelines
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ print(response.content)
 
 ## Works with
 
-**Explicitly integrated (hook-level enforcement):**
+**Explicitly supported integrations:**
 
 - **Claude Agent SDK** - relevant decisions injected before agent work;
   proposed file mutations deterministically evaluated before execution.

--- a/examples/claude-agent-sdk/README.md
+++ b/examples/claude-agent-sdk/README.md
@@ -12,8 +12,10 @@ complete, isolated reproduction of the loop proven there.
 2. **Enforcement** — a proposed file mutation is materialized, reduced to
    its introduced lines (ADR-018), and evaluated by the same `mneme check`
    path the Claude Code hook uses (`PreToolUse` -> allow/deny).
-3. **Autonomous recovery** — a blocked proposal carries the governing
-   decision id and reason back to the model; the corrected proposal passes.
+3. **Correction path** — a blocked proposal carries the governing
+   decision id and reason back to the caller. In deterministic mode the
+   corrected second proposal is scripted; with `--live`, the model
+   performs the correction itself from the block reason.
 
 Mneme governs; the model performs the correction. Mneme itself does not
 edit code and does not generate code.

--- a/examples/claude-agent-sdk/README.md
+++ b/examples/claude-agent-sdk/README.md
@@ -1,0 +1,69 @@
+# Governed model loop demo — `claude_agent_sdk`
+
+Runnable companion to [PR #293](https://github.com/MnemeHQ/mneme/pull/293),
+which added the `mneme.integrations.agent_sdk` package. This folder is a
+complete, isolated reproduction of the loop proven there.
+
+## What this proves
+
+1. **Guidance** — relevant decisions are retrieved by the existing
+   `DecisionRetriever` and injected into the model's context before any
+   work starts (`UserPromptSubmit` -> `additionalContext`).
+2. **Enforcement** — a proposed file mutation is materialized, reduced to
+   its introduced lines (ADR-018), and evaluated by the same `mneme check`
+   path the Claude Code hook uses (`PreToolUse` -> allow/deny).
+3. **Autonomous recovery** — a blocked proposal carries the governing
+   decision id and reason back to the model; the corrected proposal passes.
+
+Mneme governs; the model performs the correction. Mneme itself does not
+edit code and does not generate code.
+
+## Run
+
+Deterministic mode — no network call, no API key, fully reproducible:
+
+```
+python run.py
+```
+
+Live mode — drives one real model session end to end. Requires a working
+`claude` CLI login and the official Python package whose import name is
+`claude_agent_sdk` (see that project's install docs):
+
+```
+python run.py --live
+```
+
+## Expected deterministic result
+
+The first proposal uses a forbidden server database driver:
+
+```
+mneme: FAIL - architectural decision violated
+  [store_001] FAIL "psycopg2" - trigger: psycopg2
+      Use SQLite for local storage and database access
+```
+
+The corrected proposal passes, and the script exits `0` after printing:
+
+```
+RESULT: OK (deny -> correct -> allow)
+```
+
+Every event is also recorded on `gated.trace` with a `kind` field
+(`context_injection` vs `enforcement`), so guidance and enforcement are
+separately auditable.
+
+## Isolation
+
+`project_memory.json` in this folder is **demo data**. It is deliberately
+not the canonical memory of this repository and not shared with any other
+example.
+
+## Known friction
+
+Editing files inside this folder while a Mneme hook is active can trip one
+of the repository's legacy anti-pattern phrases on ordinary prose — a
+documented false-positive class (issues #150 / ADR-020). Typed
+`FORBID_LITERAL` rules with explicit path selectors are the designed fix;
+legacy phrases stay retrieval-gated until migrated.

--- a/examples/claude-agent-sdk/project_memory.json
+++ b/examples/claude-agent-sdk/project_memory.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "governed-loop-demo",
+    "description": "Isolated decision corpus for the claude_agent_sdk governed-loop example. Deliberately separate from any canonical project memory.",
+    "version": "0.1.0",
+    "owner": "example",
+    "created": "2026-08-22"
+  },
+  "items": [],
+  "decisions": [
+    {
+      "id": "store_001",
+      "decision": "Use SQLite for local storage and database access",
+      "rationale": "single-file portability; no server dependency for local deployments",
+      "scope": ["storage", "database", "persistence"],
+      "constraints": ["no postgres"],
+      "anti_patterns": ["psycopg2"]
+    }
+  ]
+}

--- a/examples/claude-agent-sdk/run.py
+++ b/examples/claude-agent-sdk/run.py
@@ -1,0 +1,181 @@
+"""Runnable governed-loop demo: Mneme x claude_agent_sdk (PR #293).
+
+Reproduces, in one script, the exact loop proven live in PR #293:
+
+    1. GUIDANCE      relevant decisions are retrieved and injected
+                     before any work starts.
+    2. ENFORCEMENT   a proposed file mutation is evaluated by the same
+                     `mneme check` path the Claude Code hook uses.
+    3. RECOVERY      a blocked proposal carries the governing decision
+                     back to the caller; the corrected proposal passes.
+
+Two modes:
+
+  python run.py            deterministic mode - no model, no network.
+                           The proposed contents are fixed strings and
+                           every verdict comes from real `mneme check`
+                           runs against the isolated memory in this
+                           folder.
+
+  python run.py --live     live mode - drives a real model session via
+                           the official claude_agent_sdk package with
+                           MnemeAgentSdk hooks installed. Requires that
+                           package (import name `claude_agent_sdk`;
+                           the PyPI distribution spells the name with
+                           hyphens - see that project's install docs),
+                           a working `claude` CLI login, and network.
+
+The decision corpus here is isolated example data. It is NOT the
+canonical `.mneme/project_memory.json` of this repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from mneme.integrations.agent_sdk import ACTION_ALLOW, ACTION_DENY, MnemeAgentSdk
+
+TASK = "Add database persistence to the service"
+
+VIOLATING_DB_PY = (
+    '"""Persistence module."""\n\n'
+    "import psycopg2\n\n"
+    'conn = psycopg2.connect("dbname=app")\n'
+)
+
+COMPLIANT_DB_PY = (
+    '"""Persistence module."""\n\n'
+    "import sqlite3\n\n"
+    'DB_PATH = "app.db"\n\n'
+    "conn = sqlite3.connect(DB_PATH)\n"
+)
+
+
+def prepare_workdir(base: Path) -> Path:
+    """Materialize an isolated project governed by the demo memory."""
+    work = base / "demo-project"
+    (work / ".mneme").mkdir(parents=True, exist_ok=True)
+    memory = Path(__file__).parent / "project_memory.json"
+    (work / ".mneme" / "project_memory.json").write_text(
+        memory.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return work
+
+
+def show_guidance(gated: MnemeAgentSdk) -> None:
+    injection = gated.context_for_task(TASK)
+    print("=" * 64)
+    print("1. GUIDANCE - decisions injected before work")
+    print("=" * 64)
+    print(f"   query        : {TASK}")
+    print(f"   injected ids : {injection.decision_ids}")
+    print(f"   memory       : {injection.memory_path}")
+    print()
+    print(injection.text or "   (no decisions above the relevance floor)")
+    print()
+
+
+def show_enforcement(label: str, result) -> None:
+    print("-" * 64)
+    print(label)
+    print(f"   action       : {result.action.upper()}")
+    if result.reason:
+        for line in result.reason.splitlines():
+            print(f"   {line}")
+    print()
+
+
+def run_deterministic() -> int:
+    base = Path(tempfile.mkdtemp(prefix="mneme-loop-demo-"))
+    work = prepare_workdir(base)
+    gated = MnemeAgentSdk(project_dir=work)
+
+    show_guidance(gated)
+
+    print("=" * 64)
+    print("2. ENFORCEMENT + 3. AUTONOMOUS RECOVERY")
+    print("   task: add database persistence; the first proposal uses")
+    print("   a forbidden server database driver.")
+    print("=" * 64)
+    print()
+
+    first = gated.evaluate_mutation(
+        "Write",
+        {"file_path": str(work / "db.py"), "content": VIOLATING_DB_PY},
+        cwd=str(work),
+    )
+    show_enforcement("proposal 1: psycopg2 driver", first)
+
+    second = gated.evaluate_mutation(
+        "Write",
+        {"file_path": str(work / "db.py"), "content": COMPLIANT_DB_PY},
+        cwd=str(work),
+    )
+    show_enforcement("proposal 2: stdlib sqlite3 (corrected)", second)
+
+    print("=" * 64)
+    ok = first.action == ACTION_DENY and second.action == ACTION_ALLOW
+    print(f"RESULT: {'OK' if ok else 'UNEXPECTED'} (deny -> correct -> allow)")
+    print(f"workdir: {base}")
+    return 0 if ok else 1
+
+
+def run_live() -> int:
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+    except ImportError:
+        print(
+            "live mode requires the official package (import name "
+            "claude_agent_sdk); see that project's install docs.",
+            file=sys.stderr,
+        )
+        return 2
+
+    base = Path(tempfile.mkdtemp(prefix="mneme-loop-demo-live-"))
+    work = prepare_workdir(base)
+    gated = MnemeAgentSdk(project_dir=work)
+
+    options = ClaudeAgentOptions(
+        cwd=str(work),
+        hooks=gated.hooks(),
+        permission_mode="acceptEdits",
+        max_turns=10,
+    )
+    prompt = (
+        f"{TASK}. Use the Write tool to create db.py in the current working "
+        "directory using exactly the relative path db.py. If the Write tool "
+        "is blocked, follow the block reason and immediately write a "
+        "compliant db.py instead."
+    )
+
+    async def drive() -> None:
+        async for _message in query(prompt=prompt, options=options):
+            pass  # transcript printing left to the embedding application
+
+    asyncio.run(drive())
+
+    print(json.dumps(gated.trace, indent=2))
+    final = work / "db.py"
+    text = final.read_text(encoding="utf-8") if final.exists() else ""
+    denied = [e for e in gated.trace if e.get("action") == ACTION_DENY]
+    allowed = [e for e in gated.trace if e.get("action") == ACTION_ALLOW]
+    compliant = "psycopg2" not in text
+    ok = bool(denied) and bool(allowed) and compliant
+    print(
+        f"RESULT: {'OK' if ok else 'INCOMPLETE'} "
+        f"(denied={len(denied)}, allowed={len(allowed)}, compliant={compliant})"
+    )
+    print(f"workdir: {base}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="drive a real model session")
+    args = parser.parse_args()
+    sys.exit(run_live() if args.live else run_deterministic())

--- a/examples/claude-agent-sdk/run.py
+++ b/examples/claude-agent-sdk/run.py
@@ -6,8 +6,11 @@ Reproduces, in one script, the exact loop proven live in PR #293:
                      before any work starts.
     2. ENFORCEMENT   a proposed file mutation is evaluated by the same
                      `mneme check` path the Claude Code hook uses.
-    3. RECOVERY      a blocked proposal carries the governing decision
+    3. CORRECTION    a blocked proposal carries the governing decision
                      back to the caller; the corrected proposal passes.
+                     Deterministic mode scripts both proposals; --live
+                     mode lets the model perform the correction from
+                     the block reason.
 
 Two modes:
 
@@ -98,7 +101,7 @@ def run_deterministic() -> int:
     show_guidance(gated)
 
     print("=" * 64)
-    print("2. ENFORCEMENT + 3. AUTONOMOUS RECOVERY")
+    print("2. ENFORCEMENT + 3. CORRECTION PATH")
     print("   task: add database persistence; the first proposal uses")
     print("   a forbidden server database driver.")
     print("=" * 64)


### PR DESCRIPTION
﻿Adoption surfaces for the Claude Agent SDK integration merged in #293. Converts the proven governed-model loop from an engineering result into something another developer can discover and reproduce.

## Changes

- **README** - "Works with" now separates explicitly supported integrations (claude_agent_sdk and Claude Code via hooks, Cursor via compiled rules) from generic compatibility through the Python API (`MemoryStore` / `DecisionRetriever` / `Pipeline`).
- **`examples/claude-agent-sdk/`** - runnable demo with an isolated decision corpus (`store_001`, SQLite rule):
  - deterministic mode: reproduces guidance -> deny -> correct -> allow using real `mneme check` verdicts; no model, no network, exit code 0;
  - `--live` mode: one real model session through `MnemeAgentSdk` hooks.
- **CHANGELOG** - Unreleased entry for the integration and example.

## Validation

- Full suite: 604 passed / 5 skipped (includes upstream strict-mode Pipeline fix landing in the same window).
- Encoding + install-command gates green.
- Deterministic demo run verified locally before commit.

## Governance note

The example was authored under native Mneme governance. Three guard blocks occurred on this path: the repository's legacy multi-term anti-pattern phrase fired on ordinary prose (standalone words such as a package variable name and common English terms) once the file path placed the decision in the retrieval top-K - the documented #150 / ADR-020 false-positive class. Each block was resolved by semantics-preserving rewording, verified against the enforcer before retry. No project-memory or enforcement change is included here; the typed-rule path-selector mechanism (ADR-020) remains the designed fix and is referenced from the example README.

Closes part of the adoption follow-up to #292 / #293.


