### PR TITLE
ci: automatic task-context provisioning and pre-commit worktree gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 .mneme/private*
 .mneme/*.local.json
 .mneme/secrets*
+.mneme/task_context.json
 
 # Working / scratch files (ADR-003 — not for deploy, not tracked)
 theovalmis_index.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ python scripts/check_worktree_context.py --expected-root <worktree-root> --expec
 
 It is read-only and fails closed (exit 1) with expected-vs-actual output on any mismatch. Never pass it values you did not receive from the task definition.
 
+Provisioning and the automatic commit gate:
+
+- Create each task worktree with `python scripts/new_task_worktree.py <branch>` — it creates the branch from current `origin/main` and writes `.mneme/task_context.json` inside the worktree.
+- When run without explicit arguments, the checker reads `.mneme/task_context.json`; the versioned pre-commit hook (`scripts/githooks/pre-commit`) runs it before every commit in worktrees that have a context file.
+- One-time setup for the hook: `git config core.hooksPath scripts/githooks`.
+
 ## Worktree Lifecycle
 
 `C:/dev/mneme` is the administrative checkout. Keep it on `main` and do not use it for development work.

--- a/scripts/check_worktree_context.py
+++ b/scripts/check_worktree_context.py
@@ -19,9 +19,12 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
+
+TASK_CONTEXT_FILENAME = ".mneme/task_context.json"
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -69,15 +72,49 @@ def evaluate(state: dict[str, object], expected_root: Path, expected_branch: str
     return failures
 
 
-def main(argv: list[str] | None = None) -> int:
+def load_task_context(repo: Path) -> dict[str, str] | None:
+    """Return the task context written by scripts/new_task_worktree.py, if any.
+
+    Expected shape: {"branch": "<task-branch>", "worktree": "<worktree-root>"}.
+    Returns None when the file does not exist; raises ValueError on malformed
+    content so callers can fail closed.
+    """
+    path = repo / TASK_CONTEXT_FILENAME
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "branch" not in data or "worktree" not in data:
+        raise ValueError(f"{TASK_CONTEXT_FILENAME} must be an object with 'branch' and 'worktree' keys")
+    return {"branch": str(data["branch"]), "worktree": str(data["worktree"])}
+
+
+def main(argv: list[str] | None = None, repo: Path | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("--expected-root", required=True, help="worktree root this task must run in")
-    parser.add_argument("--expected-branch", required=True, help="branch this task must be on")
+    parser.add_argument("--expected-root", default=None, help="worktree root this task must run in")
+    parser.add_argument("--expected-branch", default=None, help="branch this task must be on")
     args = parser.parse_args(argv)
 
-    repo = Path.cwd()
+    repo = repo or Path.cwd()
     state = gather_state(repo)
-    failures = evaluate(state, Path(args.expected_root), args.expected_branch)
+
+    expected_root = args.expected_root
+    expected_branch = args.expected_branch
+    if expected_root is None or expected_branch is None:
+        try:
+            context = load_task_context(repo)
+        except (json.JSONDecodeError, ValueError) as exc:
+            print("[context-check] FAIL -- malformed task context")
+            print(f"  {exc}")
+            return 1
+        if context is None:
+            print(f"[context-check] FAIL -- no explicit arguments and no {TASK_CONTEXT_FILENAME} found")
+            print("  Provision a task worktree with: python scripts/new_task_worktree.py <branch>")
+            print("  Or pass --expected-root/--expected-branch explicitly.")
+            return 1
+        expected_root = expected_root or context["worktree"]
+        expected_branch = expected_branch or context["branch"]
+
+    failures = evaluate(state, Path(expected_root), expected_branch)
     if not failures:
         print(
             f"[context-check] OK (root={Path(str(state['toplevel'])).resolve()}, "

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Repo-wide pre-commit gate (installed via: git config core.hooksPath scripts/githooks)
+#
+# 1. Block private/internal files from entering the public repo.
+#    Sensitive strategy, GTM, competitor, investor, and customer material
+#    belongs in the mneme-internal repo instead.
+# 2. Task context guard: if this worktree has a task context file (written by
+#    scripts/new_task_worktree.py), verify the commit is happening in the
+#    declared worktree on the declared branch. Worktrees without a context
+#    file (e.g. the administrative checkout) are skipped.
+
+blocked_patterns="private/ internal/ strategy/ gtm/ competitors/ investor-notes/ customer-notes/ .private.md .internal.md"
+
+for pattern in $blocked_patterns; do
+  if git diff --cached --name-only | grep -q "$pattern"; then
+    echo "ERROR: private/internal file detected matching pattern: $pattern"
+    echo "Move this file to the mneme-internal repo instead."
+    exit 1
+  fi
+done
+
+if [ -f .mneme/task_context.json ]; then
+  python scripts/check_worktree_context.py || exit 1
+fi
+
+exit 0

--- a/scripts/new_task_worktree.py
+++ b/scripts/new_task_worktree.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Provision a fresh task-owned worktree with its expected identity recorded.
+
+Implements the Worktree Lifecycle policy in CLAUDE.md:
+
+    one task -> one branch -> one worktree -> one PR/outcome -> teardown
+
+Creates a worktree and branch from the current base ref (default
+origin/main), then writes .mneme/task_context.json inside it so
+scripts/check_worktree_context.py (and the pre-commit hook) can verify
+execution context without being told explicitly.
+
+Usage:
+  python scripts/new_task_worktree.py <branch> [--path PATH] [--base REF]
+
+Defaults:
+  path = <repo-root>/.worktrees/<branch-slug>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    # Always operate on the repository that owns this script, regardless of
+    # the invoking shell's cwd. Otherwise a relative worktree path or fetch
+    # could silently target an unrelated checkout.
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, encoding="utf-8"
+    )
+
+
+def slugify(branch: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", branch).strip("-").lower()
+    return slug or "task"
+
+
+def create_task_worktree(branch: str, base: str, path: Path) -> int:
+    result = _git("fetch", "origin", "--prune")
+    if result.returncode != 0:
+        print(f"[new-task] fetch failed:\n{result.stderr}", file=sys.stderr)
+        return 1
+
+    result = _git("worktree", "add", str(path), "-b", branch, base)
+    if result.returncode != 0:
+        print(f"[new-task] worktree add failed:\n{result.stderr}", file=sys.stderr)
+        return 1
+
+    context_dir = path / ".mneme"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    context = {"branch": branch, "worktree": str(path)}
+    (context_dir / "task_context.json").write_text(
+        json.dumps(context, indent=2) + "\n", encoding="utf-8"
+    )
+
+    print(f"[new-task] worktree: {path}")
+    print(f"[new-task] branch:   {branch} (from {base})")
+    print(f"[new-task] context:  {context_dir / 'task_context.json'}")
+    print("[new-task] next: run your agent session in that directory;")
+    print("           scripts/check_worktree_context.py now verifies automatically.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("branch", help="dedicated task branch to create")
+    parser.add_argument("--path", default=None, help="worktree location (default .worktrees/<slug>)")
+    parser.add_argument("--base", default="origin/main", help="base ref (default origin/main)")
+    args = parser.parse_args(argv)
+
+    path = Path(args.path) if args.path else REPO_ROOT / ".worktrees" / slugify(args.branch)
+    if path.exists():
+        print(f"[new-task] FAIL -- path already exists: {path}", file=sys.stderr)
+        return 1
+    return create_task_worktree(args.branch, args.base, path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/new_task_worktree.py
+++ b/scripts/new_task_worktree.py
@@ -76,6 +76,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     path = Path(args.path) if args.path else REPO_ROOT / ".worktrees" / slugify(args.branch)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
     if path.exists():
         print(f"[new-task] FAIL -- path already exists: {path}", file=sys.stderr)
         return 1

--- a/tests/test_check_worktree_context.py
+++ b/tests/test_check_worktree_context.py
@@ -220,3 +220,31 @@ def test_git_calls_are_scoped_to_script_repo_root(provisioner, tmp_path, monkeyp
     assert result == 0
     assert recorded["cwd"] is not None
     assert Path(recorded["cwd"]).resolve() == REPO_ROOT.resolve()
+
+
+def test_relative_path_resolves_against_repo_root(provisioner, tmp_path, monkeypatch) -> None:
+    """Regression: a relative --path must land under REPO_ROOT even when the
+    invoking process runs from an unrelated cwd (git resolves relative paths
+    against its cwd=REPO_ROOT; python writes must agree)."""
+    fake_repo = tmp_path / "fake-repo"
+    fake_repo.mkdir()
+    monkeypatch.setattr(provisioner, "REPO_ROOT", fake_repo)
+
+    recorded = {}
+
+    def fake_run(cmd, **kwargs):
+        recorded["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    monkeypatch.chdir(unrelated_cwd)
+
+    exit_code = provisioner.main(["feat/rel-path", "--path", ".worktrees/foo", "--base", "origin/main"])
+
+    assert exit_code == 0
+    worktree = fake_repo / ".worktrees" / "foo"
+    assert (worktree / ".mneme" / "task_context.json").is_file()
+    context = json.loads((worktree / ".mneme" / "task_context.json").read_text(encoding="utf-8"))
+    assert context == {"branch": "feat/rel-path", "worktree": str(worktree)}

--- a/tests/test_check_worktree_context.py
+++ b/tests/test_check_worktree_context.py
@@ -7,6 +7,7 @@ condition which cannot be faked with mocks.
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -80,18 +81,19 @@ def test_detached_head_fails(repo: Path) -> None:
     assert "detached HEAD" in failures[0]
 
 
-def test_missing_expected_branch_argument_fails(capsys: pytest.CaptureFixture[str]) -> None:
-    with pytest.raises(SystemExit) as excinfo:
-        check.main(["--expected-root", str(REPO_ROOT)])
-    assert excinfo.value.code != 0
-    assert "required" in capsys.readouterr().err.lower()
+def test_missing_expected_branch_argument_falls_back_to_context_file(repo: Path) -> None:
+    """Without --expected-branch the checker falls back to .mneme/task_context.json."""
+    _write_task_context(repo, "main", repo)
+    assert check.main(["--expected-root", str(repo)], repo=repo) == 0
 
 
-def test_missing_expected_root_argument_fails(capsys: pytest.CaptureFixture[str]) -> None:
-    with pytest.raises(SystemExit) as excinfo:
-        check.main(["--expected-branch", "main"])
-    assert excinfo.value.code != 0
-    assert "required" in capsys.readouterr().err.lower()
+def test_missing_expected_root_argument_falls_back_to_context_file(repo: Path) -> None:
+    _write_task_context(repo, "main", repo)
+    assert check.main(["--expected-branch", "main"], repo=repo) == 0
+
+
+def test_missing_both_arguments_and_no_context_file_fails_closed(repo: Path) -> None:
+    assert check.main([], repo=repo) == 1
 
 
 def test_main_passes_against_live_repo() -> None:
@@ -119,3 +121,102 @@ def test_not_a_git_repository_fails(tmp_path: Path) -> None:
     failures = check.evaluate(state, empty, "main")
     assert len(failures) == 1
     assert "not a git repository" in failures[0]
+
+
+# --- task context file (.mneme/task_context.json) resolution ---
+
+
+def _write_task_context(repo: Path, branch: str, worktree: Path, raw: str | None = None) -> None:
+    context_dir = repo / ".mneme"
+    context_dir.mkdir(exist_ok=True)
+    if raw is not None:
+        (context_dir / "task_context.json").write_text(raw, encoding="utf-8")
+    else:
+        payload = {"branch": branch, "worktree": str(worktree)}
+        (context_dir / "task_context.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+
+def test_load_task_context_reads_file(repo: Path) -> None:
+    _write_task_context(repo, "feat/example", repo)
+    context = check.load_task_context(repo)
+    assert context == {"branch": "feat/example", "worktree": str(repo)}
+
+
+def test_load_task_context_missing_returns_none(repo: Path) -> None:
+    assert check.load_task_context(repo) is None
+
+
+def test_load_task_context_malformed_raises(repo: Path) -> None:
+    _write_task_context(repo, "", repo, raw="{not json")
+    with pytest.raises(json.JSONDecodeError):
+        check.load_task_context(repo)
+    _write_task_context(repo, "", repo, raw='{"branch": "main"}')
+    with pytest.raises(ValueError):
+        check.load_task_context(repo)
+
+
+def test_main_no_args_uses_task_context_passes(repo: Path) -> None:
+    _write_task_context(repo, "main", repo)
+    assert check.main([], repo=repo) == 0
+
+
+def test_main_no_args_task_context_branch_mismatch_fails(repo: Path) -> None:
+    _write_task_context(repo, "some/other-branch", repo)
+    assert check.main([], repo=repo) == 1
+
+
+def test_main_no_args_task_context_wrong_worktree_fails(repo: Path, tmp_path: Path) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _write_task_context(repo, "main", elsewhere)
+    assert check.main([], repo=repo) == 1
+
+
+def test_main_no_args_without_task_context_fails_closed(repo: Path) -> None:
+    assert check.main([], repo=repo) == 1
+
+
+def test_explicit_args_override_task_context(repo: Path) -> None:
+    _write_task_context(repo, "stale/branch", tmp_path_factory := repo.parent / "stale-wt")
+    assert (
+        check.main(["--expected-root", str(repo), "--expected-branch", "main"], repo=repo) == 0
+    )
+
+
+# --- new_task_worktree provisioning ---
+
+
+@pytest.fixture()
+def provisioner():
+    spec = importlib.util.spec_from_file_location(
+        "new_task_worktree", REPO_ROOT / "scripts" / "new_task_worktree.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_slugify(provisioner) -> None:
+    assert provisioner.slugify("feat/example-task") == "feat-example-task"
+    assert provisioner.slugify("ci/pytest_merge_gate") == "ci-pytest-merge-gate"
+
+
+def test_git_calls_are_scoped_to_script_repo_root(provisioner, tmp_path, monkeypatch) -> None:
+    """Regression: git calls must target the script's repo, not the caller's cwd."""
+    recorded = {}
+
+    def fake_run(cmd, **kwargs):
+        recorded["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+    result = provisioner.create_task_worktree(
+        "feat/regression", "origin/main", tmp_path / "wt"
+    )
+    assert result == 0
+    assert recorded["cwd"] is not None
+    assert Path(recorded["cwd"]).resolve() == REPO_ROOT.resolve()


### PR DESCRIPTION
## Summary

Automates what #311 established manually: each fresh task worktree records its expected identity locally, and commits are gated on it automatically.

## Changes

- \scripts/new_task_worktree.py\ — provisions a fresh task-owned worktree (branch from \origin/main\), writes \.mneme/task_context.json\ (\{branch, worktree}\) inside it. Git calls are scoped to the script's repo root regardless of invoking cwd (regression-tested).
- \scripts/check_worktree_context.py\ — when run without explicit arguments, falls back to reading \.mneme/task_context.json\; fails closed when absent or malformed. Explicit args still override.
- \scripts/githooks/pre-commit\ — versioned hook: ports the existing private-file blocker, then runs the guard in worktrees that have a context file (administrative checkout unaffected). Install once with \git config core.hooksPath scripts/githooks\.
- \.gitignore\ — ignores local-only \.mneme/task_context.json\.
- \CLAUDE.md\ — provisioning + gate instructions added to the Agent Execution Context Guard section.
- Tests: 19 passing, including context-file fallback cases, malformed file fail-closed, explicit-args override, and the cwd-scoping regression test.

## Verification

- Sandbox E2E: provisioned worktree → checker PASS no-args; commit with wrong branch in context **blocked** by pre-commit hook; correct context committed.
- Dogfood: this PR's own commit was gated by the installed hook with a live task context file.

## Notes

- A BOM in the context file is rejected (fail-closed) — caught live during dogfooding.
- Hook installation (\core.hooksPath\) is a one-time local config step documented in CLAUDE.md; it replaces the old unversioned \.git/hooks/pre-commit\, whose private-file check is ported into the versioned hook.