### PR TITLE
docs: require evidence-led technical language

### DIFF
--- a/.mneme/README.md
+++ b/.mneme/README.md
@@ -1,7 +1,8 @@
 # `.mneme/` - live enforcement memory for the Mneme repo
 
 This directory holds the canonical project memory that Mneme uses to govern
-**its own** repository. Mneme protects Mneme.
+**its own** repository. The repository therefore exercises the same governance
+memory path described for users.
 
 If you are a contributor, you do not need to know how Mneme works internally
 to read this - the file is plain JSON, and the rules describe constraints on
@@ -114,9 +115,6 @@ If a warning ever feels wrong, the right move is to file an issue or open a
 
 ## Why this exists
 
-Mneme's job is to keep AI-assisted development consistent with prior
-decisions. The strongest credibility signal we can give is to use Mneme
-on Mneme - and to do it in public, in a way contributors can read, audit,
-and learn from.
-
-That is what this directory is.
+Using Mneme on this repository makes its governance behavior observable in the
+same place as the code it governs. Contributors can inspect the memory,
+configuration, warnings, and enforcement behavior directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,9 @@ If you need to change `.mneme/project_memory.json` (the repository's own governa
 
 - If you add a new command or modify an existing one, update `README.md` or the relevant `docs/` file.
 - Changes to API boundaries should be documented.
+- State observations, scope, configuration, and evidence before interpretation. Distinguish benchmark fixtures, experimental candidates, live repo memory, and shipped production behavior when the distinction affects a claim.
+- Prefer measured descriptions over evaluative labels. Do not use phrases such as "headline finding", "important implication", "meaningfully improves", "strong signal", "promising", "worthwhile", "largest", "deepest", or "winning" as substitutes for a metric, observed mechanism, or explicit comparison criterion.
+- When one result matters more than another, state the concrete reason (for example, "affects rank 1 rather than ranks 2–3") instead of labeling it "more significant" or "more consequential".
+- Separate observation from inference. If causality is not isolated, say so; do not attribute an observed change to one mechanism when multiple variables changed.
+- Do not rewrite frozen locks, run artifacts, or preserved experiment outputs for editorial style. Record corrections or changed interpretation in a separate reconciliation or diagnosis document so the original evidence remains byte-stable.
+- Accepted ADRs are architecture records, not copy-edit targets. Change them through the ADR/amendment process when their substance needs revision; do not reopen them solely to normalize wording.

--- a/docs/ops/mneme-hq-gcp.md
+++ b/docs/ops/mneme-hq-gcp.md
@@ -9,7 +9,7 @@
 | Billing account | `01C41B-59FB59-15D3F8` (shared billing account with cannabisdeals; separate project) |
 | Region / location | `US` |
 
-Room left for `mneme-hq-dev` when dev/prod separation becomes worthwhile.
+Reserve `mneme-hq-dev` for a future separate development environment if operating requirements require dev/prod isolation.
 
 ## Service Account
 

--- a/docs/validation/r1-r6-architecture-lineage-reconciliation.md
+++ b/docs/validation/r1-r6-architecture-lineage-reconciliation.md
@@ -142,8 +142,7 @@ No disappearance event occurred (rules out class A): **the code never entered th
 
 - **Primary (B):** R1–R6 ran against an unmerged experimental clone whose role-aware implementation
   never entered canonical production. The closeout's "implementation retained" claim is wrong w.r.t. `main`.
-- **Retrieval-provenance defect (additional finding, the most consequential new fact beyond the original
-  P0):** R4–R6 used not only role-aware guidance but also a **non-canonical `DecisionRetriever`**
+- **Retrieval-provenance defect (additional finding):** R4–R6 used not only role-aware guidance but also a **non-canonical `DecisionRetriever`**
   (`F86B3BA2…`, typed-rule scoring term absent from every commit of `main`). The experiment was therefore
   a **configuration**, not merely a formatter change: one cannot transplant the role-aware code onto
   canonical retrieval and assume one is reproducing the R6 candidate. Class D does not apply — all stages
@@ -157,7 +156,6 @@ The evidence remains valid but its scope shrinks: it is evidence about an **expe
 configuration**, not about the shipped Mneme production path (`format_decisions()` on canonical
 retrieval). The frozen R6 FAIL applies to that candidate and must not be presented as an evaluation of
 current production behavior.
-
 ---
 
 ## 8. Answers to the six acceptance questions
@@ -193,7 +191,7 @@ Ordered, narrowly scoped, each a separate PR:
    restate "implementation retained" as "campaign executed on an unmerged experimental tree, preserved
    by archival snapshot"; repair or remove the phantom architecture-contract link; explicitly record the
    non-canonical retriever (`F86B3BA2…`). Do not rewrite the frozen R1–R6 locks, results, or artifacts.
-3. **Close P0.** Canonical `main` becomes unquestionably authoritative for future work.
+3. **Close P0.** Canonical `main` is the authoritative production baseline for future work.
 4. **Then open P1 retrieval precision against canonical `main`.**
    Do not use the OneDrive retriever as a starting point.
 5. **If role-aware guidance is reconsidered later, treat it as a new prospective feature.**
@@ -203,7 +201,7 @@ Ordered, narrowly scoped, each a separate PR:
      operates strictly after canonical retrieval and demonstrably does not alter scores, ranking, K,
      selection IDs, or retrieval semantics (per ADR-017, retrieval is the context-injection ranking
      layer, separate from enforcement).
-   - The experimental typed-rule scoring term (`"rules": 1.5` overlap weight) **absolutely requires an
+   - The experimental typed-rule scoring term (`"rules": 1.5` overlap weight) **requires an
      explicit amendment** before any adoption, since it modifies `DecisionRetriever` scoring itself.
 
 Explicitly **not** recommended: silently re-committing the OneDrive tree onto `main`, treating the

--- a/docs/validation/r1-r6-architecture-lineage-reconciliation.md
+++ b/docs/validation/r1-r6-architecture-lineage-reconciliation.md
@@ -142,11 +142,12 @@ No disappearance event occurred (rules out class A): **the code never entered th
 
 - **Primary (B):** R1–R6 ran against an unmerged experimental clone whose role-aware implementation
   never entered canonical production. The closeout's "implementation retained" claim is wrong w.r.t. `main`.
-- **Retrieval-provenance defect (additional finding):** R4–R6 used not only role-aware guidance but also a **non-canonical `DecisionRetriever`**
-  (`F86B3BA2…`, typed-rule scoring term absent from every commit of `main`). The experiment was therefore
-  a **configuration**, not merely a formatter change: one cannot transplant the role-aware code onto
-  canonical retrieval and assume one is reproducing the R6 candidate. Class D does not apply — all stages
-  resolved to one coherent experimental lineage; the divergence is from production, not between R stages.
+- **Retrieval-provenance defect (additional finding):** R4–R6 used not only role-aware guidance but also a
+  **non-canonical `DecisionRetriever`** (`F86B3BA2…`, typed-rule scoring term absent from every commit of
+  `main`). The experiment was therefore a **configuration**, not merely a formatter change: one cannot
+  transplant the role-aware code onto canonical retrieval and assume one is reproducing the R6 candidate.
+  Class D does not apply — all stages resolved to one coherent experimental lineage; the divergence is
+  from production, not between R stages.
 - **Not C:** provenance is proven — locks, artifacts, and run metadata all resolve to one concrete tree.
 - The R6 FAIL remains frozen and untouched by this finding.
 
@@ -156,6 +157,7 @@ The evidence remains valid but its scope shrinks: it is evidence about an **expe
 configuration**, not about the shipped Mneme production path (`format_decisions()` on canonical
 retrieval). The frozen R6 FAIL applies to that candidate and must not be presented as an evaluation of
 current production behavior.
+
 ---
 
 ## 8. Answers to the six acceptance questions


### PR DESCRIPTION
## Summary

Apply an evidence-led documentation standard across maintained core-repo prose without changing architecture, retrieval, enforcement, benchmarks, memory, or frozen validation evidence.

## Changes

- `CONTRIBUTING.md`: adds repository-wide documentation rules: state scope/evidence before interpretation, separate observation from inference, avoid unsupported evaluative labels, and distinguish frozen benchmark / experimental / live-memory / production claims.
- `.mneme/README.md`: replaces promotional self-governance wording with a factual description of what contributors can inspect.
- `docs/ops/mneme-hq-gcp.md`: replaces a vague "becomes worthwhile" condition with an explicit operating-requirements condition.
- `docs/validation/r1-r6-architecture-lineage-reconciliation.md`: removes ranking/intensifier language (`most consequential`, `unquestionably`, `absolutely`) without changing the Class B verdict, evidence, claim boundary, or remediation requirements.

## Deliberate exclusions

- Frozen locks, run artifacts, and preserved experiment outputs are not rewritten for style.
- Accepted ADRs are not reopened solely for copy editing.
- GTM/site/SEO material is outside this core-workstream cleanup.
- No word blacklist or CI linter is introduced; terms are judged by whether they substitute evaluation for evidence.

## Related

PR #299 was corrected separately because its diagnosis file exists only on that open branch; its report and PR body now use the same evidence-led wording.
