### PR TITLE
ci: worktree context guard — task-owned worktree lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,46 @@ Use conventional prefixes: `feat/`, `fix/`, `site/`, `ci/`, `docs/`, `refactor/`
 
 **Known exception — auto-generated worktree branches:** Claude Code's `--worktree` flag emits `claude/<adjective>-<noun>-<hash>` branch names. This is a hard-coded harness behavior with no configuration override. These branches are acceptable during development. Before opening a PR, rename to follow the taxonomy where practical. The squash commit title on `main` must follow the taxonomy regardless of source branch name. See ADR-010.
 
+## Agent Execution Context Guard
+
+Worktrees in this repo share one `.git`. An agent that starts work in the wrong checkout inherits that checkout's branch and commits to it. Branch selection is therefore **not agent discretion**: the orchestrating task declares the expected context; the agent only verifies it.
+
+At the start of every agent task:
+
+- Run `git rev-parse --show-toplevel` and `git branch --show-current`.
+- Verify the repository root and branch match the task's declared worktree root and task branch.
+
+Immediately before every `git commit`:
+
+- Repeat the same assertion.
+- Abort on any mismatch or on a detached HEAD.
+
+The repo-owned checker automates this:
+
+```bash
+python scripts/check_worktree_context.py --expected-root <worktree-root> --expected-branch <task-branch>
+```
+
+It is read-only and fails closed (exit 1) with expected-vs-actual output on any mismatch. Never pass it values you did not receive from the task definition.
+
+## Worktree Lifecycle
+
+`C:/dev/mneme` is the administrative checkout. Keep it on `main` and do not use it for development work.
+
+Every distinct development task — human or agent — gets a fresh task-owned worktree and dedicated branch created from current `origin/main`.
+
+- Do not start a new task by switching branches inside an existing task worktree.
+- Do not reuse another task's worktree, even if it appears idle.
+- Follow-up changes for the same PR stay in that PR's existing worktree.
+- Before beginning work and immediately before every commit, assert the expected repository root and branch with `scripts/check_worktree_context.py`.
+- After the PR merges or an experiment is formally closed, remove the worktree and prune stale worktree metadata.
+
+The model is:
+
+```text
+one task → one branch → one worktree → one PR/outcome → teardown
+```
+
 ## Merging PRs
 
 Always squash merge. Use the PR title as the commit title. `main` history should read as intentional product decisions, not raw agent iteration.

--- a/scripts/check_worktree_context.py
+++ b/scripts/check_worktree_context.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Assert that the current execution context matches the task's declared identity.
+
+Agents working in shared repositories with multiple worktrees can inherit an
+unexpected checkout (wrong worktree, wrong branch, detached HEAD) and commit
+to it without noticing. This checker makes branch identity an explicit,
+verified precondition instead of agent discretion.
+
+The expected context is provided by the orchestrating task, never chosen by
+the agent. The checker is read-only: it never modifies repository state.
+
+Usage:
+  python scripts/check_worktree_context.py --expected-root PATH --expected-branch NAME
+
+Exit codes:
+  0  actual root == expected root AND branch == expected AND HEAD attached
+  1  any mismatch or missing argument (fail closed)
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def gather_state(repo: Path) -> dict[str, object]:
+    """Collect actual execution-context facts by querying git in `repo`."""
+    toplevel = _git(repo, "rev-parse", "--show-toplevel")
+    branch = _git(repo, "branch", "--show-current")
+    symbolic = _git(repo, "symbolic-ref", "-q", "HEAD")
+    return {
+        "toplevel": toplevel.stdout.strip() if toplevel.returncode == 0 else None,
+        "toplevel_ok": toplevel.returncode == 0,
+        "branch": branch.stdout.strip(),
+        "attached": symbolic.returncode == 0,
+    }
+
+
+def evaluate(state: dict[str, object], expected_root: Path, expected_branch: str) -> list[str]:
+    """Return a list of failure descriptions; empty list means PASS."""
+    failures: list[str] = []
+    if not state["toplevel_ok"]:
+        failures.append(f"not a git repository (or worktree): {expected_root}")
+        return failures
+    actual_root = Path(str(state["toplevel"])).resolve()
+    if actual_root != expected_root.resolve():
+        failures.append(
+            f"worktree mismatch:\n    expected root:   {expected_root.resolve()}\n"
+            f"    actual root:     {actual_root}"
+        )
+    if not state["attached"]:
+        failures.append("detached HEAD (no branch is checked out)")
+    elif state["branch"] != expected_branch:
+        failures.append(
+            f"branch mismatch:\n    expected branch: {expected_branch}\n"
+            f"    actual branch:   {state['branch']}"
+        )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--expected-root", required=True, help="worktree root this task must run in")
+    parser.add_argument("--expected-branch", required=True, help="branch this task must be on")
+    args = parser.parse_args(argv)
+
+    repo = Path.cwd()
+    state = gather_state(repo)
+    failures = evaluate(state, Path(args.expected_root), args.expected_branch)
+    if not failures:
+        print(
+            f"[context-check] OK (root={Path(str(state['toplevel'])).resolve()}, "
+            f"branch={state['branch']})"
+        )
+        return 0
+    print("[context-check] FAIL -- do not proceed; abort any pending commit")
+    for failure in failures:
+        print(f"  {failure}")
+    print("  Fix: switch to the declared worktree/branch for this task before continuing.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_worktree_context.py
+++ b/tests/test_check_worktree_context.py
@@ -1,0 +1,121 @@
+"""Tests for scripts/check_worktree_context.py.
+
+Each test builds a small real git repository in a tmp_path so the checker's
+subprocess calls run against actual git state, including the detached-HEAD
+condition which cannot be faked with mocks.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_worktree_context.py"
+
+spec = importlib.util.spec_from_file_location("check_worktree_context", SCRIPT)
+check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check)
+
+
+def _git(repo: Path, *args: str) -> None:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, encoding="utf-8"
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    git_repo = tmp_path / "repo"
+    git_repo.mkdir()
+    _git(git_repo, "init", "-b", "main")
+    _git(git_repo, "config", "user.email", "test@example.com")
+    _git(git_repo, "config", "user.name", "Test")
+    (git_repo / "file.txt").write_text("one\n", encoding="utf-8")
+    _git(git_repo, "add", "file.txt")
+    _git(git_repo, "commit", "-m", "first")
+    (git_repo / "file.txt").write_text("two\n", encoding="utf-8")
+    _git(git_repo, "add", "file.txt")
+    _git(git_repo, "commit", "-m", "second")
+    return git_repo
+
+
+def test_correct_branch_and_worktree_passes(repo: Path) -> None:
+    state = check.gather_state(repo)
+    failures = check.evaluate(state, repo, "main")
+    assert failures == []
+
+
+def test_wrong_branch_fails(repo: Path) -> None:
+    _git(repo, "switch", "-c", "other-task")
+    state = check.gather_state(repo)
+    failures = check.evaluate(state, repo, "main")
+    assert len(failures) == 1
+    assert "branch mismatch" in failures[0]
+    assert "expected branch: main" in failures[0]
+    assert "actual branch:   other-task" in failures[0]
+
+
+def test_wrong_worktree_fails(repo: Path, tmp_path: Path) -> None:
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    state = check.gather_state(repo)
+    failures = check.evaluate(state, other, "main")
+    assert len(failures) == 1
+    assert "worktree mismatch" in failures[0]
+
+
+def test_detached_head_fails(repo: Path) -> None:
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+    _git(repo, "checkout", "--detach", head)
+    state = check.gather_state(repo)
+    failures = check.evaluate(state, repo, "main")
+    assert len(failures) == 1
+    assert "detached HEAD" in failures[0]
+
+
+def test_missing_expected_branch_argument_fails(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        check.main(["--expected-root", str(REPO_ROOT)])
+    assert excinfo.value.code != 0
+    assert "required" in capsys.readouterr().err.lower()
+
+
+def test_missing_expected_root_argument_fails(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        check.main(["--expected-branch", "main"])
+    assert excinfo.value.code != 0
+    assert "required" in capsys.readouterr().err.lower()
+
+
+def test_main_passes_against_live_repo() -> None:
+    """Self-check: running main() against this checkout with its own facts passes."""
+    toplevel = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"], cwd=REPO_ROOT, capture_output=True, text=True
+    ).stdout.strip()
+    if not branch:
+        pytest.skip("tests are running from a detached HEAD checkout")
+    assert check.main(["--expected-root", str(toplevel), "--expected-branch", branch]) == 0
+
+
+def test_not_a_git_repository_fails(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    state = check.gather_state(empty)
+    failures = check.evaluate(state, empty, "main")
+    assert len(failures) == 1
+    assert "not a git repository" in failures[0]


### PR DESCRIPTION
## Summary

Establishes execution-context verification for agent/human development work, closing the branch-contamination failure mode observed in the #306 incident (a hook commit landing on a PR branch between two task commits).

## Changes

- \scripts/check_worktree_context.py\ — read-only checker that asserts actual repo root == expected worktree root, actual branch == expected task branch, and HEAD is attached. Fails closed (exit 1) with expected-vs-actual output. Expected context is declared by the orchestrating task, never chosen by the agent.
- \	ests/test_check_worktree_context.py\ — 8 tests against real git repos in tmp_path: pass case, wrong branch, wrong worktree, detached HEAD, missing either argument, not-a-repo, plus a live-repo self-check.
- \CLAUDE.md\ — two new sections:
  - **Agent Execution Context Guard**: startup + pre-commit assertion requirement
  - **Worktree Lifecycle**: \C:/dev/mneme\ is administrative-only (stays on \main\); one task → one branch → one worktree → one PR/outcome → teardown; no branch-switching or worktree reuse; teardown after merge

## Scope notes

- Does not touch retrieval/enforcement/benchmark semantics (no charter amendment needed per CONTRIBUTING.md).
- Consistent with ADR-010: verifies execution context rather than inferring/renaming branch names.
- Deliberately excludes \.git/hooks\ wiring and automatic worktree provisioning — that is the next separate change once each worktree has a mechanism to know its expected identity.