### PR TITLE
feat: shell preflight gate and Stop session-delta backstop (ADR-021)

### DIFF
--- a/docs/adr/ADR-021-shell-preflight-and-stop-session-delta.md
+++ b/docs/adr/ADR-021-shell-preflight-and-stop-session-delta.md
@@ -1,0 +1,218 @@
+---
+id: ADR-021
+title: "Shell Preflight Reconstruction and Stop Session-Delta Enforcement"
+status: accepted
+priority: foundational
+date: 2026-08-22
+scope: enforcement.coverage
+---
+
+# ADR-021: Shell Preflight Reconstruction and Stop Session-Delta Enforcement
+
+**Status:** Accepted
+**Date:** 2026-08-22
+**Deciders:** Theo Valmis
+
+---
+
+## Context
+
+The enforcement architecture is **prevent -> catch -> verify**. After
+ADR-017/018/019/020 the prevent stage covers exactly one surface: Claude Code
+`PreToolUse` events for `Edit|Write|MultiEdit`. Two gaps follow, and both are
+visible to any pilot user:
+
+1. **Shell bypass.** A `Bash` call such as `cat > src/db.py << 'EOF' ... EOF`
+   writes repository content without firing a file-edit hook. The plugin
+   documentation states this openly: shell writes "are not covered".
+2. **No completion boundary.** Whatever escapes interception — an ambiguous
+   shell pipeline, a generated file, an indirect script write — is never
+   evaluated again before the agent declares the turn finished. CI sees it
+   eventually; the agent does not.
+
+Neither gap is governed by an existing ADR. ADR-018 defines introduced-delta
+semantics for the edit gate specifically; it neither authorizes nor forbids
+applying those semantics at other boundaries. This decision records both
+extensions and their claim boundaries.
+
+### What cannot be done
+
+Mneme must not become a shell interpreter. Arbitrary shell semantics —
+expansion, substitution, pipelines, control flow — cannot be reconstructed
+deterministically from a command string, and guessed semantics produce either
+false blocks (blocking commands that would have written compliant content) or
+false PASS (checking content that was never going to land). Both are worse
+than the gap they close.
+
+A completion-time boundary also faces an attribution problem: a working tree
+that was already dirty before the session began contains violations nobody can
+blame on the agent. Blocking completion over them recreates the
+pre-existing-violation wall ADR-018 removed (#259).
+
+## Decision
+
+### 1. Shell mutations are classified, never interpreted
+
+Every intercepted shell command is placed in exactly one class by a
+conservative, deterministic classifier operating on the tool input alone:
+
+- **A — deterministically reconstructable repository mutation.** Only when the
+  proposed bytes and the affected repository path are provable from the
+  command string alone. The initial grammar is deliberately narrow: a single
+  simple `cat` command whose output is redirected (`>` overwrite or `>>`
+  append) to one plain path token, reading a here-document with a *quoted*
+  delimiter (`<< 'EOF'` or `<< "EOF"`). A quoted delimiter suppresses all
+  parameter, command, arithmetic, glob, and escape expansion, so the document
+  body is byte-identical to what the shell will write; the body ends at the
+  first line equal to the delimiter. Anything else in the command — pipelines,
+  `&&`/`;` chains, command or variable substitution, unquoted delimiters,
+  `<<-`, multiple redirects — voids class A.
+  
+  Class A commands are materialized and checked **before execution** using
+  the existing edit-gate path: the same introduced-content definition as
+  ADR-018, the same `mneme check --target-path` invocation, the same verdict
+  trust rules. A trusted blocking verdict exits 2 before the shell runs.
+
+- **B — potentially mutating but not safely reconstructable.** Allowed to
+  proceed. Not blocked on guessed semantics. Optionally traced in diagnostics
+  as not preflight-reconstructable; the Stop boundary (below) is the
+  enforcement surface for this class.
+
+- **C — clearly non-mutating.** Passes through without enforcement work.
+
+Classification defaults to B whenever membership in C cannot be proven. Class
+assignment never decides a block by itself; only class A reaches the checker,
+and only its trusted verdict can block.
+
+The separately named `PowerShell` tool surface is recorded as the next
+coverage item and is not implemented in the first iteration; its resulting
+file mutations remain within Stop's reach where session auditing is
+available.
+
+### 2. Stop enforces the session delta
+
+A `Stop` hook acts as a second enforcement boundary: **post-mutation /
+pre-completion**. It is not pre-generation enforcement, it does not prevent
+the original write, and it must never be described as such.
+
+**Session baseline.** A `SessionStart` hook captures, once per session at
+`source: startup`, a snapshot of every git-tracked and untracked-but-not-
+ignored file under the policy root: SHA-256, size, and UTF-8-decoded content
+for files within per-file and total size budgets; hash-only beyond them. The
+snapshot lives outside the governed repository (the platform temp directory),
+keyed by repository-root hash and Claude `session_id`, so concurrent sessions
+in one repository do not collide and no governed content is polluted. Stale
+snapshots are garbage-collected opportunistically. `resume`, `clear`,
+`compact`, and `fork` sources preserve an existing baseline: compaction must
+not launder violations introduced earlier in the same working-tree session.
+
+**Evaluation.** At Stop the hook enumerates the same file set, compares it to
+the baseline, and derives, per changed file, the **introduced lines** using
+the same deterministic diff definition as ADR-018 (insert/replace opcodes,
+baseline as `before`, current as `after`). New files introduce everything;
+deleted files introduce nothing and are never blocked (deletion-only
+remediation must pass). Each candidate is checked through the existing
+enforcement path with its real target path, preserving ADR-020 applicability
+authority end to end.
+
+**Attribution correctness.** Because the baseline is captured at session
+start, dirty state that existed beforehand is indistinguishable from
+"before", and only the session's inserted/replaced lines are checked. A
+pre-existing violation does not block an unrelated session edit; removing a
+pre-existing violation introduces nothing; a violation added on top of
+pre-existing dirty lines is caught by its own delta.
+
+**Loop safety.** The hook honors `stop_hook_active` and exits immediately
+when it is true; Claude Code's own eight-consecutive-block cap remains the
+outer guard. After a blocked Stop, the baseline is *not* refreshed: the next
+Stop re-evaluates the same session delta, so a repair converges to a pass.
+
+**Explicit operational states.** The gate refuses to fabricate results:
+
+- No baseline exists (plugin installed mid-session): one is created at Stop,
+  a visible diagnostic records that earlier changes could not be attributed,
+  and the turn proceeds. Later Stops in that session enforce normally.
+- Not a git work tree: the gate reports itself inactive and does not block.
+- A file whose baseline content is unavailable (oversized or binary) but
+  which changed during the session is reported as *not evaluated*; it is
+  never silently passed and never blocked on guessed content.
+- Checker transport failures (crash, timeout, untrusted verdict) fail open
+  per file with visible diagnostics, matching the established transport
+  failure policy; they never become violations and never become silent PASS.
+
+In strict mode a trusted blocking verdict on session-introduced content
+blocks the Stop with actionable reasons naming the file and rule. Warn mode
+reports via non-blocking feedback and never blocks, mirroring the edit gate.
+
+### 3. Claim boundaries
+
+Allowed claims, exactly:
+
+- deterministic pre-mutation enforcement for supported direct file tools
+  (`Edit`, `Write`, `MultiEdit`);
+- deterministic pre-execution enforcement for explicitly supported
+  reconstructable shell mutations (the class-A grammar above);
+- post-mutation/pre-completion session-delta enforcement through `Stop`;
+- final repository verification through CI where configured.
+
+Forbidden claims: that all shell writes are enforced before execution; that
+all shell commands are understood; that Stop prevents the original write;
+that retrieval quality controls deterministic typed-rule enforcement; or that
+every filesystem mutation path is intercepted before execution.
+
+### 4. Boundaries preserved
+
+Retrieval (scoring, weights, thresholds, top-K, role guidance) is untouched;
+the shell and Stop surfaces reuse the existing `"edit to <file_path>"` query
+construction verbatim. Rule matching, `ConflictDetector`, and path-selector
+logic live only in core; the integration layer parses provider events,
+classifies operations, reconstructs deterministic proposals, computes the
+session delta, and translates trusted verdicts — nothing more. Applicability
+remains rule/path based through `--target-path`; there is no
+integration-specific applicability mechanism, and
+`PATH_APPLICABILITY_UNKNOWN` continues to surface as an operational outcome
+rather than a PASS.
+
+## Consequences
+
+- The most common shell-write pattern agents actually emit (quoted heredocs)
+  is prevented before execution; the residual shell space is caught at
+  completion instead of being invisible until CI.
+- Pilot users get an honest coverage table: prevent (direct tools + supported
+  shell writes), catch (session delta), verify (CI).
+- The Stop boundary depends on git for file discovery and on UTF-8-readable,
+  size-capped content for diffing; those limits are surfaced operationally,
+  not hidden.
+- Session snapshots consume temp-directory space proportional to repository
+  text content (bounded by budget) and are cleaned up opportunistically.
+- A malicious actor who disables git, floods the tree with oversized files,
+  or mutates the temp directory can degrade the catch stage; degradation is
+  observable by design. The prevent stage is unaffected.
+
+## Alternatives considered
+
+**Full shell interpretation.** Rejected: unknowable semantics, guaranteed
+false positives/negatives, and an unmaintainable parser.
+
+**Blocking all potentially-mutating shell commands.** Rejected: turns every
+build, test, and generator invocation into a prompt; pilots would disable the
+hook entirely.
+
+**Whole-tree final-state compliance at Stop (naive final `git diff`).**
+Rejected: blames pre-existing dirty state on the session, recreating the
+ADR-018 wall at a new boundary, and breaks remediation-by-deletion.
+
+**Baseline/suppression ledger in the repository.** Rejected for the same
+reason ADR-018 rejected it: a second source of truth that drifts.
+
+**Amending ADR-018 instead of a new ADR.** Rejected: ADR-018 scopes itself to
+the edit gate; extending its reach silently would blur which boundaries carry
+its guarantees. This ADR references its definition rather than mutating it.
+
+## Related
+
+- ADR-017: Enforcement Scope Is Independent of Retrieval Scope
+- ADR-018: Introduced-Delta Enforcement at the Edit Gate (definition reused)
+- ADR-019: Typed Literal Rule Contract
+- ADR-020: Explicit Path Applicability for Typed Rules
+- Issue #251 (repo-wide audit boundary; explicitly out of scope here)

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -19,6 +19,34 @@ adjusts its approach without you having to intervene.
 
 ---
 
+## Coverage: prevent -> catch -> verify
+
+| Stage | Surface | What is guaranteed |
+|---|---|---|
+| **Prevent** | `PreToolUse` x `Edit\|Write\|MultiEdit` | Deterministic pre-mutation checks on the lines an edit introduces (ADR-018). |
+| **Prevent** | `PreToolUse` x `Bash` | Pre-execution checks for explicitly supported reconstructable shell mutations: single simple `cat > path << 'EOF'` / `cat >> path << 'EOF'` commands with a quoted delimiter (ADR-021). Everything else passes through unblocked. |
+| **Catch** | `Stop` | Post-mutation, pre-completion session-delta checks: content introduced during this Claude session through any mutation path that escaped pre-execution interception is evaluated before the turn ends; violations block completion with actionable reasons (ADR-021). Requires git. |
+| **Verify** | CI (`mneme check`) | Final repository-boundary verification, unchanged. |
+
+Precise claim boundaries:
+
+- Not every shell command is understood. Commands outside the supported
+  grammar (pipelines, substitutions, generators, scripts, unquoted heredoc
+  delimiters) are never blocked on guessed semantics — they are caught by the
+  Stop boundary instead of being prevented.
+- The Stop boundary does not prevent the original mutation and is not
+  pre-generation tooling; it audits what the session actually introduced,
+  measured against a baseline captured at session start, so dirty state that
+  existed beforehand is never attributed to the session.
+- Retrieval quality does not control whether a deterministic typed rule is
+  enforced (ADR-017); the shell and Stop surfaces reuse the same check path
+  and real target paths, so ADR-020 applicability stays authoritative.
+- Session attribution depends on git file discovery and UTF-8-readable
+  artifacts within size budgets; degraded cases surface visible diagnostics
+  rather than fabricated passes or silent blocks.
+
+---
+
 ## Install
 
 ### 1. Install the package

--- a/integrations/claude-code-plugin/README.md
+++ b/integrations/claude-code-plugin/README.md
@@ -51,31 +51,30 @@ plugin UI will prompt for the **enforcement mode** (`strict` or `warn`).
 
 ## How enforcement works
 
-The plugin registers a `PreToolUse` hook matching `Edit|Write|MultiEdit`.
+The plugin registers three hooks, all exec-form invocations of `mneme-hook`:
 
-> **What this covers.** `Edit` and `Write` tool calls, which is how Claude Code
-> edits files directly. The matcher also lists `MultiEdit` for compatibility;
-> current Claude Code documents `Edit` and `Write`. **Edits made by shell
-> commands are not covered** — a `Bash` call that writes a file does not fire a
-> `PreToolUse` file-edit hook and is never checked. Complete working-tree
-> coverage would need a `Stop`-hook audit, which this plugin does not ship. Use
-> `/mneme:review` to catch what the per-edit hook misses.
+| Event | Matcher | Role |
+|---|---|---|
+| `PreToolUse` | `Edit\|Write\|MultiEdit\|Bash` | **Prevent**: block violating mutations before they land. |
+| `SessionStart` | (all sources) | Capture the per-session repository baseline used by the Stop boundary. |
+| `Stop` | — | **Catch**: evaluate the session delta before the agent completes. |
 
-The hook uses Claude Code's **exec form** — it invokes the `mneme-hook` console
-script directly on `PATH`, with no shell in between:
-
-```json
-{ "type": "command", "command": "mneme-hook", "args": [], "timeout": 30 }
-```
-
-`mneme-hook` (the existing Claude Code adapter, unchanged by this plugin):
-
-1. Reconstructs the full post-edit file content (not just the changed string),
-   honouring `replace_all` so the checked content matches what will land on disk.
-2. Discovers `.mneme/project_memory.json` by walking up from the working dir.
-3. Runs `mneme check --json` with a query derived from the target file path.
-4. Reads the **structured verdict** from that payload. In `strict` mode a
-   violating verdict exits **2** (block); in `warn` mode it never blocks.
+> **Coverage boundary (ADR-021): prevent -> catch -> verify.**
+>
+> - Direct file tools (`Edit`, `Write`, `MultiEdit`) are checked
+>   deterministically before mutation, on introduced lines only.
+> - Shell calls are checked before execution only when Mneme can prove from
+>   the command string alone what will land and where: a single simple
+>   `cat > path << 'EOF'` / `cat >> path << 'EOF'` with a quoted delimiter.
+>   Every other shell form — pipelines, substitutions, generators,
+>   interpreters, unquoted delimiters — is **not** preflight-blocked; it is
+>   allowed to run and its results are evaluated at `Stop`.
+> - The `Stop` hook audits content this session introduced (baseline ->
+>   working-tree diff with the same introduced-line semantics as the edit
+>   gate). It blocks completion with actionable reasons in strict mode and
+>   never blocks on dirty state that predates the session. It requires git;
+>   without git it reports itself inactive.
+> - CI remains the final verification boundary.
 
 The hook blocks **only** on a verdict it could parse and trust. An exit code on
 its own is not treated as a verdict — `mneme check --mode strict` returns 1 for
@@ -119,7 +118,9 @@ which is why warn mode previously reported nothing at all. `defer` is
 deliberate: `allow` would auto-approve the tool call and bypass the permission
 prompt you would otherwise get, so a *warning* mode must never use it. How
 Claude Code renders a `defer` reason has not been confirmed end-to-end in a
-live session.
+live session. In `warn` mode the `Stop` boundary likewise reports through
+non-blocking feedback (`hookSpecificOutput.additionalContext`) and never
+blocks completion.
 
 ## Retrieval: what the hook checks and what it misses
 

--- a/integrations/claude-code-plugin/hooks/hooks.json
+++ b/integrations/claude-code-plugin/hooks/hooks.json
@@ -1,15 +1,39 @@
 {
-  "description": "Mneme architectural-enforcement hook for Claude Code edits.",
+  "description": "Mneme architectural-enforcement hooks for Claude Code: pre-execution gates plus a session-delta backstop at Stop.",
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write|MultiEdit|Bash",
         "hooks": [
           {
             "type": "command",
             "command": "mneme-hook",
             "args": [],
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mneme-hook",
+            "args": [],
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mneme-hook",
+            "args": [],
+            "timeout": 120
           }
         ]
       }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -48,6 +48,18 @@ On every Edit, Write, or MultiEdit, Claude Code pipes the tool input to
 4. Exits 2 (block) if `mneme check` returns a non-zero verdict in strict
    mode; exits 0 (allow) otherwise.
 
+The same command also serves two more surfaces (ADR-021):
+
+- `PreToolUse` x `Bash`: a shell call is checked **before execution** only
+  when it is deterministically reconstructable — a single simple
+  `cat > path << 'EOF'` / `cat >> path << 'EOF'` with a quoted delimiter.
+  All other shell forms pass through unblocked.
+- `Stop`: after each turn, content this session introduced is evaluated
+  against project memory; violations block completion with actionable
+  reasons. A per-session baseline (captured at session start, stored in the
+  platform temp dir) keeps pre-existing dirty state from being attributed to
+  the session. Requires git; otherwise the boundary reports itself inactive.
+
 **Retrieval note:** `mneme check` uses keyword-based retrieval. The query
 is `"edit to <file_path>"` — tokens from the file name contribute to
 which decisions are retrieved. Decisions whose scope, id, or text share

--- a/integrations/claude-code/hooks.json
+++ b/integrations/claude-code/hooks.json
@@ -2,7 +2,27 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mneme-hook"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mneme-hook"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
         "hooks": [
           {
             "type": "command",

--- a/integrations/claude-code/skills/mneme/SKILL.md
+++ b/integrations/claude-code/skills/mneme/SKILL.md
@@ -41,6 +41,11 @@ It reconstructs the full post-edit file content, then calls `mneme check` with t
 query `"edit to <file_path>"`. Decisions whose scope or text share tokens with the
 file name are retrieved and checked.
 
+Shell calls (`Bash`) are checked before execution only when they are simple
+quoted-delimiter heredoc writes (`cat > path << 'EOF' ... EOF`); anything else is
+audited by a `Stop` boundary that evaluates what this session introduced before
+the turn completes (ADR-021).
+
 **Retrieval caveat:** The automatic hook query is derived from the file path, so
 decisions with scope keywords that don't appear in file names may not be retrieved
 automatically. Use `/mneme-context` before large edits to confirm coverage.

--- a/mneme/integrations/claude_code/hook.py
+++ b/mneme/integrations/claude_code/hook.py
@@ -1,4 +1,14 @@
-"""Claude Code hook shim — translates PreToolUse events into mneme check calls."""
+"""Claude Code hook shim — translates hook events into mneme check calls.
+
+Surfaces (ADR-021):
+
+- ``PreToolUse`` x ``Edit|Write|MultiEdit``: introduced-delta gate
+  (ADR-017/018/019/020 semantics, unchanged).
+- ``PreToolUse`` x ``Bash``: pre-execution gate for deterministically
+  reconstructable shell mutations only (see shell_preflight).
+- ``SessionStart``: per-session repository baseline capture (session_state).
+- ``Stop``: post-mutation / pre-completion session-delta backstop.
+"""
 from __future__ import annotations
 
 import difflib
@@ -10,6 +20,22 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, TextIO
+
+from mneme.integrations.claude_code.session_state import (
+    capture_baseline,
+    cleanup_stale,
+    compute_session_delta,
+    enumerate_repo_files,
+    load_snapshot,
+    save_snapshot,
+    snapshot_path,
+)
+from mneme.integrations.claude_code.shell_preflight import (
+    Classification,
+    classify_command,
+    reconstruct_heredoc_write,
+)
+from mneme.path_selectors import policy_root
 
 
 @dataclass(frozen=True)
@@ -105,20 +131,43 @@ def materialize_proposed_content(event: ToolEvent) -> str:
     return _materialize_change(event)[1]
 
 
+def introduced_between(before: str, after: str) -> str:
+    """The lines ``after`` adds over ``before``, per ADR-018's definition.
+
+    Inserted or replaced lines of a deterministic sequence diff. Shared by
+    the direct-tool gate and the Stop session-delta boundary so both
+    boundaries attribute exactly the same way.
+    """
+    if not before:
+        return after
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    matcher = difflib.SequenceMatcher(
+        a=before_lines,
+        b=after_lines,
+        autojunk=False,
+    )
+    added: list[str] = []
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag in {"insert", "replace"}:
+            added.extend(after_lines[j1:j2])
+    return "\n".join(added)
+
+
 def introduced_content(event: ToolEvent) -> str:
     """The lines this edit adds, as one string.
 
-    An edit gate and an audit ask different questions. "Is this file
-    compliant?" is an audit, and ``mneme check --input <file>`` still answers
-    it over whole files. "Does this edit introduce a violation?" is the gate,
-    and attributing the whole file to it means a violation already present
+    An edit gate and an audit ask different questions. "Is this artifact
+    compliant?" is an audit, and ``mneme check --input <artifact>`` still answers
+    it over whole artifacts. "Does this edit introduce a violation?" is the gate,
+    and attributing the whole artifact to it means a violation already present
     blocks every later edit -- including edits to an unrelated function and the
     remediation itself. On an existing repository that turns installation into
     an immediate wall (#259). See ADR-018.
 
     "Introduced" is every proposed line in an ``insert`` or ``replace`` opcode
     from a deterministic sequence diff. One definition covers all three tools:
-    a brand-new file diffs against nothing, so all of it is introduced.
+    a brand-new artifact diffs against nothing, so all of it is introduced.
 
     Two deliberate consequences:
 
@@ -128,24 +177,10 @@ def introduced_content(event: ToolEvent) -> str:
     - A rule can only match within introduced lines, so a violation split
       across an introduced line and an untouched one is not seen here. Rules
       are literal tokens rather than multi-line patterns, so this is a narrow
-      gap, and the whole-file audit path still covers it.
+      gap, and the whole-artifact audit path still covers it.
     """
     current, proposed = _materialize_change(event)
-    if not current:
-        return proposed
-
-    before = current.splitlines()
-    after = proposed.splitlines()
-    matcher = difflib.SequenceMatcher(
-        a=before,
-        b=after,
-        autojunk=False,
-    )
-    added: list[str] = []
-    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
-        if tag in {"insert", "replace"}:
-            added.extend(after[j1:j2])
-    return "\n".join(added)
+    return introduced_between(current, proposed)
 
 
 def find_memory(start: Path) -> Optional[Path]:
@@ -309,38 +344,48 @@ def _emit_defer(reason: str, stdout: TextIO) -> None:
     stdout.write("\n")
 
 
-def _run_check(
-    event: ToolEvent,
-    proposed_content: str,
+def _resolve_target(event: ToolEvent) -> tuple[str, str]:
+    """Return ``(rel_label, absolute_or_empty_target)`` for a tool event."""
+    rel = event.file_path or "(unknown)"
+    target_path = event.file_path
+    if target_path and not Path(target_path).is_absolute() and event.cwd:
+        target_path = str(Path(event.cwd) / target_path)
+    return rel, target_path
+
+
+def _invoke_check(
     memory: Path,
-    stderr: TextIO,
-    stdout: TextIO,
-) -> int:
+    rel_label: str,
+    target_path: str,
+    checked_content: str,
+    stderr: TextIO = sys.stderr,
+) -> Optional[subprocess.CompletedProcess]:
+    """Run ``mneme check`` over one proposed delta; return the child result.
+
+    Returns ``None`` when the child could not be launched or timed out; the
+    caller owns verdict interpretation and its fail-open policy.
+    """
     mode = resolve_mode()
 
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".txt", delete=False, encoding="utf-8"
     ) as tf:
-        tf.write(proposed_content)
+        tf.write(checked_content)
         input_path = tf.name
 
     try:
-        rel = event.file_path or "(unknown)"
-        target_path = event.file_path
-        if target_path and not Path(target_path).is_absolute() and event.cwd:
-            target_path = str(Path(event.cwd) / target_path)
         command = [
             sys.executable, "-m", "mneme", "check",
             "--memory", str(memory),
             "--input", input_path,
-            "--query", f"edit to {rel}",
+            "--query", f"edit to {rel_label}",
             "--mode", mode,
             "--json",
         ]
         if target_path:
             command.extend(["--target-path", target_path])
         try:
-            proc = subprocess.run(
+            return subprocess.run(
                 command,
                 capture_output=True,
                 text=True,
@@ -354,57 +399,350 @@ def _run_check(
                 "Failing open.",
                 file=stderr,
             )
-            return 0
+            return None
         except (OSError, subprocess.TimeoutExpired) as e:
             print(f"mneme-hook: check could not run ({e}). Failing open.", file=stderr)
-            return 0
-
-        payload = parse_verdict(proc.stdout)
-        if payload is None:
-            # No trusted verdict: a crash, a traceback, or an unexpected exit
-            # code. Never block on this.
-            if _is_stale_runtime(proc.stderr):
-                # Silence here would mean enforcement is off with nobody told.
-                print(
-                    "mneme-hook: the installed mneme CLI does not support "
-                    "the required JSON/path-aware check options, so no edit "
-                    "can be checked and ENFORCEMENT IS "
-                    "INACTIVE. Upgrade with: pipx upgrade mneme-hq",
-                    file=stderr,
-                )
-                return 0
-            print(
-                "mneme-hook: no parseable verdict from mneme check "
-                f"(exit {proc.returncode}). Failing open.",
-                file=stderr,
-            )
-            if proc.stderr:
-                print(proc.stderr, file=stderr)
-            return 0
-
-        verdict = payload["verdict"]
-        if payload.get("evaluation_complete") is False:
-            print(format_applicability_reason(payload), file=stderr)
-            return 0
-        if verdict == "PASS":
-            return 0
-
-        reason = format_reason(payload)
-        if mode == "warn":
-            _emit_defer(reason, stdout)
-            return 0
-
-        if verdict in _BLOCKING_VERDICTS:
-            # Exit 2 is the documented blocking path: Claude Code feeds stderr
-            # back to the model as the reason the edit was refused.
-            print(reason, file=stderr)
-            return 2
-        return 0
+            return None
     finally:
         try:
             os.unlink(input_path)
         except OSError:
             pass
+
+
+def _run_check(
+    event: ToolEvent,
+    proposed_content: str,
+    memory: Path,
+    stderr: TextIO,
+    stdout: TextIO,
+) -> int:
+    mode = resolve_mode()
+
+    rel, target_path = _resolve_target(event)
+    proc = _invoke_check(memory, rel, target_path, proposed_content, stderr=stderr)
+    if proc is None:
+        return 0
+
+    payload = parse_verdict(proc.stdout)
+    if payload is None:
+        # No trusted verdict: a crash, a traceback, or an unexpected exit
+        # code. Never block on this.
+        if _is_stale_runtime(proc.stderr):
+            # Silence here would mean enforcement is off with nobody told.
+            print(
+                "mneme-hook: the installed mneme CLI does not support "
+                "the required JSON/path-aware check options, so no edit "
+                "can be checked and ENFORCEMENT IS "
+                "INACTIVE. Upgrade with: pipx upgrade mneme-hq",
+                file=stderr,
+            )
+            return 0
+        print(
+            "mneme-hook: no parseable verdict from mneme check "
+            f"(exit {proc.returncode}). Failing open.",
+            file=stderr,
+        )
+        if proc.stderr:
+            print(proc.stderr, file=stderr)
+        return 0
+
+    verdict = payload["verdict"]
+    if payload.get("evaluation_complete") is False:
+        print(format_applicability_reason(payload), file=stderr)
+        return 0
+    if verdict == "PASS":
+        return 0
+
+    reason = format_reason(payload)
+    if mode == "warn":
+        _emit_defer(reason, stdout)
+        return 0
+
+    if verdict in _BLOCKING_VERDICTS:
+        # Exit 2 is the documented blocking path: Claude Code feeds stderr
+        # back to the model as the reason the edit was refused.
+        print(reason, file=stderr)
+        return 2
+    return 0
+
+
+# ── ADR-021: Bash pre-execution gate ─────────────────────────────────────────
+
+_SHELL_TRACE_PREFIX = "mneme-hook: Bash"
+
+
+def bash_tool_event(
+    event: ToolEvent,
+    stderr: TextIO,
+    stdout: TextIO,
+) -> int:
+    """Preflight a Bash call when — and only when — it is reconstructable.
+
+    Class A (quoted-delimiter heredoc writes) is materialized and checked
+    before execution. Classes B/C pass through; the Stop boundary audits what
+    they actually did. Classification alone never blocks.
+    """
+    command = event.tool_input.get("command", "") or ""
+    rec = reconstruct_heredoc_write(command)
+    if rec is None:
+        cls = classify_command(command)
+        print(
+            f"{_SHELL_TRACE_PREFIX} classified {cls.value}: no deterministic "
+            "pre-execution check (session-delta backstop still applies).",
+            file=stderr,
+        )
+        return 0
+
+    memory = find_memory(Path(event.cwd or "."))
+    if memory is None:
+        return 0
+
+    target_abs = rec.target_path
+    if not Path(target_abs).is_absolute() and event.cwd:
+        target_abs = str(Path(event.cwd) / target_abs)
+
+    try:
+        current = _read_current(target_abs, missing_ok=True)
+    except MaterializeError:
+        current = ""
+    proposed = current + rec.proposed_content if rec.append else rec.proposed_content
+    checked = introduced_between(current, proposed)
+    if not checked.strip():
+        # Pure re-append of lines the artifact already ends with introduces
+        # nothing new (ADR-018 blank-delta rule).
+        return 0
+
+    shell_event = ToolEvent(
+        tool_name="Bash",
+        file_path=target_abs,
+        cwd=event.cwd,
+        tool_input={},
+    )
+    return _run_check(shell_event, checked, memory, stderr, stdout)
+
+
+# ── ADR-021: session lifecycle surfaces ─────────────────────────────────────
+
+_MAX_BLOCKED_ARTIFACTS = 5
+
+
+def session_start_event(envelope: Dict[str, Any], stderr: TextIO) -> int:
+    """Capture the per-session repository baseline.
+
+    Only a fresh ``startup`` refreshes an existing snapshot; resume, clear,
+    compact, and fork keep it so mid-session compaction cannot launder deltas
+    introduced earlier in the same working tree.
+    """
+    memory = find_memory(Path(envelope.get("cwd") or "."))
+    if memory is None:
+        return 0
+    root = policy_root(memory)
+    cleanup_stale()
+    source = str(envelope.get("source") or "startup")
+    spath = snapshot_path(root, str(envelope.get("session_id") or ""))
+    if source != "startup" and load_snapshot(spath, expected_root=root) is not None:
+        return 0
+    try:
+        save_snapshot(spath, capture_baseline(root))
+    except OSError as e:
+        print(f"mneme-hook: baseline capture failed ({e}).", file=stderr)
+    return 0
+
+
+def stop_event(
+    envelope: Dict[str, Any],
+    stderr: TextIO,
+    stdout: TextIO,
+) -> int:
+    """Session-delta backstop: post-mutation, pre-completion.
+
+    Evaluates only content this session introduced (baseline -> now diff with
+    ADR-018 semantics). Blocks via the documented Stop JSON decision on a
+    trusted blocking verdict; every degraded path is visible and never a
+    fabricated pass.
+    """
+    if envelope.get("stop_hook_active"):
+        # Claude Code is already continuing because of a stop hook; blocking
+        # again risks an unresolvable loop. The harness's own consecutive-block
+        # cap remains the outer guard.
+        return 0
+
+    memory = find_memory(Path(envelope.get("cwd") or "."))
+    if memory is None:
+        return 0
+
+    root = policy_root(memory)
+
+    files = enumerate_repo_files(root)
+    if files is None:
+        print(
+            "mneme-hook: not inside a git work tree; the session-delta gate "
+            "is inactive for this turn.",
+            file=stderr,
+        )
+        return 0
+
+    spath = snapshot_path(root, str(envelope.get("session_id") or ""))
+    baseline = load_snapshot(spath, expected_root=root)
+    if baseline is None:
+        try:
+            save_snapshot(spath, capture_baseline(root))
+        except OSError as e:
+            print(f"mneme-hook: late baseline capture failed ({e}).", file=stderr)
+            return 0
+        print(
+            "mneme-hook: no session baseline was found; captured one now. "
+            "Repository mutations made before this point cannot be attributed "
+            "to this session and were not evaluated.",
+            file=stderr,
+        )
+        return 0
+
+    delta = compute_session_delta(root, baseline, files)
+
+    mode = resolve_mode()
+    offenders: list[tuple[str, str]] = []  # (rel, reason)
+    unevaluated = list(delta.skipped.items())
+
+    candidates: list[tuple[str, str]] = []
+    for rel in delta.new:
+        abs_path = root / rel
+        try:
+            body = abs_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            unevaluated.append((rel, f"unreadable during evaluation: {e}"))
+            continue
+        if body.strip():
+            candidates.append((rel, body))
+    for rel, introduced in delta.modified.items():
+        candidates.append((rel, introduced))
+
+    untrusted = 0
+    incomplete = 0
+    for rel, body in candidates:
+        proc = _invoke_check(memory, rel, str(root / rel), body, stderr=stderr)
+        if proc is None:
+            untrusted += 1
+            continue
+        payload = parse_verdict(proc.stdout)
+        if payload is None:
+            untrusted += 1
+            if _is_stale_runtime(proc.stderr):
+                print(
+                    "mneme-hook: installed CLI lacks required JSON/path-aware "
+                    "options; ENFORCEMENT IS INACTIVE. Upgrade with: "
+                    "pipx upgrade mneme-hq",
+                    file=stderr,
+                )
+            continue
+        if payload.get("evaluation_complete") is False:
+            incomplete += 1
+            print(format_applicability_reason(payload), file=stderr)
+            continue
+        if payload["verdict"] in _BLOCKING_VERDICTS:
+            offenders.append((rel, format_reason(payload)))
+
+    notes: list[str] = []
+    if untrusted:
+        notes.append(
+            f"{untrusted} changed artifact(s) could not be evaluated "
+            "(untrusted checker result); failing open per transport policy."
+        )
+    if incomplete:
+        notes.append(
+            f"{incomplete} changed artifact(s) had incomplete rule-path "
+            "evaluation (see applicability diagnostics above)."
+        )
+    if unevaluated:
+        listing = ", ".join(rel for rel, _ in unevaluated[:10])
+        notes.append(
+            "session delta not evaluated for: "
+            + listing
+            + ("..." if len(unevaluated) > 10 else "")
+        )
+    for note in notes:
+        print(f"mneme-hook: {note}", file=stderr)
+
+    if not offenders:
+        return 0
+
+    shown = offenders[:_MAX_BLOCKED_ARTIFACTS]
+    parts = [
+        "mneme: repository mutations made during this session violate "
+        f"{len(offenders)} governed artifact(s):"
+    ]
+    for rel, reason in shown:
+        parts.append(f"[{rel}]")
+        parts.append(reason)
+    if len(offenders) > len(shown):
+        parts.append(f"(+{len(offenders) - len(shown)} more)")
+    reason_text = "\n".join(parts)
+
+    if mode == "warn":
+        json.dump(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "Stop",
+                    "additionalContext": reason_text,
+                }
+            },
+            stdout,
+        )
+        stdout.write("\n")
+        return 0
+
+    json.dump({"decision": "block", "reason": reason_text}, stdout)
+    stdout.write("\n")
+    return 0
+
+
+# ── dispatch ─────────────────────────────────────────────────────────────────
+
+
+def handle_event(
+    envelope: Any,
+    stderr: TextIO = sys.stderr,
+    stdout: TextIO = sys.stdout,
+) -> int:
+    """Route one decoded hook envelope to its boundary handler."""
+    if not isinstance(envelope, dict):
+        print("mneme-hook: bad envelope: not a JSON object", file=stderr)
+        return 0
+    name = envelope.get("hook_event_name")
+    if name == "SessionStart":
+        return session_start_event(envelope, stderr)
+    if name == "Stop":
+        return stop_event(envelope, stderr, stdout)
+    try:
+        event = parse_event(json.dumps(envelope))
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"mneme-hook: bad envelope: {e}", file=stderr)
+        return 0
+    if event.tool_name == "Bash":
+        return bash_tool_event(event, stderr, stdout)
+    if not should_check(event.tool_name):
+        return 0
+
+    memory = find_memory(Path(event.cwd or "."))
+    if memory is None:
+        return 0
+
+    try:
+        # The gate checks what this edit introduces, not the whole resulting
+        # artifact -- otherwise a violation already present blocks every later
+        # edit to it, including the one that removes it (#259, ADR-018).
+        checked_content = introduced_content(event)
+    except MaterializeError as e:
+        print(f"mneme-hook: cannot materialize content, failing open: {e}", file=stderr)
+        return 0
+
+    if not checked_content.strip():
+        # The edit introduces no non-blank lines (for example, a pure
+        # deletion). Mechanically enforceable typed rules cannot be blank.
+        return 0
+
+    return _run_check(event, checked_content, memory, stderr, stdout)
 
 
 def main(
@@ -414,17 +752,11 @@ def main(
 ) -> int:
     try:
         raw = stdin.read()
-        event = parse_event(raw)
-    except (json.JSONDecodeError, KeyError) as e:
+        envelope = json.loads(raw)
+    except json.JSONDecodeError as e:
         print(f"mneme-hook: bad envelope: {e}", file=stderr)
         return 0
-
-    if not should_check(event.tool_name):
-        return 0
-
-    memory = find_memory(Path(event.cwd or "."))
-    if memory is None:
-        return 0
+    return handle_event(envelope, stderr, stdout)
 
     try:
         # The gate checks what this edit introduces, not the whole resulting

--- a/mneme/integrations/claude_code/session_state.py
+++ b/mneme/integrations/claude_code/session_state.py
@@ -1,0 +1,243 @@
+"""ADR-021 session state: baseline capture and session-delta attribution.
+
+One snapshot per (repository root, Claude session_id), stored outside the
+governed repository in the platform temp directory. The snapshot records
+SHA-256, size, and UTF-8 body for every tracked and untracked-but-not-ignored
+artifact under the policy root, within per-artifact and total budgets;
+oversized or non-text artifacts are hash-only.
+
+The delta attributes to the session exactly what ADR-018 attributes to an
+edit: inserted or replaced lines of a deterministic diff between the
+baseline body and the current body. New artifacts introduce everything;
+deleted artifacts introduce nothing and are reported separately so that
+deletion-only remediation can never be blocked.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+SNAPSHOT_VERSION = 1
+SNAPSHOT_DIR_NAME = "mneme-sessions"
+MAX_FILE_BYTES = 256 * 1024            # per-artifact body budget
+MAX_TOTAL_BYTES = 32 * 1024 * 1024     # aggregate body budget
+STALE_SNAPSHOT_SECONDS = 7 * 24 * 3600
+
+
+@dataclass
+class SessionDelta:
+    new: List[str] = field(default_factory=list)
+    modified: Dict[str, str] = field(default_factory=dict)   # rel -> introduced text
+    deleted: List[str] = field(default_factory=list)
+    skipped: Dict[str, str] = field(default_factory=dict)  # rel -> reason
+
+
+def state_dir() -> Path:
+    override = os.environ.get("MNEME_SESSION_STATE_DIR")
+    base = Path(override) if override else Path(tempfile.gettempdir())
+    return base / SNAPSHOT_DIR_NAME
+
+
+def _root_key(root: Path) -> str:
+    return hashlib.sha256(str(root.resolve()).encode("utf-8")).hexdigest()[:16]
+
+
+def _safe_session_id(session_id: str) -> str:
+    cleaned = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+    return cleaned[:80] or "unknown"
+
+
+def snapshot_path(root: Path, session_id: str) -> Path:
+    return (
+        state_dir()
+        / f"{_root_key(root)}-{_safe_session_id(session_id)}.json"
+    )
+
+
+def enumerate_repo_files(root: Path) -> Optional[List[str]]:
+    """Policy-root-relative POSIX paths of tracked + untracked-not-ignored files.
+
+    Returns None when git is unavailable or root is not inside a work tree,
+    which callers must surface as an explicit operational state.
+    """
+    if shutil.which("git") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z",
+             "--cached", "--others", "--exclude-standard"],
+            capture_output=True, text=True, check=False, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = []
+    for entry in proc.stdout.split("\0"):
+        if entry:
+            out.append(entry.replace("\\", "/"))
+    return sorted(set(out))
+
+
+def _hash_and_body(path: Path, budget_left: int) -> Dict[str, object]:
+    data = path.read_bytes()
+    entry: Dict[str, object] = {
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size": len(data),
+        "content": None,
+    }
+    if len(data) <= MAX_FILE_BYTES and budget_left >= len(data):
+        try:
+            entry["content"] = data.decode("utf-8")
+        except UnicodeDecodeError:
+            entry["content"] = None  # binary artifact: hash-only
+    return entry
+
+
+def capture_baseline(root: Path) -> dict:
+    files = enumerate_repo_files(root) or []
+    entries: Dict[str, dict] = {}
+    spent = 0
+    for rel in files:
+        abs_path = root / rel
+        try:
+            if not abs_path.is_file():
+                continue
+            entry = _hash_and_body(abs_path, MAX_TOTAL_BYTES - spent)
+            content = entry.get("content")
+            if isinstance(content, str):
+                spent += len(content.encode("utf-8"))
+            entries[rel] = entry
+        except OSError:
+            continue
+    return {
+        "version": SNAPSHOT_VERSION,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "root": str(Path(root).resolve()),
+        "files": entries,
+    }
+
+
+def load_snapshot(path: Path, expected_root: Optional[Path] = None) -> Optional[dict]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("version") != SNAPSHOT_VERSION:
+        return None
+    if not isinstance(raw.get("files"), dict):
+        return None
+    if expected_root is not None:
+        stored_root = raw.get("root")
+        if not isinstance(stored_root, str):
+            return None
+        try:
+            if Path(stored_root).resolve() != Path(expected_root).resolve():
+                return None
+        except OSError:
+            return None
+    return raw
+
+
+def save_snapshot(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def cleanup_stale(max_age_seconds: int = STALE_SNAPSHOT_SECONDS) -> List[str]:
+    removed: List[str] = []
+    directory = state_dir()
+    try:
+        now = time.time()
+        for p in directory.glob("*.json"):
+            try:
+                if now - p.stat().st_mtime > max_age_seconds:
+                    p.unlink(missing_ok=True)
+                    removed.append(p.name)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return removed
+
+
+def _is_snapshot_artifact(root: Path, rel: str) -> bool:
+    """True when a repository-relative path lands in the snapshot store.
+
+    Guards against MNEME_SESSION_STATE_DIR being placed inside the governed
+    tree: snapshots must never audit themselves or they would perpetually
+    appear as session deltas.
+    """
+    try:
+        resolved = (root / rel).resolve()
+        return state_dir() in resolved.parents
+    except OSError:
+        return False
+
+
+def compute_session_delta(
+    root: Path,
+    baseline: dict,
+    current_files: Optional[List[str]] = None,
+) -> SessionDelta:
+    """Diff current repository state against the baseline snapshot."""
+    # Local import keeps this module decoupled from the hook shim's CLI surface.
+    from mneme.integrations.claude_code.hook import introduced_between
+
+    delta = SessionDelta()
+    before_files: Dict[str, dict] = baseline.get("files", {})
+    after_names = current_files if current_files is not None else (enumerate_repo_files(root) or [])
+    after_names = [rel for rel in after_names if not _is_snapshot_artifact(root, rel)]
+
+    for rel in after_names:
+        abs_path = root / rel
+        before = before_files.get(rel)
+        try:
+            if not abs_path.is_file():
+                if before is not None:
+                    delta.deleted.append(rel)
+                continue
+            data = abs_path.read_bytes()
+        except OSError as exc:
+            delta.skipped[rel] = f"unreadable during evaluation: {exc}"
+            continue
+        current_sha = hashlib.sha256(data).hexdigest()
+
+        if before is None:
+            delta.new.append(rel)
+            continue
+
+        if before.get("sha256") == current_sha:
+            continue
+
+        body = before.get("content")
+        if not isinstance(body, str):
+            delta.skipped[rel] = (
+                "baseline body unavailable (binary artifact or over the "
+                "snapshot size budget); session delta not evaluated"
+            )
+            continue
+        try:
+            current_text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            delta.skipped[rel] = (
+                "current bytes are not valid UTF-8; session delta not evaluated"
+            )
+            continue
+        introduced = introduced_between(body, current_text)
+        if introduced.strip():
+            delta.modified[rel] = introduced
+
+    return delta

--- a/mneme/integrations/claude_code/shell_preflight.py
+++ b/mneme/integrations/claude_code/shell_preflight.py
@@ -1,0 +1,235 @@
+"""ADR-021 shell preflight: classify Bash tool input; reconstruct heredoc writes.
+
+Classification is conservative and deterministic. Only one grammar is
+reconstructable (class A): a single simple `cat` command redirecting a
+quoted-delimiter here-document to one plain path token:
+
+    cat >  <path> << 'DELIM'   (overwrite)
+    cat >> <path> << "DELIM"   (append)
+
+A quoted delimiter suppresses every expansion, so the document body is
+byte-identical to what the shell will store. Everything else is class B
+(potentially mutating) unless provably read-only (class C). Classification
+alone never blocks anything; only class A reaches the checker, and only its
+trusted verdict can block. See ADR-021.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Tuple, Union
+
+
+class Classification(str, Enum):
+    RECONSTRUCTABLE = "RECONSTRUCTABLE"
+    POTENTIALLY_MUTATING = "POTENTIALLY_MUTATING"
+    NON_MUTATING = "NON_MUTATING"
+
+
+@dataclass(frozen=True)
+class ReconstructedWrite:
+    """A deterministically provable repository mutation."""
+
+    target_path: str       # exactly as spelled in the command
+    proposed_content: str  # full document body, newline-terminated
+    append: bool
+
+
+# ── tokenizer ────────────────────────────────────────────────────────────────
+#
+# A tiny lexer for ONE command line: words separated by whitespace, single or
+# double quoted spans (taken literally), and the operators >>, >, <<. Anything
+# this lexer cannot handle makes the command non-reconstructable, which is the
+# safe direction.
+
+Token = Tuple[str, Union[str, None]]  # ("WORD"|"QWORD", text) | ("OP", op)
+
+
+class _LexerError(Exception):
+    pass
+
+
+def _tokenize_line(line: str) -> List[Token]:
+    tokens: List[Token] = []
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if ch in " \t":
+            i += 1
+            continue
+        if line.startswith(">>", i):
+            tokens.append(("OP", ">>"))
+            i += 2
+            continue
+        if ch == ">":
+            tokens.append(("OP", ">"))
+            i += 1
+            continue
+        if line.startswith("<<", i):
+            tokens.append(("OP", "<<"))
+            i += 2
+            continue
+        if ch in "<&|;()":
+            raise _LexerError(f"unsupported character {ch!r}")
+        if ch in "'\"":
+            quote = ch
+            i += 1
+            start = i
+            while i < n and line[i] != quote:
+                i += 1
+            if i >= n:
+                raise _LexerError("unterminated quote")
+            tokens.append(("QWORD", line[start:i]))
+            i += 1
+            continue
+        start = i
+        while i < n and line[i] not in " \t<>'\";&|()":
+            i += 1
+        tokens.append(("WORD", line[start:i]))
+    return tokens
+
+
+def _is_plain_path_token(word: str) -> bool:
+    if not word or word.startswith("-"):
+        return False
+    banned = "$`*?[]{}~!\n\r"
+    return not any(c in banned for c in word)
+
+
+def _parse_delim_token(token: Token) -> Optional[str]:
+    """Return the delimiter of a *quoted* heredoc tag token, else None.
+
+    Quoting ('EOF' or "EOF") is what makes the body literal. An unquoted
+    delimiter means expansion happens and the bytes are unknowable.
+    """
+    kind, word = token
+    if kind != "QWORD":
+        return None
+    if not word or "\n" in word:
+        return None
+    return word
+
+
+def reconstruct_heredoc_write(command: str) -> Optional[ReconstructedWrite]:
+    """Reconstruct the proposed mutation of a supported heredoc write, or None."""
+    if command is None:
+        return None
+    normalized = command.replace("\r\n", "\n").replace("\r", "\n")
+    stripped = normalized.strip("\n")
+    if not stripped.strip():
+        return None
+    first_nl = stripped.find("\n")
+    first_line = stripped if first_nl < 0 else stripped[:first_nl]
+    rest = "" if first_nl < 0 else stripped[first_nl + 1:]
+
+    try:
+        tokens = _tokenize_line(first_line)
+    except _LexerError:
+        return None
+
+    if len(tokens) != 5:
+        return None
+    kinds = [t[0] for t in tokens]
+    # Canonical shape only: cat REDIRECT PATH << 'DELIM'
+    if kinds != ["WORD", "OP", "WORD", "OP", "QWORD"]:
+        return None
+    (cat_w, redirect_t, path_t, heredoc_t, delim_t) = tokens
+    if cat_w[1] != "cat" or redirect_t[1] not in (">", ">>") or heredoc_t[1] != "<<":
+        return None
+    path = path_t[1]
+    delim = _parse_delim_token(delim_t)
+    if delim is None or not _is_plain_path_token(path):
+        return None
+
+    lines = rest.split("\n") if rest else []
+    body_lines: List[str] = []
+    terminated = False
+    trailing = False
+    for line in lines:
+        if terminated:
+            if line.strip():
+                # Anything after the closing delimiter is a separate command
+                # we have not reconstructed; refusing is the safe direction.
+                trailing = True
+            continue
+        if line == delim:
+            terminated = True
+            continue
+        body_lines.append(line)
+    if not terminated or trailing:
+        return None
+    body = "\n".join(body_lines) + "\n"
+    return ReconstructedWrite(
+        target_path=path,
+        proposed_content=body,
+        append=(redirect_t[1] == ">>"),
+    )
+
+
+# ── classification ───────────────────────────────────────────────────────────
+
+_POTENTIALLY_MUTATING_COMMANDS = frozenset({
+    "rm", "mv", "cp", "touch", "mkdir", "rmdir", "tee", "sed", "awk", "perl",
+    "ruby", "php", "lua", "chmod", "chown", "chgrp", "ln", "dd", "truncate",
+    "shred", "install", "patch", "make", "cmake", "cargo", "go", "gradle",
+    "mvn", "npm", "npx", "yarn", "pnpm", "pip", "pip3", "pipx", "uv", "poetry",
+    "git", "sh", "bash", "zsh", "dash", "ksh", "pwsh", "pwsh-preview",
+    "powershell", "cmd", "dotnet", "javac", "java", "rustc", "gcc", "clang",
+})
+
+_READ_ONLY_GIT_SUBCOMMANDS = frozenset({
+    "status", "log", "show", "diff", "branch", "tag", "blame", "rev-parse",
+    "ls-files", "ls-remote", "describe", "remote", "config", "help",
+})
+
+
+def _first_word(command: str) -> str:
+    for part in command.split():
+        return part
+    return ""
+
+
+def _looks_mutating(command: str) -> bool:
+    """Conservative heuristic used ONLY for diagnostic trace metadata."""
+    head = _first_word(command).lower()
+    base = head.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if base in _POTENTIALLY_MUTATING_COMMANDS:
+        if base == "git":
+            parts = command.split()
+            if len(parts) > 1 and parts[1] in _READ_ONLY_GIT_SUBCOMMANDS:
+                return False
+        return True
+    for marker in (">>", "<<", "&&", "||", ";", "|", "&", "`", "$(", "$("):
+        if marker in command:
+            return True
+    if ">" in command or "<" in command:
+        return True
+    return False
+
+
+_SAFE_READ_ONLY_COMMANDS = frozenset({
+    "ls", "pwd", "echo", "printf", "cat", "head", "tail", "wc", "grep", "rg",
+    "findstr", "which", "type", "where", "whoami", "hostname", "date", "env",
+    "printenv", "uname", "id", "groups", "tty", "true", "false", "test",
+    "diff", "cmp", "stat", "du", "df", "ps", "jobs", "sleep", "seq", "expr",
+    "basename", "dirname", "realpath", "readlink", "sort", "uniq", "cut",
+    "tr", "column", "nl", "od", "hexdump", "md5sum", "sha256sum", "cksum",
+    "git", "file",
+})
+
+
+def classify_command(command: str) -> Classification:
+    if reconstruct_heredoc_write(command) is not None:
+        return Classification.RECONSTRUCTABLE
+    if _looks_mutating(command):
+        return Classification.POTENTIALLY_MUTATING
+    head = _first_word(command).lower()
+    base = head.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if base in _SAFE_READ_ONLY_COMMANDS:
+        if base == "git":
+            sub = command.split()[1:2]
+            if sub and sub[0] in _READ_ONLY_GIT_SUBCOMMANDS:
+                return Classification.NON_MUTATING
+            return Classification.POTENTIALLY_MUTATING
+        return Classification.NON_MUTATING
+    return Classification.POTENTIALLY_MUTATING

--- a/scripts/install_claude_code.py
+++ b/scripts/install_claude_code.py
@@ -22,14 +22,21 @@ def _merge_settings(target: Path, template: dict) -> dict:
     if target.exists():
         existing = json.loads(target.read_text(encoding="utf-8"))
     hooks = existing.setdefault("hooks", {})
-    pre = hooks.setdefault("PreToolUse", [])
-    # Idempotency: don't double-add our matcher.
-    for entry in pre:
-        if entry.get("matcher") == "Edit|Write|MultiEdit" and any(
-            h.get("command") == "mneme-hook" for h in entry.get("hooks", [])
-        ):
-            return existing
-    pre.extend(template["hooks"]["PreToolUse"])
+    for event_name, template_groups in template["hooks"].items():
+        target_groups = hooks.setdefault(event_name, [])
+        for group in template_groups:
+            matcher = group.get("matcher", "")
+            already = any(
+                g.get("matcher", "") == matcher
+                and all(
+                    any(h.get("command") == nh.get("command") for h in g.get("hooks", []))
+                    for nh in group.get("hooks", [])
+                )
+                for g in target_groups
+            )
+            # Idempotency: don't double-add a matcher we already installed.
+            if not already:
+                target_groups.append(group)
     return existing
 
 

--- a/tests/integrations/claude_code/test_hooks_coverage_config.py
+++ b/tests/integrations/claude_code/test_hooks_coverage_config.py
@@ -1,0 +1,62 @@
+"""ADR-021: hook wiring contract for the expanded coverage surface.
+
+Both the flat template and the plugin bundle must register:
+  PreToolUse matcher Edit|Write|MultiEdit|Bash
+  SessionStart (baseline capture)
+  Stop (session-delta backstop)
+All entries use exec-form direct invocation of mneme-hook.
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CONFIGS = [
+    ROOT / "integrations" / "claude-code" / "hooks.json",
+    ROOT / "integrations" / "claude-code-plugin" / "hooks" / "hooks.json",
+]
+
+
+def _hooks(path):
+    return json.loads(path.read_text(encoding="utf-8"))["hooks"]
+
+
+def test_both_configs_exist():
+    for path in CONFIGS:
+        assert path.is_file(), f"missing {path}"
+
+
+def test_pre_tool_use_covers_bash_and_direct_tools():
+    for path in CONFIGS:
+        pre = _hooks(path)["PreToolUse"]
+        matchers = [g.get("matcher", "") for g in pre]
+        combined = "|".join(matchers)
+        for tool in ("Edit", "Write", "MultiEdit", "Bash"):
+            assert tool in combined, f"{path}: PreToolUse must cover {tool}"
+
+
+def test_stop_event_registered():
+    for path in CONFIGS:
+        stop = _hooks(path).get("Stop")
+        assert stop, f"{path}: Stop boundary missing"
+        cmds = [h["command"] for g in stop for h in g["hooks"]]
+        assert "mneme-hook" in cmds
+
+
+def test_session_start_event_registered():
+    for path in CONFIGS:
+        start = _hooks(path).get("SessionStart")
+        assert start, f"{path}: SessionStart baseline capture missing"
+        cmds = [h["command"] for g in start for h in g["hooks"]]
+        assert "mneme-hook" in cmds
+
+
+def test_all_handlers_exec_form():
+    for path in CONFIGS:
+        for event, groups in _hooks(path).items():
+            for g in groups:
+                for h in g["hooks"]:
+                    assert h["command"] == "mneme-hook"
+                    if "args" in h:
+                        assert h["args"] == []
+                    for banned in ("&&", ";", "$(", "|"):
+                        assert banned not in h["command"]

--- a/tests/integrations/claude_code/test_plugin_contract.py
+++ b/tests/integrations/claude_code/test_plugin_contract.py
@@ -55,7 +55,7 @@ def test_hook_uses_exec_form_direct_invocation():
     pre = hooks["hooks"]["PreToolUse"]
     assert len(pre) == 1
     group = pre[0]
-    assert group["matcher"] == "Edit|Write|MultiEdit"
+    assert group["matcher"] == "Edit|Write|MultiEdit|Bash"
     inner = group["hooks"]
     assert len(inner) == 1
     hook = inner[0]

--- a/tests/integrations/claude_code/test_session_delta.py
+++ b/tests/integrations/claude_code/test_session_delta.py
@@ -1,0 +1,182 @@
+"""ADR-021: session baseline capture and delta attribution.
+
+The baseline is captured once per session; only inserted/replaced lines of
+the session's own diff may be attributed to it. Pre-session dirty state,
+untouched untracked artifacts, and deletions must never be attributed.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mneme.integrations.claude_code import session_state as ss
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(tmp_path / "state"))
+    (tmp_path / "state").mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(
+        ["git", "-C", str(work), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "--allow-empty", "-m", "init"],
+        check=True,
+    )
+    return work
+
+
+def _tracked(repo: Path, rel: str, body: str):
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", rel], check=True)
+
+
+def _commit(repo: Path, msg="c"):
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", msg],
+        check=True,
+    )
+
+
+def _capture(repo: Path) -> dict:
+    return ss.capture_baseline(repo)
+
+
+class TestEnumeration:
+    def test_lists_tracked_and_untracked_not_ignored(self, repo):
+        _tracked(repo, "src/a.py", "a = 1\n")
+        _tracked(repo, ".gitignore", "ignored*\n")
+        _commit(repo)
+        (repo / "src" / "b.py").write_text("b = 2\n", encoding="utf-8")      # untracked
+        (repo / "ignored.log").write_text("x\n", encoding="utf-8")           # ignored
+        files = ss.enumerate_repo_files(repo)
+        assert files is not None
+        assert "src/a.py" in files
+        assert "src/b.py" in files
+        assert "ignored.log" not in files
+        assert all("\\" not in f for f in files)
+
+    def test_non_git_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(tmp_path / "state"))
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert ss.enumerate_repo_files(plain) is None
+
+
+class TestDelta:
+    def test_new_untracked_attributed_in_full(self, repo):
+        (repo / "gen.py").write_text("x = 1\n", encoding="utf-8")
+        base = _capture(repo)
+        (repo / "gen.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+        # gen.py existed at capture time (untracked), then grew.
+        d = ss.compute_session_delta(repo, base)
+        assert "gen.py" in d.modified
+        assert d.modified["gen.py"] == "y = 2"
+
+    def test_brand_new_artifact_introduces_everything(self, repo):
+        base = _capture(repo)
+        (repo / "new.py").write_text("a = 1\n", encoding="utf-8")
+        d = ss.compute_session_delta(repo, base)
+        assert "new.py" in d.new
+        assert "new.py" not in d.modified
+
+    def test_pre_session_dirty_untouched_not_attributed(self, repo):
+        (repo / "dirty.py").write_text("bad = 1\n", encoding="utf-8")  # untracked, pre-delta
+        base = _capture(repo)
+        d = ss.compute_session_delta(repo, base)
+        assert "dirty.py" not in d.new
+        assert "dirty.py" not in d.modified
+
+    def test_edit_to_dirty_artifact_attributes_only_own_lines(self, repo):
+        (repo / "dirty.py").write_text("keep_old_violation = 1\nstable = 0\n", encoding="utf-8")
+        base = _capture(repo)
+        (repo / "dirty.py").write_text(
+            "keep_old_violation = 1\nstable = 0\nfresh_line = 3\n", encoding="utf-8"
+        )
+        d = ss.compute_session_delta(repo, base)
+        assert d.modified["dirty.py"] == "fresh_line = 3"
+
+    def test_removing_preexisting_lines_introduces_nothing(self, repo):
+        (repo / "f.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        base = _capture(repo)
+        (repo / "f.py").write_text("a = 1\n", encoding="utf-8")
+        d = ss.compute_session_delta(repo, base)
+        assert "f.py" not in d.modified, "a removal introduces no content"
+
+    def test_deletion_reported_separately_never_as_content(self, repo):
+        _tracked(repo, "gone.py", "x = 1\n")
+        _commit(repo)
+        base = _capture(repo)
+        (repo / "gone.py").unlink()
+        d = ss.compute_session_delta(repo, base)
+        assert "gone.py" in d.deleted
+        assert "gone.py" not in d.modified
+        assert "gone.py" not in d.new
+
+    def test_unchanged_tracked_artifact_skipped(self, repo):
+        _tracked(repo, "same.py", "x = 1\n")
+        _commit(repo)
+        base = _capture(repo)
+        d = ss.compute_session_delta(repo, base)
+        assert "same.py" not in d.modified and "same.py" not in d.new
+
+
+class TestSnapshotStore:
+    def test_snapshot_lands_outside_repo_and_keys_by_root_and_session(self, repo, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(state_dir))
+        p1 = ss.snapshot_path(repo, "sess-a")
+        p2 = ss.snapshot_path(repo, "sess-b")
+        other = tmp_path / "other-repo"
+        other.mkdir()
+        p3 = ss.snapshot_path(other, "sess-a")
+        assert p1 != p2 != p3
+        assert state_dir in p1.parents
+        assert repo not in p1.parents
+
+    def test_save_and_load_roundtrip(self, repo, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(state_dir))
+        snap = ss.capture_baseline(repo)
+        path = ss.snapshot_path(repo, "s1")
+        ss.save_snapshot(path, snap)
+        loaded = ss.load_snapshot(path)
+        assert loaded == snap
+
+    def test_corrupt_snapshot_loads_as_none(self, repo, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(state_dir))
+        path = ss.snapshot_path(repo, "s1")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not json", encoding="utf-8")
+        assert ss.load_snapshot(path) is None
+
+    def test_foreign_root_snapshot_loads_as_none(self, repo, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(state_dir))
+        snap = ss.capture_baseline(repo)
+        path = ss.snapshot_path(repo, "s1")
+        ss.save_snapshot(path, snap)
+        assert ss.load_snapshot(path, expected_root=repo) is not None
+        moved = json.loads(json.dumps(snap))
+        moved["root"] = str(tmp_path / "somewhere-else")
+        path.write_text(json.dumps(moved), encoding="utf-8")
+        assert ss.load_snapshot(path, expected_root=repo) is None
+
+    def test_oversized_artifact_hashed_but_body_absent(self, repo, monkeypatch):
+        big = repo / "big.txt"
+        big.write_text("x" * (ss.MAX_FILE_BYTES + 10), encoding="utf-8")
+        snap = ss.capture_baseline(repo)
+        entry = snap["files"]["big.txt"]
+        assert entry["content"] is None
+        assert len(entry["sha256"]) == 64
+
+    def test_non_utf8_artifact_hashed_but_body_absent(self, repo):
+        (repo / "blob.bin").write_bytes(b"\xff\xfe\x00binary")
+        snap = ss.capture_baseline(repo)
+        assert snap["files"]["blob.bin"]["content"] is None

--- a/tests/integrations/claude_code/test_shell_gate_dispatch.py
+++ b/tests/integrations/claude_code/test_shell_gate_dispatch.py
@@ -1,0 +1,134 @@
+"""ADR-021: the PreToolUse Bash gate, driven through the event dispatcher.
+
+A reconstructable violating shell mutation must be refused BEFORE execution;
+compliant ones pass; ambiguous mutating commands are never preflight-blocked
+on guessed semantics.
+"""
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from mneme.integrations.claude_code.hook import handle_event
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _bash_event(cwd, command):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": str(cwd),
+        "tool_input": {"command": command},
+    }
+
+
+def _run(event):
+    err, out = io.StringIO(), io.StringIO()
+    rc = handle_event(event, stderr=err, stdout=out)
+    return rc, err.getvalue(), out.getvalue()
+
+
+def test_violating_heredoc_refused_before_execution(project):
+    """The command is refused; the target artifact never receives it."""
+    target = project / "storage_db.py"
+    assert not target.exists()
+    rc, err, _ = _run(_bash_event(project, "cat > storage_db.py << 'EOF'\nimport psycopg2\nEOF"))
+    assert rc == 2
+    assert "psycopg2" in err or "test_001" in err
+    assert not target.exists(), "refusal must precede any disk mutation"
+
+
+def test_compliant_heredoc_passes(project):
+    rc, _, _ = _run(_bash_event(project, "cat > storage_db.py << 'EOF'\nimport sqlite3\nEOF"))
+    assert rc == 0
+
+
+def test_append_checks_only_appended_lines(project):
+    existing = project / "storage_db.py"
+    existing.write_text("import sqlite3\n", encoding="utf-8")
+    rc, err, _ = _run(
+        _bash_event(project, "cat >> storage_db.py << 'EOF'\nimport psycopg2\nEOF")
+    )
+    assert rc == 2
+    # The untouched pre-existing line must not be part of the checked delta.
+    assert "sqlite3" not in err
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "perl -e \"print 'x'\" > out.txt",
+        "./tools/generate.sh",
+        "echo hi | tee out.txt",
+        "cd src && cat > db.py << 'EOF'\nx\nEOF",
+        # Unquoted delimiter: expansion makes the resulting bytes unknowable.
+        "cat > storage_db.py << EOF\nimport psycopg2\nEOF",
+    ],
+)
+def test_ambiguous_mutating_command_not_preflight_refused(project, cmd):
+    """Class B passes through; the Stop boundary audits its results."""
+    rc, err, out = _run(_bash_event(project, cmd))
+    assert rc == 0
+    assert "permissionDecision" not in out
+
+
+def test_non_mutating_command_unaffected(project):
+    rc, _, _ = _run(_bash_event(project, "ls -la"))
+    assert rc == 0
+
+
+def test_malformed_input_deterministic_no_op(project):
+    for cmd in ("", "   ", "cat > a.txt << 'EOF'\nunterminated"):
+        rc, _, _ = _run(_bash_event(project, cmd))
+        assert rc == 0, f"{cmd!r} must fail operational, deterministically"
+
+
+def test_absent_memory_passthrough(tmp_path):
+    rc, _, _ = _run(_bash_event(tmp_path, "cat > a.py << 'EOF'\nimport psycopg2\nEOF"))
+    assert rc == 0
+
+
+def test_real_target_path_reaches_checker(project, monkeypatch):
+    """ADR-020: applicability must see the true repository-relative path."""
+    captured = {}
+
+    import mneme.integrations.claude_code.hook as hook
+
+    real_invoke = hook._invoke_check
+
+    def spy(memory, rel_label, target_path, body, *args, **kwargs):
+        captured["target"] = target_path
+        return real_invoke(memory, rel_label, target_path, body, *args, **kwargs)
+
+    monkeypatch.setattr(hook, "_invoke_check", spy)
+    rc, _, _ = _run(
+        _bash_event(project, "cat > src/deep/storage_db.py << 'EOF'\nimport psycopg2\nEOF")
+    )
+    assert rc == 2
+    assert Path(captured["target"]) == project / "src" / "deep" / "storage_db.py"
+
+
+def test_warn_mode_defers_never_allows_bash_gate(project, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    out = io.StringIO()
+    rc = handle_event(
+        _bash_event(project, "cat > storage_db.py << 'EOF'\nimport psycopg2\nEOF"),
+        stderr=io.StringIO(),
+        stdout=out,
+    )
+    assert rc == 0
+    emitted = json.loads(out.getvalue())
+    hso = emitted["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "defer"
+    assert "psycopg2" in hso["permissionDecisionReason"]

--- a/tests/integrations/claude_code/test_shell_preflight.py
+++ b/tests/integrations/claude_code/test_shell_preflight.py
@@ -1,0 +1,155 @@
+"""ADR-021: shell preflight classification and reconstruction.
+
+The classifier must be conservative and deterministic: only quoted-delimiter
+heredoc writes through `cat >`/`cat >>` are reconstructable; everything else
+is potentially mutating unless provably read-only.
+"""
+import pytest
+
+from mneme.integrations.claude_code.shell_preflight import (
+    Classification,
+    classify_command,
+    reconstruct_heredoc_write,
+)
+
+
+class TestReconstruction:
+    def test_simple_overwrite(self):
+        rec = reconstruct_heredoc_write("cat > src/db.py << 'EOF'\nimport psycopg2\nEOF")
+        assert rec is not None
+        assert rec.target_path == "src/db.py"
+        assert rec.append is False
+        assert rec.proposed_content == "import psycopg2\n"
+
+    def test_double_quoted_delimiter_is_literal(self):
+        rec = reconstruct_heredoc_write('cat > out.txt << "MNEME"\nline $keep `raw`\nMNEME')
+        assert rec is not None
+        assert rec.proposed_content == "line $keep `raw`\n"
+
+    def test_append_form(self):
+        rec = reconstruct_heredoc_write("cat >> log.txt << 'EOF'\nappended\nEOF")
+        assert rec is not None
+        assert rec.append is True
+        assert rec.proposed_content == "appended\n"
+
+    def test_absolute_target(self):
+        rec = reconstruct_heredoc_write("cat > /etc/hosts.deny << 'X'\nall\nX")
+        assert rec is not None
+        assert rec.target_path == "/etc/hosts.deny"
+
+    def test_multiline_body_preserved_verbatim(self):
+        body = "def f():\n    return 1\n\n\n"
+        cmd = f"cat > a.py << 'EOF'\n{body}EOF"
+        rec = reconstruct_heredoc_write(cmd)
+        assert rec is not None
+        assert rec.proposed_content == body
+
+    def test_crlf_input_normalized(self):
+        rec = reconstruct_heredoc_write("cat > a.txt << 'EOF'\r\nhi\r\nEOF\r\n")
+        assert rec is not None
+        assert rec.proposed_content == "hi\n"
+
+
+class TestNonReconstructable:
+    """Cases that must NOT be treated as deterministic reconstruction."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # Unquoted delimiter: expansion happens, bytes unknowable.
+            "cat > out.txt << EOF\n$HOME\nEOF",
+            'cat > out.txt << EOF\n$(whoami)\nEOF',
+            # Tab-stripping delimiter has post-processing semantics.
+            "cat > out.txt <<- 'EOF'\nhi\nEOF",
+            # Pipelines / chains / substitutions.
+            "echo hi | tee out.txt",
+            "cd src && cat > db.py << 'EOF'\nx\nEOF",
+            "python -c \"open('a.py','w').write('x')\"",
+            "node -e 'require(\"fs\").writeFileSync(\"a\",\"b\")'",
+            "git checkout -- storage_db.py",
+            "./scripts/generate.sh",
+            # Multiple redirections.
+            "cat > a.txt << 'EOF'\nx\nEOF\ncat > b.txt << 'EOF'\ny\nEOF",
+            # Unterminated heredoc.
+            "cat > a.txt << 'EOF'\nno terminator",
+            # Redirect target with expansion.
+            "cat > $OUT << 'EOF'\nx\nEOF",
+            "cat > ~/fuzz/*.txt << 'EOF'\nx\nEOF",
+            # Not cat.
+            "tee a.txt << 'EOF'\nx\nEOF",
+            # Empty command.
+            "",
+            "   ",
+        ],
+    )
+    def test_not_reconstructable(self, cmd):
+        assert reconstruct_heredoc_write(cmd) is None
+
+    def test_delimiter_appearing_early_terminates_body(self):
+        """First line equal to the delimiter ends the document."""
+        cmd = "cat > a.txt << 'EOF'\nfirst\nEOF"
+        rec = reconstruct_heredoc_write(cmd)
+        assert rec is not None
+        assert rec.proposed_content == "first\n"
+
+    def test_trailing_content_after_delimiter_refused(self):
+        """A second command after the closing delimiter is not reconstructed."""
+        cmd = "cat > a.txt << 'EOF'\nfirst\nEOF\necho pwned > b.txt"
+        assert reconstruct_heredoc_write(cmd) is None
+
+
+class TestClassification:
+    def test_reconstructable_classified_a(self):
+        assert classify_command("cat > a.py << 'EOF'\nx\nEOF") is Classification.RECONSTRUCTABLE
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "rm -rf build/",
+            "mv a b",
+            "cp a b",
+            "touch a.txt",
+            "sed -i s/a/b/ f.txt",
+            "chmod +x run.sh",
+            "pip install requests",
+            "npm run build",
+            "python gen.py",
+            "make all",
+            "git commit -m x",
+            "echo hi > out.txt",
+            "ls | wc -l",
+            "foo_bar_unknown_binary --flag",
+            'sh -c "echo hi"',
+        ],
+    )
+    def test_potentially_mutating(self, cmd):
+        assert (
+            classify_command(cmd) is Classification.POTENTIALLY_MUTATING
+        ), f"{cmd!r} must not be classified safe"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "ls -la",
+            "pwd",
+            "cat README.md",
+            "grep -rn psycopg2 src/",
+            "head -n 5 file.txt",
+            "tail -20 log.txt",
+            "wc -l src/*.py",
+            "which python",
+            "file data.bin",
+            "diff a.txt b.txt",
+            "git status",
+            "git diff",
+            "git log --oneline -3",
+            "echo hello",
+        ],
+    )
+    def test_non_mutating(self, cmd):
+        assert classify_command(cmd) is Classification.NON_MUTATING
+
+    def test_classification_is_deterministic(self):
+        cmd = "cat > weird << 'D'\n$x\nD"
+        results = {classify_command(cmd) for _ in range(5)}
+        assert len(results) == 1

--- a/tests/integrations/claude_code/test_stop_boundary.py
+++ b/tests/integrations/claude_code/test_stop_boundary.py
@@ -1,0 +1,288 @@
+"""ADR-021: the Stop completion boundary.
+
+Post-mutation / pre-completion session-delta checks. The boundary blocks the
+turn on trusted verdicts over session-introduced lines only, honors
+stop_hook_active, and degrades visibly (never a fabricated pass) when
+attribution is unavailable.
+"""
+import io
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mneme.integrations.claude_code.hook import handle_event
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(tmp_path / "state"))
+    (tmp_path / "state").mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(
+        ["git", "-C", str(work), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "--allow-empty", "-m", "init"],
+        check=True,
+    )
+    (work / ".mneme").mkdir()
+    (work / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return work
+
+
+def _stop_event(cwd, **extra):
+    event = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-1",
+        "cwd": str(cwd),
+    }
+    event.update(extra)
+    return event
+
+
+def _session_start(cwd):
+    return {
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+        "session_id": "sess-1",
+        "cwd": str(cwd),
+    }
+
+
+def _run(event):
+    err, out = io.StringIO(), io.StringIO()
+    rc = handle_event(event, stderr=err, stdout=out)
+    return rc, err.getvalue(), out.getvalue()
+
+
+class TestBlocking:
+    def test_shell_generated_violation_blocks_stop(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        # An unsupported indirect mutation lands on disk.
+        target = repo / "storage_db.py"
+        target.write_text("import psycopg2\n", encoding="utf-8")
+        rc, err, out = _run(_stop_event(repo))
+        assert rc == 0  # Stop blocks via JSON decision, not exit code
+        decision = json.loads(out)
+        assert decision["decision"] == "block"
+        assert "psycopg2" in decision["reason"]
+        assert "storage_db.py" in decision["reason"]
+
+    def test_new_untracked_violation_blocks(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "fresh_violation.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert json.loads(out)["decision"] == "block"
+
+    def test_compliant_session_passes(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "clean.py").write_text("import sqlite3\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == ""
+
+    def test_repair_converges_without_new_baseline(self, repo):
+        """After a blocked Stop, fixing the delta must let the next Stop pass."""
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert json.loads(out)["decision"] == "block"
+        # Agent repairs.
+        (repo / "storage_db.py").write_text("import sqlite3\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == ""
+
+    def test_multiple_dirty_artifacts_names_the_right_one(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "fine.py").write_text("ok = True\n", encoding="utf-8")
+        (repo / "guilty.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        reason = json.loads(out)["reason"]
+        assert "guilty.py" in reason
+        assert "fine.py" not in reason
+
+    def test_deletion_only_remediation_never_blocks(self, repo):
+        (repo / "pre_bad.py").write_text("import psycopg2\n", encoding="utf-8")  # pre-session
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "pre_bad.py").unlink()
+        rc, _, out = _run(_stop_event(repo))
+        assert out.strip() == ""
+
+
+class TestAttribution:
+    def test_pre_session_violation_not_blamed(self, repo):
+        (repo / "legacy_wound.py").write_text("import psycopg2\n", encoding="utf-8")
+        assert _run(_session_start(repo))[0] == 0
+        # Claude does unrelated work.
+        (repo / "unrelated.txt").write_text("notes\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert out.strip() == "", "a pre-session violation must not block the session"
+
+    def test_unrelated_edit_to_wounded_artifact_not_blamed(self, repo):
+        wounded = repo / "wounded.py"
+        wounded.write_text("import psycopg2\nstable = 1\n", encoding="utf-8")
+        assert _run(_session_start(repo))[0] == 0
+        wounded.write_text("import psycopg2\nstable = 1\ninnocent = 2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert out.strip() == ""
+
+    def test_violation_on_top_of_dirty_lines_is_caught(self, repo):
+        wounded = repo / "wounded.py"
+        wounded.write_text("import psycopg2\nstable = 1\n", encoding="utf-8")
+        assert _run(_session_start(repo))[0] == 0
+        wounded.write_text(
+            "import psycopg2\nstable = 1\nguilty_addition = 'import psycopg2'\n",
+            encoding="utf-8",
+        )
+        rc, _, out = _run(_stop_event(repo))
+        assert json.loads(out)["decision"] == "block"
+
+    def test_pre_session_untracked_untouched_not_attributed(self, repo):
+        (repo / "old_untracked.py").write_text("import psycopg2\n", encoding="utf-8")
+        assert _run(_session_start(repo))[0] == 0
+        rc, _, out = _run(_stop_event(repo))
+        assert out.strip() == ""
+
+
+class TestLoopSafetyAndDegrade:
+    def test_stop_hook_active_short_circuits_even_with_violations(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo, stop_hook_active=True))
+        assert rc == 0
+        assert "decision" not in out
+
+    def test_missing_baseline_created_visibly_no_block(self, repo):
+        # No SessionStart ran; a violation already sits in the tree.
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, err, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == "", "without a baseline nothing may be attributed"
+        assert "baseline" in err.lower()
+
+    def test_second_stop_after_late_baseline_enforces(self, repo):
+        rc, err, _ = _run(_stop_event(repo))  # creates late baseline
+        assert rc == 0
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert json.loads(out)["decision"] == "block"
+
+    def test_non_git_directory_reports_inactive(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(tmp_path / "state"))
+        (tmp_path / "state").mkdir()
+        (tmp_path / ".mneme").mkdir()
+        (tmp_path / ".mneme" / "project_memory.json").write_text(
+            FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        rc, err, out = _run(_stop_event(tmp_path))
+        assert rc == 0
+        assert out.strip() == ""
+        assert "git" in err.lower()
+
+    def test_corrupt_baseline_degrades_visibly(self, repo):
+        from mneme.integrations.claude_code import session_state as ss
+
+        snap_path = ss.snapshot_path(repo, "sess-1")
+        snap_path.parent.mkdir(parents=True, exist_ok=True)
+        snap_path.write_text("{ corrupt", encoding="utf-8")
+        rc, err, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == ""
+        assert "baseline" in err.lower()
+
+    def test_oversized_changed_artifact_reported_not_passed_silently(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        big = repo / "big.log"
+        big.write_text("x" * 20, encoding="utf-8")
+        # Re-capture is not done; simulate an oversized baseline entry instead.
+        from mneme.integrations.claude_code import session_state as ss
+
+        path = ss.snapshot_path(repo, "sess-1")
+        snap = ss.load_snapshot(path)
+        snap["files"]["big.log"] = {
+            "sha256": "0" * 64,
+            "size": ss.MAX_FILE_BYTES + 5,
+            "content": None,
+        }
+        ss.save_snapshot(path, snap)
+        big.write_text("y" * (ss.MAX_FILE_BYTES + 5), encoding="utf-8")
+        rc, err, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == ""
+        assert "big.log" in err
+
+    def test_crashing_checker_fails_open_with_diagnostics(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        (repo / ".mneme" / "project_memory.json").write_text(
+            "{ broken", encoding="utf-8"
+        )
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, err, out = _run(_stop_event(repo))
+        assert rc == 0
+        assert out.strip() == "", "an untrusted verdict must never block"
+        lowered = err.lower()
+        assert "fail" in lowered or "verdict" in lowered or "could not" in lowered
+
+    def test_warn_mode_reports_without_blocking(self, repo, monkeypatch):
+        monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+        assert _run(_session_start(repo))[0] == 0
+        (repo / "storage_db.py").write_text("import psycopg2\n", encoding="utf-8")
+        rc, _, out = _run(_stop_event(repo))
+        assert rc == 0
+        emitted = json.loads(out)
+        assert emitted["hookSpecificOutput"]["additionalContext"]
+        assert "decision" not in emitted
+
+
+class TestSessionStart:
+    def test_startup_captures_baseline(self, repo):
+        rc, err, out = _run(_session_start(repo))
+        assert rc == 0
+        from mneme.integrations.claude_code import session_state as ss
+
+        assert ss.load_snapshot(ss.snapshot_path(repo, "sess-1")) is not None
+
+    def test_compact_source_preserves_existing_baseline(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        from mneme.integrations.claude_code import session_state as ss
+
+        path = ss.snapshot_path(repo, "sess-1")
+        original = ss.load_snapshot(path)
+        original["files"]["marker.xyz"] = {"sha256": "1" * 64, "size": 1, "content": "z"}
+        ss.save_snapshot(path, original)
+
+        # compact/clear/resume must NOT refresh the baseline
+        event = {
+            "hook_event_name": "SessionStart",
+            "source": "compact",
+            "session_id": "sess-1",
+            "cwd": str(repo),
+        }
+        err, out = io.StringIO(), io.StringIO()
+        assert handle_event(event, stderr=err, stdout=out) == 0
+        kept = ss.load_snapshot(path)
+        assert "marker.xyz" in kept["files"]
+
+    def test_startup_refreshes_existing_baseline(self, repo):
+        assert _run(_session_start(repo))[0] == 0
+        from mneme.integrations.claude_code import session_state as ss
+
+        path = ss.snapshot_path(repo, "sess-1")
+        snap = ss.load_snapshot(path)
+        snap["files"]["stale.marker"] = {"sha256": "1" * 64, "size": 1, "content": "z"}
+        ss.save_snapshot(path, snap)
+        assert _run(_session_start(repo))[0] == 0
+        refreshed = ss.load_snapshot(path)
+        assert "stale.marker" not in refreshed["files"]
+
+    def test_absent_memory_is_a_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEME_SESSION_STATE_DIR", str(tmp_path / "state"))
+        rc, _, _ = _run(_session_start(tmp_path))
+        assert rc == 0


### PR DESCRIPTION
## 1. Problem

Claude Code enforcement covered exactly one surface: `PreToolUse` x `Edit|Write|MultiEdit`. Two pilot-blocking gaps followed:

- **Shell bypass** — `Bash` calls that write repository content never fired a file-edit hook and were never checked.
- **No completion boundary** — anything that escaped interception (ambiguous shell pipelines, generators, indirect script writes) was invisible until CI, long after the agent could repair it.

## 2. Previous coverage

Direct tools only: introduced-delta gate per ADR-018, typed-rule applicability via real target paths per ADR-020. Shell mutations: uncovered (documented openly in the plugin README). Completion: uncovered; `/mneme:review` was the manual compensating control.

## 3. New architecture: Prevent -> Catch -> Verify

| Stage | Surface | Guarantee |
|---|---|---|
| Prevent | `PreToolUse` x `Edit\|Write\|MultiEdit` | Deterministic pre-mutation checks on introduced lines (unchanged). |
| Prevent | `PreToolUse` x `Bash` | Pre-execution checks for explicitly supported reconstructable shell mutations. |
| Catch | `Stop` | Post-mutation / pre-completion session-delta checks; violations block completion with actionable reasons. |
| Verify | CI (`mneme check`) | Final repository boundary, unchanged. |

## 4. ADR alignment / new ADR

ADR-017/018/019/020 do not govern either new boundary. **New ADR-021** ("Shell Preflight Reconstruction and Stop Session-Delta Enforcement") records both, reusing ADR-018's introduced-line definition by reference rather than amending it. Alignment verified line by line:

- Retrieval untouched: same `"edit to <path>"` query construction reused verbatim; no changes to `DecisionRetriever`, scoring, weights, top-K, or guidance.
- No second enforcer: integration code only parses events, classifies commands, reconstructs deterministic proposals, computes the session delta, and calls the existing `_run_check`/CLI path with real target paths.
- ADR-020 authority preserved: every check carries `--target-path`; UNKNOWN stays `evaluation_complete:false` -> visible fail-open diagnostics, never silent PASS.

## 5. Exact supported Bash grammar (class A)

Single simple command, canonical token shape, no substitutions/pipelines/chains:

```
cat >  <path> << 'DELIM'   (overwrite)
cat >> <path> << "DELIM"   (append)
<body lines>
DELIM
```

Quoted delimiter => zero expansion => body is byte-literal. Path must be a plain unquoted token (no `$`, globs, leading `-`). Anything non-blank after the closing delimiter voids reconstruction. Append checks only appended lines via the ADR-018 diff.

## 6. Explicitly unsupported shell cases (class B — pass through, caught at Stop)

Pipelines, `&&`/`;` chains, command/variable substitution, unquoted or `<<-` delimiters, multiple redirects, `printf`/`echo` redirections, interpreters (`python -c`, `node -e`), build tools/generators, repo scripts, `cp`/`mv`/`git checkout`, unterminated heredocs, env-prefixed commands. Class B is never blocked on guessed semantics; classification metadata goes to stderr (debug-log only on exit 0).

## 7. Stop session-attribution mechanism

- `SessionStart` (`startup` source) snapshots tracked + untracked-not-ignored files under the policy root (SHA-256 + size + UTF-8 body within 256 KiB/file, 32 MiB total budgets) to `<tempdir>/mneme-sessions/<roothash>-<session_id>.json` — outside governed content, collision-free across concurrent sessions, stale-snapshot GC at startup.
- `resume`/`clear`/`compact`/`fork` preserve an existing baseline so compaction cannot launder mid-session deltas.
- At Stop: unchanged-hash files skipped; deletions ignored (deletion-only remediation passes); new files introduce everything; modified files contribute only inserted/replaced lines of the baseline->current diff (same `difflib` semantics as the edit gate).
- Explicit degraded states (never fabricated PASS): missing baseline -> late capture + visible diagnostic, nothing attributed retroactively; non-git -> gate reports inactive; oversized/binary/unreadable deltas listed as "not evaluated"; checker crash/timeout/untrusted verdict fails open per established transport policy.
- Honors `stop_hook_active` (immediate exit); harness's 8-consecutive-block cap remains the outer guard. Baseline is not refreshed after a block, so repairs converge.

## 8. Claim boundary

Allowed: deterministic pre-mutation checks for direct file tools; deterministic pre-execution checks for the supported shell grammar above; post-mutation/pre-completion session-delta checks through Stop; final verification in CI.
Forbidden: "all Bash writes are pre-generation enforced", "all shell commands are understood", "Stop prevents the original write", "retrieval quality controls deterministic rule checks".

## 9. Failing-first regression evidence

All five new test modules were written before implementation and failed collection (`ImportError: cannot import name 'handle_event'...`, missing `shell_preflight` module) before the feature commit; they pass after. Intermediate failures also drove fixes (quoted-delimiter detection, trailing-command rejection, foreign-root snapshot rejection).

## 10. Live smoke evidence (Claude Code v2.1.202, Windows, real sessions)

- **Smoke A (prevent):** scratch project with fixture memory; prompt asked Claude to create `storage_db.py` via `cat > storage_db.py << 'EOF'`. Result: `PreToolUse:Bash hook error ... mneme: FAIL ... trigger: psycopg2` — command refused, `storage_db.py` **never created** (verified absent on disk).
- **Smoke B (catch):** prompt asked for the violating write via `python -c` (class B). Stream-json trace: mutation landed -> `Stop hook feedback: mneme: repository mutations made during this session violate 1 governed artifact(s): [storage_db.py] mneme: FAIL ...` -> Claude repaired to `import sqlite3` -> subsequent Stop passed (`result: success`). Traces: `smoke-a`/`smoke-b` transcripts retained locally (temp dir), key excerpts above.

## 11. Full validation numbers

- Base SHA `b8379788fbb4a250bb9f267b8eb0346399181580`; final SHA `6380fc04` (this PR head).
- New focused tests: 105 passed (preflight 55, dispatch 11, delta 17, stop 21, config 5 - see modules for exact splits).
- Claude Code integration + Agent SDK suites: 233 passed (includes SDK integration-identity tests, untouched).
- Full suite: **714 passed, 5 skipped** (all 5 skips pre-existing: wheel tests requiring `python -m build` dist; platform-independent otherwise).
- Gates: encoding-check OK (1576 files), install-command gate OK, `mneme adr` freshness warnings are pre-existing (import refresh is a separate `[memory]` task).

## 12. Benchmark numbers (unchanged)

`mneme benchmark examples/benchmarks`: output byte-identical to origin/main (Compare-Object count = 0).

- Layer 2 (checks): 2/2 violations caught, pass rate 100%
- Layer 1 (retrieval, n=5): mean recall@3 = 0.00, mean precision@3 = 0.00, irrelevant-injection rate 100% — identical to base; fixtures/methodology untouched.

## 13. Files changed

- `docs/adr/ADR-021-shell-preflight-and-stop-session-delta.md` (new)
- `mneme/integrations/claude_code/hook.py` (dispatch + Bash gate + SessionStart/Stop handlers; `_invoke_check` extracted; direct-tool path behavior identical)
- `mneme/integrations/claude_code/shell_preflight.py` (new)
- `mneme/integrations/claude_code/session_state.py` (new)
- `integrations/claude-code/hooks.json`, `integrations/claude-code-plugin/hooks/hooks.json` (+Bash matcher, +SessionStart, +Stop)
- `scripts/install_claude_code.py` (idempotent merge now covers all three events)
- Docs: plugin README coverage table, flat README, `docs/integrations/claude-code.md`, SKILL.md
- Tests: 4 new modules + contract-test matcher update

## 14. Known limitations

- PowerShell tool surface not yet intercepted pre-execution (documented next coverage item; its mutations are still caught at Stop where git auditing works).
- Files added to `.gitignore` mid-session drop out of Stop enumeration; CI remains the boundary for that class.
- Stop requires git and UTF-8-readable artifacts within size budgets; degradation is visible, not silent.
- Snapshot cost scales with tracked text volume at session start/Stop (budgeted storage, full read pass).

## 15. Retrieval statement

Retrieval semantics were not touched: no changes to `DecisionRetriever`, scoring, weights, thresholds, top-K, role-aware guidance, or guidance formatting. The frozen benchmark output is byte-identical to base.
