### PR TITLE
fix: strict Pipeline.run raises when scoped-rule applicability is unknown

### DIFF
--- a/mneme/pipeline.py
+++ b/mneme/pipeline.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from mneme.conflict_detector import Conflict, ConflictDetector
+from mneme.conflict_detector import (
+    Conflict,
+    ConflictDetector,
+    PathApplicabilityUnknownError,
+)
 from mneme.context_builder import DEFAULT_MAX_DECISIONS, format_decisions
 from mneme.decision_retriever import DecisionRetriever, ScoredDecision
 from mneme.llm_adapter import LLMAdapter
@@ -113,6 +117,13 @@ class Pipeline:
 
         Returns:
             A PipelineResult with every stage's output recorded.
+
+        Raises:
+            MnemeConflictError: strict mode and a conflict was detected.
+            PathApplicabilityUnknownError: strict mode and a scoped typed rule
+                could not be evaluated (no usable target path). Mirrors the CLI's
+                operational-failure precedence and ConflictDetector.detect();
+                unavailable applicability never becomes a silent pass (ADR-020).
         """
         scored = self.retriever.retrieve(query)
         system_prompt = format_decisions(
@@ -166,5 +177,13 @@ class Pipeline:
                 conflicts=detection.conflicts,
                 result=result,
             )
+
+        # Strict mode must not silently complete while a scoped typed rule was
+        # unevaluated: the conflict set above cannot be trusted as "governed"
+        # when part of it never ran (ADR-020 sec. 6). The CLI already treats
+        # this state as an operational failure and ConflictDetector.detect()
+        # raises; this is the same contract for the Pipeline surface.
+        if self.enforcement_mode == "strict" and not detection.evaluation_complete:
+            raise PathApplicabilityUnknownError(detection.applicability)
 
         return result

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -41,6 +41,106 @@ def test_pipeline_runs_conflict_detection_after_response():
     ), f"expected a postgres conflict, got {result.conflicts!r}"
 
 
+def test_pipeline_strict_mode_raises_when_scoped_rule_is_unevaluated(tmp_path):
+    """Regression (adversarial review AR-001): strict mode must not silently
+    complete while a scoped typed rule could not be evaluated.
+
+    The CLI treats PATH_APPLICABILITY_UNKNOWN as an operational failure (exit 2,
+    never a policy verdict) and ConflictDetector.detect() raises
+    PathApplicabilityUnknownError. Pipeline.run() in strict mode did neither:
+    the unevaluated scoped rule was skipped, conflicts stayed empty, and the
+    call returned normally even though the response contained the forbidden
+    literal. ADR-020 sec. 6 forbids unavailable applicability from becoming a
+    silent successful evaluation.
+    """
+    from mneme.conflict_detector import PathApplicabilityUnknownError
+
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    memory.parent.mkdir()
+    memory.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Legacy client documentation",
+            "scope": ["docs"],
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+    p = Pipeline(memory_path=memory, dry_run=True, enforcement_mode="strict")
+
+    with pytest.raises(PathApplicabilityUnknownError) as excinfo:
+        p.run(
+            "update docs",
+            _override_response="install legacy-client",
+        )
+
+    # The error exposes exactly which rule could not be evaluated and why.
+    assert any(
+        item.outcome.value == "UNKNOWN" and item.rule_value == "install legacy-client"
+        for item in excinfo.value.applicability
+    )
+
+
+def test_pipeline_strict_mode_still_raises_conflict_when_target_resolves(tmp_path):
+    """The AR-001 fix must not disturb the normal strict-mode contract: with a
+    target path that resolves applicability, a violating response still raises
+    MnemeConflictError."""
+    from mneme.schemas import MnemeConflictError
+
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    memory.parent.mkdir()
+    memory.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Legacy client documentation",
+            "scope": ["docs"],
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+    p = Pipeline(memory_path=memory, dry_run=True, enforcement_mode="strict")
+
+    with pytest.raises(MnemeConflictError):
+        p.run(
+            "update docs",
+            _override_response="install legacy-client",
+            target_path=tmp_path / "docs" / "guide.md",
+        )
+
+
+def test_pipeline_warn_mode_keeps_reporting_unknown_without_raising(tmp_path):
+    """warn mode keeps returning a result; the caller inspects
+    evaluation_complete. Only strict mode escalates to an operational error."""
+    memory = tmp_path / ".mneme" / "project_memory.json"
+    memory.parent.mkdir()
+    memory.write_text(json.dumps({
+        "meta": {"name": "test", "description": "test"},
+        "decisions": [{
+            "id": "ADR-020",
+            "decision": "Legacy client documentation",
+            "scope": ["docs"],
+            "rules": [{
+                "type": "FORBID_LITERAL",
+                "value": "install legacy-client",
+                "include_paths": ["docs/**"],
+            }],
+        }],
+    }), encoding="utf-8")
+    p = Pipeline(memory_path=memory, dry_run=True, enforcement_mode="warn")
+
+    result = p.run("update docs", _override_response="install legacy-client")
+    assert not result.evaluation_complete
+    assert result.conflicts == []
+
+
 def test_pipeline_reports_scoped_rule_non_evaluation_and_accepts_target(tmp_path):
     memory = tmp_path / ".mneme" / "project_memory.json"
     memory.parent.mkdir()


### PR DESCRIPTION
﻿## Finding

**AR-001** from `docs/validation/adversarial-architecture-review-2026-08-22.md` (adversarial architecture review, 2026-08-22): `Pipeline.run()` was the one execution surface that let unavailable path applicability become a silent successful evaluation.

## Before

In strict mode, `Pipeline.run()` used `ConflictDetector.evaluate()`, which records `PATH_APPLICABILITY_UNKNOWN` in `PipelineResult` but never raises. A scoped `FORBID_LITERAL` rule with no usable target path was therefore skipped, conflicts stayed empty, and the call **returned normally** even when the response contained the forbidden literal:

```
Pipeline(mem).run("install legacy-client",
                  _override_response="pip install legacy-client")   # strict mode
-> no raise, conflicts: [], evaluation_complete: False
```

The CLI already treats UNKNOWN as an operational failure (exit 2, never a policy verdict) and `ConflictDetector.detect()` raises `PathApplicabilityUnknownError`. The Pipeline was the inconsistent third consumer.

## After

Strict mode raises `PathApplicabilityUnknownError` (carrying the applicability trace) when any scoped typed rule cannot be evaluated. Warn mode is unchanged: it still returns a result with `evaluation_complete=False` for caller inspection.

## Architecture

Corrective alignment with ADR-020 §6 ("Unavailable applicability is not a silent PASS"). **No ADR amendment required** — this applies semantics the CLI and conflict detector already implement. No retrieval, matcher, benchmark, memory, or ADR changes.

## Proof

Regression test (`test_pipeline_strict_mode_raises_when_scoped_rule_is_unevaluated`) was written first and **failed against the pre-fix code** (`Failed: DID NOT RAISE <class 'mneme.conflict_detector.PathApplicabilityUnknownError'>`, 1 failed / 16 passed), then passed after the fix.

## Validation

- Full suite: `604 passed, 5 skipped` (baseline 601 + 3 new tests; identical skips)
- Benchmark unchanged: `7/7` violations caught, mean recall@3 `1.00`, precision@3 `0.33` (frozen Layer 1 numbers intact)
- New tests pin all three strict/warn outcomes: strict raises on unevaluated scoped rules; strict still raises `MnemeConflictError` when applicability resolves and a violation exists; warn keeps returning an inspectable result without raising

## Scope

Only:
- `mneme/pipeline.py`
- `tests/test_pipeline.py`

## Working-tree note

An unrelated uncommitted `README.md` edit present in the working tree is **excluded from this branch and not part of this PR**.
