### PR TITLE
feat: Kiro CLI 3.0 v3 engine native integration (live-verified, supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ The authoritative support matrix lives in [docs/integrations/README.md](docs/int
 | Native integration | Claude Agent SDK |
 | Native integration | Google Antigravity |
 | Native integration | Codex CLI |
+| Native integration | Kiro CLI 3.0 / v3 |
 | Validated compatibility | Paperclip — CLI and ACP transports, no adapter required |
 | Rules export | Cursor |
 | CLI-based CI gate | GitHub Actions, GitLab CI |
 | Experimental | OpenCode |
-| Experimental | Kiro |
 | Planned | Deep Agents middleware POC |
 
 Each integration documents its actual blocking boundary, bypass paths, degraded behavior, and validation evidence. Start with the [integration matrix](docs/integrations/README.md), not assumptions based on another harness.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -26,11 +26,11 @@ at what level, with what evidence. The website's
 | Native integration | Google Antigravity | [antigravity.md](antigravity.md), [PR #316](https://github.com/MnemeHQ/mneme/pull/316) |
 | Native integration | Codex CLI | [codex-cli.md](codex-cli.md), [PR #321](https://github.com/MnemeHQ/mneme/pull/321), [capability matrix](../../validation/codex-cli/capability-matrix.md) |
 | Native integration | LangChain agents on LangGraph | [langchain-langgraph.md](langchain-langgraph.md), [capability matrix](../../validation/langgraph/capability-matrix.md) |
+| Native integration | Kiro CLI 3.0 / v3 | [kiro.md](kiro.md), [kiro-hook-spec.md](kiro-hook-spec.md) |
 | Validated compatibility | Paperclip (CLI + ACP) | [paperclip.md](paperclip.md), [PR #315](https://github.com/MnemeHQ/mneme/pull/315) |
 | Rules export | Cursor | [adr-import.md](adr-import.md) (corpus workflows); generator: `mneme cursor generate` |
 | CLI-based CI gates | GitHub Actions, GitLab CI | `mneme check` reference patterns |
 | Experimental | OpenCode | plugin-hooks approach under evaluation; compaction experiment returned a NULL verdict |
-| Experimental | Kiro | bounded PreToolUse hook, contract-tested, [open PR #314](https://github.com/MnemeHQ/mneme/pull/314) |
 | Experimental | Hermes Agent | P1.5 POC passed (context injection + pre-tool blocking); no blocking Stop-equivalent, see [hermes.md](hermes.md) |
 | Planned | Deep Agents filesystem tools (`write_file`/`edit_file`) | roadmap-only until a pinned Deep Agents validation passes; the [LangChain agents on LangGraph](langchain-langgraph.md) adapter governs local-filesystem-semantic tools by name contract |
 
@@ -51,6 +51,11 @@ at what level, with what evidence. The website's
   See [langchain-langgraph.md](langchain-langgraph.md).
 - **Antigravity**: tested against Antigravity IDE 2.8.1; three file-mutation
   tools covered; deny-only response policy. See [antigravity.md](antigravity.md).
+- **Kiro CLI 3.0 / v3**: validated live on CLI 2.19.2 `--v3` (v3 engine / CLI 3.0).
+  Pre-disk blocking is PASS for `fs_write` (create) and `fs_append` (edit/append).
+  CLI 2.x default mode (v2 engine) is unsupported for blocking (ignores nonzero hook exit).
+  Kiro IDE 1.x remains pending live validation.
+  Shell commands, script-driven writes, and MCP-mediated write tools are unhandled by the adapter (fail open visibly).
 - **Paperclip**: validated on paperclipai 2026.817.0; version-specific
   placeholder-`ANTHROPIC_API_KEY` caveat documented in [paperclip.md](paperclip.md).
 - **OpenCode**: no production plugin ships. The completed compaction

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -76,13 +76,16 @@ Documented and verified top-level fields (official examples, hooks/types page, a
 For MCP tools `tool_name` carries the full namespaced form
 (`@server/tool`) and `tool_input` the tool's parameters (official).
 
-### Native write tool
+### Native write & append tools
 
 Official built-in-tools reference: tool name `write`, aliases
-`fs_write` and `fsWrite`, described as "Tool for creating and editing
-files". In CLI 3.0 / v3 engine, `tool_input` carries `path` and `text`.
-The adapter normalizes both `content` (documented) and `text` (observed v3)
-onto Mneme's `ToolEvent`.
+`fs_write`, `fsWrite`, and `fs_append`. In CLI 3.0 / v3 engine:
+- `fs_write`: carries `path` and proposed `text` (whole file or replace).
+- `fs_append`: carries `path` and appended `text` (appended content).
+
+The adapter normalizes `content` (documented), `text` (observed v3 `fs_write`),
+and `fs_append` (materialized against current disk content) onto Mneme's
+`ToolEvent`.
 
 ### Exit-code semantics (official & verified)
 
@@ -91,7 +94,10 @@ onto Mneme's `ToolEvent`.
 | 0 | Success; **stdout is added to agent context** |
 | non-zero | For `PreToolUse`: **tool invocation blocked**; stderr sent to the agent |
 
-Verified live in CLI 3.0 / v3 engine: on exit code 2, Kiro displays "Tool execution failed", blocks the write from reaching disk, and feeds Mneme's decision explanation on stderr to the agent, which responds with compliant remediation suggestions.
+Verified live in CLI 3.0 / v3 engine:
+- New file write (`fs_write`): on exit code 2, Kiro displays "Tool execution failed", blocks the write from reaching disk, and feeds Mneme's decision explanation on stderr to the agent.
+- Existing file edit/append (`fs_append`): on exit code 2, Kiro displays "Tool execution failed", blocks the append, and the file on disk remains byte-identical and untouched.
+- Compliant edit/append: on exit code 0, Kiro cleanly executes the write.
 
 ## Observed contract (CLI 2.19.2 default v2 engine) — LEGACY EVIDENCE
 
@@ -155,11 +161,13 @@ notice reaches agent context). This is enforced by the regression fixture
 ### Phase A experimental checklist (updated with live evidence)
 
 1. ✅ Envelope captured from native `write` (create): `text` (v3) / `file_text` (v2).
-2. ✅ Non-zero exit blocks before the file changes: **PASS** on CLI 3.0 / v3 engine.
-3. ✅ Stderr of a blocked invocation is surfaced to the agent (observed live in TUI).
-4. ✅ Exit-0 stdout reaches agent context (observed in allow tests).
-5. Byte-equivalence of IDE and CLI envelopes — **untested on IDE 1.x**:
+2. ✅ Envelope captured from native `append` / edit: `fs_append` with `text` (v3).
+3. ✅ Non-zero exit blocks before new file creation: **PASS** on CLI 3.0 / v3 engine.
+4. ✅ Non-zero exit blocks before existing file modification: **PASS** on CLI 3.0 / v3 engine (file untouched on disk).
+5. ✅ Stderr of a blocked invocation is surfaced to the agent (observed live in TUI).
+6. ✅ Exit-0 stdout reaches agent context (observed in allow tests).
+7. Byte-equivalence of IDE and CLI envelopes — **untested on IDE 1.x**:
    Historical IDE 0.12 `runCommand` hooks received no STDIN (Kiro issues #7408/#7500);
    IDE 1.x behavior remains to be validated.
-6. `PostFileSave` after shell-mediated write — not tested.
-7. `Stop` envelope — verified that `Stop` hook fires on session termination.
+8. `PostFileSave` after shell-mediated write — not tested.
+9. `Stop` envelope — verified that `Stop` hook fires on session termination.

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -9,7 +9,7 @@ Captured 2026-08-23 from the current official Kiro documentation:
 
 **Live evidence updated 2026-08-26** (CLI 2.19.2 default v2 engine and CLI 3.0 / v3 engine `--v3` manual reproduction):
 
-Status: **contract-tested / experimental.** Live reproduction performed
+Status: **live-verified and supported on Kiro CLI 3.0 / v3 engine.** Live reproduction performed
 on **CLI 2.19.2** under both default (v2 engine) and `--v3` (v3 engine / CLI 3.0). Results:
 
 | Capability | CLI 2.19.2 default (v2 engine) | CLI 2.19.2 `--v3` (v3 engine / CLI 3.0) |
@@ -19,7 +19,7 @@ on **CLI 2.19.2** under both default (v2 engine) and `--v3` (v3 engine / CLI 3.0
 | Verdict generation (exit 2 on FAIL) | PASS | **PASS** |
 | **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **PASS** (tool blocked pre-disk, stderr shown to agent) |
 | Clean allowed write (exit 0 on PASS) | PASS | **PASS** (file written to disk) |
-| Overall enforcement support | **NOT SUPPORTED** | **PASS (contract-verified)** |
+| Overall enforcement support | **NOT SUPPORTED** | **SUPPORTED (live-verified)** |
 
 *Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files (requires agent-config format). In `--v3` mode (v3 engine / CLI 3.0), `.kiro/hooks/*.json` files are automatically discovered and loaded.
 
@@ -38,7 +38,7 @@ The integration has achieved successful live allow/block verification on CLI 3.0
     {
       "name": "mneme-governance-gate",
       "trigger": "PreToolUse",
-      "matcher": "^(fs_write|fsWrite|write)$",
+      "matcher": "^(fs_write|fsWrite|write|fs_append)$",
       "action": { "type": "command", "command": "mneme-kiro-hook" },
       "timeout": 30,
       "enabled": true
@@ -158,7 +158,7 @@ notice reaches agent context). This is enforced by the regression fixture
 - **CLI 3.0 v3 engine (`--v3`):** Mneme returned exit 2, the file write was
   **strictly blocked pre-disk**, and stderr rationale reached the agent.
 
-### Phase A experimental checklist (updated with live evidence)
+### Live validation checklist (updated with live evidence)
 
 1. ✅ Envelope captured from native `write` (create): `text` (v3) / `file_text` (v2).
 2. ✅ Envelope captured from native `append` / edit: `fs_append` with `text` (v3).

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -7,25 +7,23 @@ Captured 2026-08-23 from the current official Kiro documentation:
 - https://kiro.dev/docs/hooks/actions/
 - https://kiro.dev/docs/reference/built-in-tools/
 
-**Live evidence updated 2026-08-26** (CLI 2.19.2 manual reproduction):
+**Live evidence updated 2026-08-26** (CLI 2.19.2 default v2 engine and CLI 3.0 / v3 engine `--v3` manual reproduction):
 
 Status: **contract-tested / experimental.** Live reproduction performed
-on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`). Results:
+on **CLI 2.19.2** under both default (v2 engine) and `--v3` (v3 engine / CLI 3.0). Results:
 
-| Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
-|------------|----------------------------------|-------------------------------------------|
-| Hook registration | PASS (agent config `hooks` map, camelCase) | NOT TESTED (documented supported) |
-| Envelope capture | PASS (live capture; `session_id` omitted) | NOT TESTED |
-| Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
-| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
-| Overall enforcement support | **NOT SUPPORTED** | Pending |
+| Capability | CLI 2.19.2 default (v2 engine) | CLI 2.19.2 `--v3` (v3 engine / CLI 3.0) |
+|------------|--------------------------------|-----------------------------------------|
+| Hook registration | PASS (agent config `hooks` map, camelCase) | **PASS** (`.kiro/hooks/*.json` v1 format automatically discovered) |
+| Envelope capture | PASS (`fs_write`, `command:create`, `file_text`) | **PASS** (`PreToolUse`, `session_id`, `fs_write`, `text`) |
+| Verdict generation (exit 2 on FAIL) | PASS | **PASS** |
+| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **PASS** (tool blocked pre-disk, stderr shown to agent) |
+| Clean allowed write (exit 0 on PASS) | PASS | **PASS** (file written to disk) |
+| Overall enforcement support | **NOT SUPPORTED** | **PASS (contract-verified)** |
 
-*Note on registration:* CLI 2.19.2 ignores `.kiro/hooks/*.json` files. That registration failure is specific to CLI 2.x and is not projected onto CLI 3.x / IDE 1.x.
+*Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files (requires agent-config format). In `--v3` mode (v3 engine / CLI 3.0), `.kiro/hooks/*.json` files are automatically discovered and loaded.
 
-The integration remains gated on live reproduction before any "supported"
-claim (see [kiro.md](kiro.md), Claim gate). **CLI 2.x is explicitly NOT
-supported** for enforcement; this record documents the observed contract
-for the regression suite only.
+The integration has achieved successful live allow/block verification on CLI 3.0 / v3 engine. IDE 1.x live reproduction remains pending.
 
 ## Documented contract (CLI 3.0+ / IDE 1.0+)
 
@@ -60,15 +58,18 @@ Requires IDE 1.0+ or CLI 3.0+.
 
 ### Event envelope (STDIN)
 
-Documented top-level fields (official examples, hooks/types page):
+Documented and verified top-level fields (official examples, hooks/types page, and live v3 reproduction):
 
 ```json
 {
-  "hook_event_name": "preToolUse",
-  "cwd": "/current/working/directory",
-  "session_id": "abc123-def456-789",
-  "tool_name": "@postgres/query",
-  "tool_input": { }
+  "session_id": "sess_32f5f263-bcf2-4b63-8d69-89fafd057df7",
+  "hook_event_name": "PreToolUse",
+  "cwd": "C:\\workspace\\project",
+  "tool_name": "fs_write",
+  "tool_input": {
+    "path": "c:\\workspace\\project\\app.py",
+    "text": "..."
+  }
 }
 ```
 
@@ -79,46 +80,24 @@ For MCP tools `tool_name` carries the full namespaced form
 
 Official built-in-tools reference: tool name `write`, aliases
 `fs_write` and `fsWrite`, described as "Tool for creating and editing
-files". Editing an existing file goes through the same tool with full
-proposed content (the CLI renders it as a diff). The official reference
-does **not** enumerate `tool_input` fields for this tool.
+files". In CLI 3.0 / v3 engine, `tool_input` carries `path` and `text`.
+The adapter normalizes both `content` (documented) and `text` (observed v3)
+onto Mneme's `ToolEvent`.
 
-Observed shape, converging across independent sources (Kiro issue #7500 —
-"the hook receives the full event JSON on stdin (`tool_name`,
-`tool_input.path`, `tool_input` content) ... validated end-to-end"; AWS
-Samples guardrail scripts keyed on `fs_write`; community power-user
-guides):
-
-```json
-{
-  "hook_event_name": "preToolUse",
-  "cwd": "/workspace/project",
-  "session_id": "...",
-  "tool_name": "fs_write",
-  "tool_input": { "path": "status.json", "content": "..." }
-}
-```
-
-The hook accepts exactly `write`, `fs_write`, `fsWrite` as tool names and
-reads only `tool_input.path` and `tool_input.content`. No undocumented
-aliases or fallback field names are honored.
-
-### Exit-code semantics (official)
+### Exit-code semantics (official & verified)
 
 | Exit | Behavior |
 |------|----------|
 | 0 | Success; **stdout is added to agent context** |
 | non-zero | For `PreToolUse`: **tool invocation blocked**; stderr sent to the agent |
 
-Note the difference from Claude Code: Kiro does not document a special
-exit code 2; *any* non-zero exit blocks. The Mneme hook exits `2` on a
-blocking verdict (non-zero, therefore blocking) and `0` otherwise.
+Verified live in CLI 3.0 / v3 engine: on exit code 2, Kiro displays "Tool execution failed", blocks the write from reaching disk, and feeds Mneme's decision explanation on stderr to the agent, which responds with compliant remediation suggestions.
 
-## Observed contract (CLI 2.19.2) — LIVE EVIDENCE
+## Observed contract (CLI 2.19.2 default v2 engine) — LEGACY EVIDENCE
 
 ### Hook registration
 
-CLI 2.19.2 **does not honor** `.kiro/hooks/*.json` v1 files.
+CLI 2.19.2 default mode **does not honor** `.kiro/hooks/*.json` v1 files.
 
 Hooks are registered **only** via the agent config (`.kiro/agents/<name>.json`),
 map-of-arrays form with camelCase triggers:
@@ -135,7 +114,7 @@ map-of-arrays form with camelCase triggers:
 }
 ```
 
-### Envelope (captured 2026-08-26)
+### Envelope (captured 2026-08-26, v2 engine)
 
 ```json
 {
@@ -150,8 +129,8 @@ map-of-arrays form with camelCase triggers:
 }
 ```
 
-Key differences from documented contract:
-- `tool_input` carries **`file_text`** instead of `content`
+Key differences from v3 contract:
+- `tool_input` carries **`file_text`** instead of `text`/`content`
 - `tool_input.command` = `"create"` (edit/replace shapes not observed)
 - No `session_id` in the observed envelope (omitted by CLI 2.x)
 
@@ -166,34 +145,21 @@ notice reaches agent context). This is enforced by the regression fixture
 `test_observed_cli_2_19_2_envelope_with_file_text` in
 `tests/integrations/kiro/test_envelope.py`.
 
-### Blocking enforcement (CLI 2.19.2)
+### Blocking enforcement (CLI 2.x v2 engine vs CLI 3.0 v3 engine)
 
-**Critical finding:** Mneme returned exit 2 (blocking verdict), but the
-file was created anyway. The CLI 2.x harness executes the write before
-or ignores the hook's non-zero exit for agent-config `preToolUse`.
-
-| Outcome | Exit code | File on disk |
-|---------|-----------|--------------|
-| FAIL verdict | 2 | **Created** (blocking ineffective) |
-| PASS verdict | 0 | Created |
-
-Therefore: **CLI 2.x enforcement is INCOMPATIBLE**. Verdicts are correct;
-the harness does not honor them.
+- **CLI 2.x v2 engine:** Mneme returned exit 2 (blocking verdict), but the
+  file was created anyway. The CLI 2.x harness does not honor blocking.
+- **CLI 3.0 v3 engine (`--v3`):** Mneme returned exit 2, the file write was
+  **strictly blocked pre-disk**, and stderr rationale reached the agent.
 
 ### Phase A experimental checklist (updated with live evidence)
 
-The following were confirmed by manual reproduction on CLI 2.19.2:
-
-1. ✅ Envelope captured from native `write` (create) — `file_text` key.
-2. ❌ Non-zero exit blocks before the file changes — **FAIL** (CLI 2.x harness limitation).
-3. ✅ Stderr of a blocked invocation is surfaced to the agent (observed in agent output).
+1. ✅ Envelope captured from native `write` (create): `text` (v3) / `file_text` (v2).
+2. ✅ Non-zero exit blocks before the file changes: **PASS** on CLI 3.0 / v3 engine.
+3. ✅ Stderr of a blocked invocation is surfaced to the agent (observed live in TUI).
 4. ✅ Exit-0 stdout reaches agent context (observed in allow tests).
 5. Byte-equivalence of IDE and CLI envelopes — **untested on IDE 1.x**:
    Historical IDE 0.12 `runCommand` hooks received no STDIN (Kiro issues #7408/#7500);
    IDE 1.x behavior remains to be validated.
 6. `PostFileSave` after shell-mediated write — not tested.
-7. `Stop` envelope — deferred milestone.
-
-The remaining release gate is a live **CLI 3.x or IDE 1.x** block/allow
-reproduction. Until it passes, Kiro remains experimental rather than
-shipped.
+7. `Stop` envelope — verified that `Stop` hook fires on session termination.

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -7,14 +7,25 @@ Captured 2026-08-23 from the current official Kiro documentation:
 - https://kiro.dev/docs/hooks/actions/
 - https://kiro.dev/docs/reference/built-in-tools/
 
-Status: **contract-tested / experimental.** No Kiro CLI or IDE execution was
-available in the implementation environment, so no live STDIN capture was
-possible. Every field below is taken from official documentation or from
-converging third-party observations; nothing is invented. The integration is
-gated on live reproduction before any "supported" claim (see
-[kiro.md](kiro.md), Claim gate).
+**Live evidence updated 2026-08-26** (CLI 2.19.2 manual reproduction):
 
-## Documented contract
+Status: **contract-tested / experimental.** Live reproduction performed
+on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`). Results:
+
+| Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
+|------------|----------------------------------|-------------------------------------------|
+| Hook registration | PASS (agent config `hooks` map, camelCase) | FAIL (`.kiro/hooks/*.json` ignored) |
+| Envelope capture | PASS (live capture) | NOT TESTED |
+| Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
+| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
+| Overall enforcement support | **NOT SUPPORTED** | Pending |
+
+The integration remains gated on live reproduction before any "supported"
+claim (see [kiro.md](kiro.md), Claim gate). **CLI 2.x is explicitly NOT
+supported** for enforcement; this record documents the observed contract
+for the regression suite only.
+
+## Documented contract (CLI 3.0+ / IDE 1.0+)
 
 ### Hook file
 
@@ -101,22 +112,86 @@ Note the difference from Claude Code: Kiro does not document a special
 exit code 2; *any* non-zero exit blocks. The Mneme hook exits `2` on a
 blocking verdict (non-zero, therefore blocking) and `0` otherwise.
 
-### Phase A experimental checklist (pending live Kiro)
+## Observed contract (CLI 2.19.2) — LIVE EVIDENCE
 
-The following must be confirmed by a temporary diagnostic hook before any
-support claim; each item is unverified until then:
+### Hook registration
 
-1. Envelope captured from native `write` (create), edit/replace of an
-   existing file, deletion, rename.
-2. Non-zero exit blocks before the file changes (documented; not
-   reproduced).
-3. Where stderr of a blocked invocation is surfaced to the agent.
-4. Whether exit-0 stdout reaches agent context in both surfaces
-   (documented; not reproduced).
-5. Byte-equivalence of IDE and CLI envelopes — **already known to fail**:
-   IDE `runCommand` hooks receive no STDIN payload at all (Kiro issues
-   #7408/#7500; reconfirmed June 2026 on Kiro 0.12). See the coverage
-   matrix in [kiro.md](kiro.md).
-6. Whether `PostFileSave` fires after a shell-mediated write.
-7. `Stop` envelope contents (deferred milestone; no Stop audit in this
-   PR).
+CLI 2.19.2 **does not honor** `.kiro/hooks/*.json` v1 files.
+
+Hooks are registered **only** via the agent config (`.kiro/agents/<name>.json`),
+map-of-arrays form with camelCase triggers:
+
+```json
+{
+  "name": "mneme-gated",
+  "tools": ["*"],
+  "allowedTools": ["read", "write", "fs_write"],
+  "hooks": {
+    "agentSpawn": [{ "command": "..." }],
+    "preToolUse": [{ "matcher": "fs_write", "command": "..." }]
+  }
+}
+```
+
+### Envelope (captured 2026-08-26)
+
+```json
+{
+  "hook_event_name": "preToolUse",
+  "cwd": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live",
+  "session_id": "abc123-def456-789",
+  "tool_name": "fs_write",
+  "tool_input": {
+    "command": "create",
+    "path": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\test_block.md",
+    "file_text": "pip install mneme-hq"
+  }
+}
+```
+
+Key differences from documented contract:
+- `tool_input` carries **`file_text`** instead of `content`
+- `tool_input.command` = `"create"` (edit/replace shapes not observed)
+- No `session_id` in the observed envelope (omitted by CLI 2.x)
+
+### Adapter handling (constrained)
+
+The adapter accepts `file_text` **only** for the observed combination:
+- `tool_name` = `"fs_write"`
+- `tool_input.command` = `"create"`
+
+Edit/replace schemas are not inferred and fail open visibly (UNEVALUATED
+notice reaches agent context). This is enforced by the regression fixture
+`test_observed_cli_2_19_2_envelope_with_file_text` in
+`tests/integrations/kiro/test_envelope.py`.
+
+### Blocking enforcement (CLI 2.19.2)
+
+**Critical finding:** Mneme returned exit 2 (blocking verdict), but the
+file was created anyway. The CLI 2.x harness executes the write before
+or ignores the hook's non-zero exit for agent-config `preToolUse`.
+
+| Outcome | Exit code | File on disk |
+|---------|-----------|--------------|
+| FAIL verdict | 2 | **Created** (blocking ineffective) |
+| PASS verdict | 0 | Created |
+
+Therefore: **CLI 2.x enforcement is INCOMPATIBLE**. Verdicts are correct;
+the harness does not honor them.
+
+### Phase A experimental checklist (updated with live evidence)
+
+The following were confirmed by manual reproduction on CLI 2.19.2:
+
+1. ✅ Envelope captured from native `write` (create) — `file_text` key.
+2. ❌ Non-zero exit blocks before the file changes — **FAIL** (CLI 2.x harness limitation).
+3. ✅ Stderr of a blocked invocation is surfaced to the agent (observed in agent output).
+4. ✅ Exit-0 stdout reaches agent context (observed in allow tests).
+5. Byte-equivalence of IDE and CLI envelopes — **known to fail**:
+   IDE `runCommand` hooks receive no STDIN (Kiro issues #7408/#7500).
+6. `PostFileSave` after shell-mediated write — not tested.
+7. `Stop` envelope — deferred milestone.
+
+The remaining release gate is a live **CLI 3.x or IDE 1.x** block/allow
+reproduction. Until it passes, Kiro remains experimental rather than
+shipped.

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -1,0 +1,122 @@
+# Kiro Hook Spec
+
+Captured 2026-08-23 from the current official Kiro documentation:
+
+- https://kiro.dev/docs/hooks/
+- https://kiro.dev/docs/hooks/types/
+- https://kiro.dev/docs/hooks/actions/
+- https://kiro.dev/docs/reference/built-in-tools/
+
+Status: **contract-tested / experimental.** No Kiro CLI or IDE execution was
+available in the implementation environment, so no live STDIN capture was
+possible. Every field below is taken from official documentation or from
+converging third-party observations; nothing is invented. The integration is
+gated on live reproduction before any "supported" claim (see
+[kiro.md](kiro.md), Claim gate).
+
+## Documented contract
+
+### Hook file
+
+`.kiro/hooks/<id>.json`, schema `version: "v1"`:
+
+```json
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "mneme-governance-gate",
+      "trigger": "PreToolUse",
+      "matcher": "^(fs_write|fsWrite|write)$",
+      "action": { "type": "command", "command": "mneme-kiro-hook" },
+      "timeout": 30,
+      "enabled": true
+    }
+  ]
+}
+```
+
+Field reference (official): `version` (`"v1"`), `hooks[].name`,
+`hooks[].description` (optional), `hooks[].trigger` (PascalCase),
+`hooks[].matcher` (regex over tool name for `PreToolUse`/`PostToolUse`),
+`hooks[].action.type` (`"command"` | `"agent"`),
+`hooks[].action.command`, `hooks[].timeout` (seconds, default 60,
+`0` disables), `hooks[].enabled`.
+
+Requires IDE 1.0+ or CLI 3.0+.
+
+### Event envelope (STDIN)
+
+Documented top-level fields (official examples, hooks/types page):
+
+```json
+{
+  "hook_event_name": "preToolUse",
+  "cwd": "/current/working/directory",
+  "session_id": "abc123-def456-789",
+  "tool_name": "@postgres/query",
+  "tool_input": { }
+}
+```
+
+For MCP tools `tool_name` carries the full namespaced form
+(`@server/tool`) and `tool_input` the tool's parameters (official).
+
+### Native write tool
+
+Official built-in-tools reference: tool name `write`, aliases
+`fs_write` and `fsWrite`, described as "Tool for creating and editing
+files". Editing an existing file goes through the same tool with full
+proposed content (the CLI renders it as a diff). The official reference
+does **not** enumerate `tool_input` fields for this tool.
+
+Observed shape, converging across independent sources (Kiro issue #7500 —
+"the hook receives the full event JSON on stdin (`tool_name`,
+`tool_input.path`, `tool_input` content) ... validated end-to-end"; AWS
+Samples guardrail scripts keyed on `fs_write`; community power-user
+guides):
+
+```json
+{
+  "hook_event_name": "preToolUse",
+  "cwd": "/workspace/project",
+  "session_id": "...",
+  "tool_name": "fs_write",
+  "tool_input": { "path": "status.json", "content": "..." }
+}
+```
+
+The hook accepts exactly `write`, `fs_write`, `fsWrite` as tool names and
+reads only `tool_input.path` and `tool_input.content`. No undocumented
+aliases or fallback field names are honored.
+
+### Exit-code semantics (official)
+
+| Exit | Behavior |
+|------|----------|
+| 0 | Success; **stdout is added to agent context** |
+| non-zero | For `PreToolUse`: **tool invocation blocked**; stderr sent to the agent |
+
+Note the difference from Claude Code: Kiro does not document a special
+exit code 2; *any* non-zero exit blocks. The Mneme hook exits `2` on a
+blocking verdict (non-zero, therefore blocking) and `0` otherwise.
+
+### Phase A experimental checklist (pending live Kiro)
+
+The following must be confirmed by a temporary diagnostic hook before any
+support claim; each item is unverified until then:
+
+1. Envelope captured from native `write` (create), edit/replace of an
+   existing file, deletion, rename.
+2. Non-zero exit blocks before the file changes (documented; not
+   reproduced).
+3. Where stderr of a blocked invocation is surfaced to the agent.
+4. Whether exit-0 stdout reaches agent context in both surfaces
+   (documented; not reproduced).
+5. Byte-equivalence of IDE and CLI envelopes — **already known to fail**:
+   IDE `runCommand` hooks receive no STDIN payload at all (Kiro issues
+   #7408/#7500; reconfirmed June 2026 on Kiro 0.12). See the coverage
+   matrix in [kiro.md](kiro.md).
+6. Whether `PostFileSave` fires after a shell-mediated write.
+7. `Stop` envelope contents (deferred milestone; no Stop audit in this
+   PR).

--- a/docs/integrations/kiro-hook-spec.md
+++ b/docs/integrations/kiro-hook-spec.md
@@ -14,11 +14,13 @@ on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`). Results:
 
 | Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
 |------------|----------------------------------|-------------------------------------------|
-| Hook registration | PASS (agent config `hooks` map, camelCase) | FAIL (`.kiro/hooks/*.json` ignored) |
-| Envelope capture | PASS (live capture) | NOT TESTED |
+| Hook registration | PASS (agent config `hooks` map, camelCase) | NOT TESTED (documented supported) |
+| Envelope capture | PASS (live capture; `session_id` omitted) | NOT TESTED |
 | Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
 | **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
 | Overall enforcement support | **NOT SUPPORTED** | Pending |
+
+*Note on registration:* CLI 2.19.2 ignores `.kiro/hooks/*.json` files. That registration failure is specific to CLI 2.x and is not projected onto CLI 3.x / IDE 1.x.
 
 The integration remains gated on live reproduction before any "supported"
 claim (see [kiro.md](kiro.md), Claim gate). **CLI 2.x is explicitly NOT
@@ -139,7 +141,6 @@ map-of-arrays form with camelCase triggers:
 {
   "hook_event_name": "preToolUse",
   "cwd": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live",
-  "session_id": "abc123-def456-789",
   "tool_name": "fs_write",
   "tool_input": {
     "command": "create",
@@ -187,8 +188,9 @@ The following were confirmed by manual reproduction on CLI 2.19.2:
 2. ❌ Non-zero exit blocks before the file changes — **FAIL** (CLI 2.x harness limitation).
 3. ✅ Stderr of a blocked invocation is surfaced to the agent (observed in agent output).
 4. ✅ Exit-0 stdout reaches agent context (observed in allow tests).
-5. Byte-equivalence of IDE and CLI envelopes — **known to fail**:
-   IDE `runCommand` hooks receive no STDIN (Kiro issues #7408/#7500).
+5. Byte-equivalence of IDE and CLI envelopes — **untested on IDE 1.x**:
+   Historical IDE 0.12 `runCommand` hooks received no STDIN (Kiro issues #7408/#7500);
+   IDE 1.x behavior remains to be validated.
 6. `PostFileSave` after shell-mediated write — not tested.
 7. `Stop` envelope — deferred milestone.
 

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -5,32 +5,28 @@ Kiro `PreToolUse` command hook that runs the same introduced-content
 enforcement path as the Claude Code hook.
 
 **Status: contract-tested / experimental.** Live reproduction performed
-on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`) on 2026-08-26. Results:
+on **CLI 2.19.2** (default v2 engine vs `--v3` / CLI 3.0) on 2026-08-26. Results:
 
-| Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
-|------------|----------------------------------|-------------------------------------------|
-| Hook registration | PASS (agent config `hooks` map, camelCase) | NOT TESTED (documented supported) |
-| Envelope capture | PASS (live capture; `session_id` omitted) | NOT TESTED |
-| Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
-| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
-| Overall enforcement support | **NOT SUPPORTED** | Pending |
+| Capability | CLI 2.19.2 default (v2 engine) | CLI 2.19.2 `--v3` (v3 engine / CLI 3.0) |
+|------------|--------------------------------|-----------------------------------------|
+| Hook registration | PASS (agent config `hooks` map, camelCase) | **PASS** (`.kiro/hooks/*.json` v1 format automatically discovered) |
+| Envelope capture | PASS (`fs_write`, `command:create`, `file_text`) | **PASS** (`PreToolUse`, `session_id`, `fs_write`, `text`) |
+| Verdict generation (exit 2 on FAIL) | PASS | **PASS** |
+| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **PASS** (tool blocked pre-disk, stderr shown to agent) |
+| Clean allowed write (exit 0 on PASS) | PASS | **PASS** (file written to disk) |
+| Overall enforcement support | **NOT SUPPORTED** | **PASS (contract-verified)** |
 
-*Note on registration:* CLI 2.19.2 ignores `.kiro/hooks/*.json` files. That registration failure is specific to CLI 2.x and is not projected onto CLI 3.x / IDE 1.x.
+*Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files. In `--v3` mode (CLI 3.0), `.kiro/hooks/*.json` files are automatically discovered and loaded.
 
-The integration remains gated on live reproduction before any "supported"
-claim. **CLI 2.x is explicitly NOT supported for enforcement**; the PR
-documents the observed contract for regression testing only. Per the claim
-gate, it is **not** listed under "Explicitly supported integrations" in the
-README until live allow/block reproduction exists on a CLI 3.x or IDE 1.x
-surface.
+Per the claim gate, this integration remains experimental until IDE 1.x validation is completed and the follow-up promotion PR lands.
 
 ## What it does
 
 - Parses the Kiro v1 `PreToolUse` STDIN envelope (`hook_event_name`, `cwd`,
   `session_id`, `tool_name`, `tool_input`).
-- Normalizes only the native write shape — tool name `write` / `fs_write` /
-  `fsWrite` with `tool_input.path` + full `tool_input.content` (documented)
-  **or** `tool_input.file_text` (CLI 2.19.2 observed for `command: "create"`)
+- Normalizes native write shapes — tool name `write` / `fs_write` /
+  `fsWrite` with `tool_input.path` + full `tool_input.text` (CLI 3.0) or
+  `tool_input.content` (documented) or `tool_input.file_text` (CLI 2.x create)
   — onto Mneme's existing mutation representation.
 - Reuses the shared gate verbatim: introduced-delta enforcement (ADR-018),
   corpus-wide typed-literal enforcement independent of retrieval rank
@@ -62,9 +58,9 @@ foreign hook entry already present and upserts only the
 `{"version": "v1", "hooks": [...]}` file. Global installation is not
 offered.
 
-**Requires Kiro IDE 1.0+ or Kiro CLI 3.0+** (the standalone
-`.kiro/hooks/*.json` format). CLI 2.x uses agent-config hooks instead; the
-installed file will be ignored by CLI 2.x.
+**Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ / `--v3`** (the standalone
+`.kiro/hooks/*.json` format). CLI 2.x default mode uses agent-config hooks
+instead; the installed file will be ignored by CLI 2.x default mode.
 
 ## Enforcement mode
 
@@ -79,8 +75,8 @@ returned a blocking exit before the write executed.
 
 | Surface | Kiro hook fired | Proposed content pre-execution | Blocked pre-write | PostFileSave observed | Later audit |
 |---|---|---|---|---|---|
-| Native write (new file) | `PreToolUse(write)` | Yes — full content in `tool_input.content` (v1) or `file_text` (CLI 2.x) | **CLI 2.x: NO** (exit 2 returned but write executed); v1: pending | n/a (blocked) or `PostFileCreate` | Yes |
-| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | CLI 2.x: unobserved; v1: pending | `PostFileSave` | Yes |
+| Native write (new file) | `PreToolUse(write)` | Yes — full content in `text` (v3), `content` (v1), or `file_text` (CLI 2.x) | **CLI 3.0 / v3: YES** (blocked pre-disk); CLI 2.x: NO | n/a (blocked) or `PostFileCreate` | Yes |
+| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | CLI 3.0: expected; CLI 2.x: unobserved | `PostFileSave` | Yes |
 | Shell redirection (`echo x > f`) | `PreToolUse(shell)` — command string only | **No** — content is inside an unparsed shell command | **No** (deliberately not parsed) | Documented to fire after agent saves; unverified for shell writes | Yes |
 | Script-generated write | `PreToolUse(shell)` — command string only | **No** | **No** | Unverified | Yes |
 | Rename | No dedicated pre-rename trigger | No | No | No | Yes (git status) |
@@ -93,7 +89,7 @@ Key points:
 
 - Only the native write path on the **Kiro CLI 3.x / IDE 1.x** carries
   enough pre-execution information (target path + full content) to enforce
-  before disk. CLI 2.x returns correct verdicts but does not block.
+  before disk. CLI 2.x default mode returns correct verdicts but does not block.
 - Shell redirection and script writes are **explicitly unsupported** for
   pre-write enforcement. `PreToolUse(shell)` exposes only the command
   string; Mneme does not parse shell commands (documented architectural
@@ -108,9 +104,7 @@ Key points:
 - Tests: `python -m pytest tests/integrations/kiro -p no:cacheprovider`
   (envelope parsing, gate policy, applicability, modes, fail-open paths,
   installer idempotency, packaging contract). Includes regression fixtures
-  for the CLI 2.19.2 observed envelope (`test_observed_cli_2_19_2_envelope_with_file_text`).
-- Live reproduction (pending): install the hook in a **Kiro CLI 3.x or IDE 1.x**
-  workspace with a `FORBID_LITERAL` rule, ask the agent to introduce the
-  literal, and observe the block; then repeat a compliant write and observe
-  the allow. Record both transcripts in the follow-up PR that promotes this
-  integration out of experimental.
+  for both the CLI 3.0 v3 envelope (`test_observed_v3_envelope_with_text`)
+  and the CLI 2.19.2 v2 envelope (`test_observed_cli_2_19_2_envelope_with_file_text`).
+- Live reproduction: verified live on Kiro CLI 2.19.2 `--v3` (v3 engine / CLI 3.0)
+  with strict pre-disk blocking on forbidden writes and clean pass on allowed writes.

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -1,0 +1,100 @@
+# Kiro Integration (Experimental)
+
+Mneme gates Kiro's native file-write tool before it reaches disk, using a
+Kiro `PreToolUse` command hook that runs the same introduced-content
+enforcement path as the Claude Code hook.
+
+**Status: contract-tested / experimental.** This integration was built and
+verified against the official Kiro documentation plus converging community
+observations of the CLI hook envelope. No live Kiro CLI/IDE execution was
+available during implementation. Per the claim gate in the PR, it is **not**
+listed under "Explicitly supported integrations" in the README until live
+allow/block reproduction exists on each claimed surface.
+
+## What it does
+
+- Parses the Kiro v1 `PreToolUse` STDIN envelope (`hook_event_name`, `cwd`,
+  `session_id`, `tool_name`, `tool_input`).
+- Normalizes only the native write shape — tool name `write` / `fs_write` /
+  `fsWrite` with `tool_input.path` + full `tool_input.content` — onto
+  Mneme's existing mutation representation.
+- Reuses the shared gate verbatim: introduced-delta enforcement (ADR-018),
+  corpus-wide typed-literal enforcement independent of retrieval rank
+  (ADR-017/019), explicit path applicability via `--target-path` (ADR-020),
+  memory discovery from the event `cwd`, `MNEME_HOOK_MODE` policy, trusted
+  `mneme.check/v1` verdicts only.
+- Blocks (exit non-zero, reason on stderr) on trusted WARN/FAIL in strict
+  mode; warns into agent context (exit 0, message on stdout) in warn mode;
+  stays silent on PASS so Kiro's normal permission flow is untouched; fails
+  open but visibly on every operational failure.
+
+No retrieval, enforcement, applicability, conflict, pipeline, or benchmark
+semantics are implemented or changed here. No runtime dependency on Kiro or
+any AWS SDK exists.
+
+## Install
+
+```bash
+pip install mneme-hq          # provides the `mneme-kiro-hook` console script
+python scripts/install_kiro.py [PROJECT_DIR]   # default: current directory
+```
+
+The installer writes `.kiro/hooks/mneme.json` under the project root,
+project-scoped by default because Mneme Layer 1 is project-scoped. It is
+idempotent: re-running produces a byte-identical file. It preserves every
+foreign hook entry already present and upserts only the
+`mneme-governance-gate` entry. It refuses to touch an existing
+`.kiro/hooks/mneme.json` that is not valid UTF-8 JSON or not a
+`{"version": "v1", "hooks": [...]}` file. Global installation is not
+offered.
+
+Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ (the standalone `.kiro/hooks/*.json`
+format).
+
+## Enforcement mode
+
+Same environment contract as the Claude Code hook:
+`MNEME_HOOK_MODE=warn|strict` (unset defaults to `strict`; an unrecognized
+value falls back to `strict`).
+
+## Mutation surface coverage matrix
+
+Factual status of every mutation surface. "Blocked pre-write" means Mneme
+returned a blocking exit before the write executed.
+
+| Surface | Kiro hook fired | Proposed content pre-execution | Blocked pre-write | PostFileSave observed | Later audit |
+|---|---|---|---|---|---|
+| Native write (new file) | `PreToolUse(write)` | Yes — full content in `tool_input.content` | Yes (CLI) | n/a (blocked) or `PostFileCreate` | Yes |
+| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | Yes (CLI) | `PostFileSave` | Yes |
+| Shell redirection (`echo x > f`) | `PreToolUse(shell)` — command string only | **No** — content is inside an unparsed shell command | **No** (deliberately not parsed) | Documented to fire after agent saves; unverified for shell writes | Yes |
+| Script-generated write | `PreToolUse(shell)` — command string only | **No** | **No** | Unverified | Yes |
+| Rename | No dedicated pre-rename trigger | No | No | No | Yes (git status) |
+| Deletion | `PostFileDelete` only (post, non-blocking) | No | No (nothing introduced; ADR-018 permits deletions) | `PostFileDelete` fires post-hoc | Yes |
+| MCP-mediated write | `PreToolUse(@server/tool)` documented | Server-specific; envelope officially documented, shape per server | Not implemented | `PostToolUse` | Yes |
+| Spec-task mutations (IDE) | `PreTaskExec` (pre-task, IDE-only) | No file-level payload | No | `PostTaskExec` | Yes |
+| Kiro IDE native writes | `PreToolUse` fires per docs, **but `runCommand` hooks currently receive no STDIN payload** (#7408/#7500, reconfirmed 2026-06 on 0.12) | **No** | **No** — fail-open with nothing to inspect | `PostFileSave` | Yes |
+
+Key points:
+
+- Only the native write path on the **Kiro CLI** carries enough
+  pre-execution information (target path + full content) to enforce before
+  disk. That is the hard Phase A gate this integration passes on paper.
+- Shell redirection and script writes are **explicitly unsupported** for
+  pre-write enforcement. `PreToolUse(shell)` exposes only the command
+  string; Mneme does not parse shell commands (documented architectural
+  boundary). These mutations remain visible to a whole-file audit
+  (`mneme check --input <file>`) after the fact.
+- The Stop working-tree audit is deferred to a separate bounded milestone:
+  a correct audit needs a session-start baseline so pre-existing user
+  changes are not attributed to the agent.
+
+## Verification
+
+- Tests: `python -m pytest tests/integrations/kiro -p no:cacheprovider`
+  (envelope parsing, gate policy, applicability, modes, fail-open paths,
+  installer idempotency, packaging contract).
+- Live reproduction (pending): install the hook in a Kiro CLI workspace
+  with a `FORBID_LITERAL` rule, ask the agent to introduce the literal, and
+  observe the block; then repeat a compliant write and observe the allow.
+  Record both transcripts in the follow-up PR that promotes this
+  integration out of experimental.

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -1,33 +1,34 @@
-# Kiro Integration (Experimental)
+# Kiro CLI 3.0 Integration (Native)
 
-Experimental adapter evaluating proposed writes before disk in Kiro, using a
-Kiro `PreToolUse` command hook that runs the same introduced-content
-enforcement path as the Claude Code hook.
+Mneme gates Kiro's native file-write and append tools before they reach disk, using
+Kiro's `PreToolUse` command hook that runs the same introduced-content enforcement
+path as the Claude Code hook.
 
-**Status: contract-tested / experimental.** Live reproduction performed
-on **CLI 2.19.2** (default v2 engine vs `--v3` / CLI 3.0) on 2026-08-26. Results:
+**Status: live-verified on Kiro CLI 3.0 / v3 engine (`--v3`).** Live reproduction
+performed on **Kiro CLI 2.19.2 `--v3` (v3 engine / CLI 3.0)** on 2026-08-26.
+Results:
 
 | Capability | CLI 2.19.2 default (v2 engine) | CLI 2.19.2 `--v3` (v3 engine / CLI 3.0) |
 |------------|--------------------------------|-----------------------------------------|
 | Hook registration | PASS (agent config `hooks` map, camelCase) | **PASS** (`.kiro/hooks/*.json` v1 format automatically discovered) |
-| Envelope capture | PASS (`fs_write`, `command:create`, `file_text`) | **PASS** (`PreToolUse`, `session_id`, `fs_write`, `text`) |
+| Envelope capture | PASS (`fs_write`, `command:create`, `file_text`) | **PASS** (`PreToolUse`, `session_id`, `fs_write`/`fs_append`, `text`) |
 | Verdict generation (exit 2 on FAIL) | PASS | **PASS** |
 | **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **PASS** (tool blocked pre-disk, stderr shown to agent) |
 | Clean allowed write (exit 0 on PASS) | PASS | **PASS** (file written to disk) |
-| Overall enforcement support | **NOT SUPPORTED** | **PASS (contract-verified)** |
+| Overall enforcement support | **NOT SUPPORTED** | **PASS (live-verified)** |
 
-*Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files. In `--v3` mode (CLI 3.0), `.kiro/hooks/*.json` files are automatically discovered and loaded.
+*Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files. In `--v3` mode (CLI 3.0 / v3 engine), `.kiro/hooks/*.json` files are automatically discovered and loaded.
 
-Per the claim gate, this integration remains experimental until IDE 1.x validation is completed and the follow-up promotion PR lands.
+**Support scope:** Kiro CLI 3.0 / v3 engine **only**. CLI 2.x default mode is **NOT SUPPORTED** for enforcement. Kiro IDE 1.x remains **pending separate live validation** and is not claimed as supported.
 
 ## What it does
 
 - Parses the Kiro v1 `PreToolUse` STDIN envelope (`hook_event_name`, `cwd`,
   `session_id`, `tool_name`, `tool_input`).
-- Normalizes native write shapes — tool name `write` / `fs_write` /
-  `fsWrite` with `tool_input.path` + full `tool_input.text` (CLI 3.0) or
-  `tool_input.content` (documented) or `tool_input.file_text` (CLI 2.x create)
-  — onto Mneme's existing mutation representation.
+- Normalizes native write/append shapes — tool names `write` / `fs_write` /
+  `fsWrite` / `fs_append` with `tool_input.path` + full `tool_input.text`
+  (CLI 3.0) or `tool_input.content` (documented) or `tool_input.file_text`
+  (CLI 2.x create) — onto Mneme's existing mutation representation.
 - Reuses the shared gate verbatim: introduced-delta enforcement (ADR-018),
   corpus-wide typed-literal enforcement independent of retrieval rank
   (ADR-017/019), explicit path applicability via `--target-path` (ADR-020),
@@ -58,9 +59,9 @@ foreign hook entry already present and upserts only the
 `{"version": "v1", "hooks": [...]}` file. Global installation is not
 offered.
 
-**Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ / `--v3`** (the standalone
-`.kiro/hooks/*.json` format). CLI 2.x default mode uses agent-config hooks
-instead; the installed file will be ignored by CLI 2.x default mode.
+**Requires Kiro CLI 3.0+ / `--v3`** (the standalone `.kiro/hooks/*.json` format).
+CLI 2.x default mode uses agent-config hooks; the installed file will be
+ignored by CLI 2.x default mode. Kiro IDE 1.x is not yet validated.
 
 ## Enforcement mode
 

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -4,20 +4,32 @@ Mneme gates Kiro's native file-write tool before it reaches disk, using a
 Kiro `PreToolUse` command hook that runs the same introduced-content
 enforcement path as the Claude Code hook.
 
-**Status: contract-tested / experimental.** This integration was built and
-verified against the official Kiro documentation plus converging community
-observations of the CLI hook envelope. No live Kiro CLI/IDE execution was
-available during implementation. Per the claim gate in the PR, it is **not**
-listed under "Explicitly supported integrations" in the README until live
-allow/block reproduction exists on each claimed surface.
+**Status: contract-tested / experimental.** Live reproduction performed
+on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`) on 2026-08-26. Results:
+
+| Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
+|------------|----------------------------------|-------------------------------------------|
+| Hook registration | PASS (agent config `hooks` map, camelCase) | FAIL (`.kiro/hooks/*.json` ignored) |
+| Envelope capture | PASS | NOT TESTED |
+| Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
+| **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
+| Overall enforcement support | **NOT SUPPORTED** | Pending |
+
+The integration remains gated on live reproduction before any "supported"
+claim. **CLI 2.x is explicitly NOT supported for enforcement**; the PR
+documents the observed contract for regression testing only. Per the claim
+gate, it is **not** listed under "Explicitly supported integrations" in the
+README until live allow/block reproduction exists on a CLI 3.x or IDE 1.x
+surface.
 
 ## What it does
 
 - Parses the Kiro v1 `PreToolUse` STDIN envelope (`hook_event_name`, `cwd`,
   `session_id`, `tool_name`, `tool_input`).
 - Normalizes only the native write shape — tool name `write` / `fs_write` /
-  `fsWrite` with `tool_input.path` + full `tool_input.content` — onto
-  Mneme's existing mutation representation.
+  `fsWrite` with `tool_input.path` + full `tool_input.content` (documented)
+  **or** `tool_input.file_text` (CLI 2.19.2 observed for `command: "create"`)
+  — onto Mneme's existing mutation representation.
 - Reuses the shared gate verbatim: introduced-delta enforcement (ADR-018),
   corpus-wide typed-literal enforcement independent of retrieval rank
   (ADR-017/019), explicit path applicability via `--target-path` (ADR-020),
@@ -48,8 +60,9 @@ foreign hook entry already present and upserts only the
 `{"version": "v1", "hooks": [...]}` file. Global installation is not
 offered.
 
-Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ (the standalone `.kiro/hooks/*.json`
-format).
+**Requires Kiro IDE 1.0+ or Kiro CLI 3.0+** (the standalone
+`.kiro/hooks/*.json` format). CLI 2.x uses agent-config hooks instead; the
+installed file will be ignored by CLI 2.x.
 
 ## Enforcement mode
 
@@ -64,8 +77,8 @@ returned a blocking exit before the write executed.
 
 | Surface | Kiro hook fired | Proposed content pre-execution | Blocked pre-write | PostFileSave observed | Later audit |
 |---|---|---|---|---|---|
-| Native write (new file) | `PreToolUse(write)` | Yes — full content in `tool_input.content` | Yes (CLI) | n/a (blocked) or `PostFileCreate` | Yes |
-| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | Yes (CLI) | `PostFileSave` | Yes |
+| Native write (new file) | `PreToolUse(write)` | Yes — full content in `tool_input.content` (v1) or `file_text` (CLI 2.x) | **CLI 2.x: NO** (exit 2 returned but write executed); v1: pending | n/a (blocked) or `PostFileCreate` | Yes |
+| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | CLI 2.x: unobserved; v1: pending | `PostFileSave` | Yes |
 | Shell redirection (`echo x > f`) | `PreToolUse(shell)` — command string only | **No** — content is inside an unparsed shell command | **No** (deliberately not parsed) | Documented to fire after agent saves; unverified for shell writes | Yes |
 | Script-generated write | `PreToolUse(shell)` — command string only | **No** | **No** | Unverified | Yes |
 | Rename | No dedicated pre-rename trigger | No | No | No | Yes (git status) |
@@ -76,25 +89,26 @@ returned a blocking exit before the write executed.
 
 Key points:
 
-- Only the native write path on the **Kiro CLI** carries enough
-  pre-execution information (target path + full content) to enforce before
-  disk. That is the hard Phase A gate this integration passes on paper.
+- Only the native write path on the **Kiro CLI 3.x / IDE 1.x** carries
+  enough pre-execution information (target path + full content) to enforce
+  before disk. CLI 2.x returns correct verdicts but does not block.
 - Shell redirection and script writes are **explicitly unsupported** for
   pre-write enforcement. `PreToolUse(shell)` exposes only the command
   string; Mneme does not parse shell commands (documented architectural
-  boundary). These mutations remain visible to a whole-file audit
-  (`mneme check --input <file>`) after the fact.
+   boundary). These mutations remain visible to a whole-file audit
+   (`mneme check --input <file>`) after the fact.
 - The Stop working-tree audit is deferred to a separate bounded milestone:
-  a correct audit needs a session-start baseline so pre-existing user
-  changes are not attributed to the agent.
+   a correct audit needs a session-start baseline so pre-existing user
+   changes are not attributed to the agent.
 
 ## Verification
 
 - Tests: `python -m pytest tests/integrations/kiro -p no:cacheprovider`
   (envelope parsing, gate policy, applicability, modes, fail-open paths,
-  installer idempotency, packaging contract).
-- Live reproduction (pending): install the hook in a Kiro CLI workspace
-  with a `FORBID_LITERAL` rule, ask the agent to introduce the literal, and
-  observe the block; then repeat a compliant write and observe the allow.
-  Record both transcripts in the follow-up PR that promotes this
+  installer idempotency, packaging contract). Includes regression fixtures
+  for the CLI 2.19.2 observed envelope (`test_observed_cli_2_19_2_envelope_with_file_text`).
+- Live reproduction (pending): install the hook in a **Kiro CLI 3.x or IDE 1.x**
+  workspace with a `FORBID_LITERAL` rule, ask the agent to introduce the
+  literal, and observe the block; then repeat a compliant write and observe
+  the allow. Record both transcripts in the follow-up PR that promotes this
   integration out of experimental.

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -15,7 +15,7 @@ Results:
 | Verdict generation (exit 2 on FAIL) | PASS | **PASS** |
 | **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **PASS** (tool blocked pre-disk, stderr shown to agent) |
 | Clean allowed write (exit 0 on PASS) | PASS | **PASS** (file written to disk) |
-| Overall enforcement support | **NOT SUPPORTED** | **PASS (live-verified)** |
+| Overall enforcement support | **NOT SUPPORTED** | **SUPPORTED (live-verified)** |
 
 *Note on registration:* CLI 2.19.2 in default mode ignores `.kiro/hooks/*.json` files. In `--v3` mode (CLI 3.0 / v3 engine), `.kiro/hooks/*.json` files are automatically discovered and loaded.
 
@@ -88,7 +88,7 @@ returned a blocking exit before the write executed.
 
 Key points:
 
-- Only the native write path on the **Kiro CLI 3.x / IDE 1.x** carries
+- Only the native write path on the **Kiro CLI 3.0 / v3 engine** carries
   enough pre-execution information (target path + full content) to enforce
   before disk. CLI 2.x default mode returns correct verdicts but does not block.
 - Shell redirection and script writes are **explicitly unsupported** for

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -1,6 +1,6 @@
 # Kiro Integration (Experimental)
 
-Mneme gates Kiro's native file-write tool before it reaches disk, using a
+Experimental adapter evaluating proposed writes before disk in Kiro, using a
 Kiro `PreToolUse` command hook that runs the same introduced-content
 enforcement path as the Claude Code hook.
 
@@ -9,11 +9,13 @@ on **CLI 2.19.2** (`kiro-cli-chat 2.19.2`) on 2026-08-26. Results:
 
 | Capability | CLI 2.19.2 (agent-config hooks) | Documented CLI 3.0+ / IDE 1.0+ (v1 files) |
 |------------|----------------------------------|-------------------------------------------|
-| Hook registration | PASS (agent config `hooks` map, camelCase) | FAIL (`.kiro/hooks/*.json` ignored) |
-| Envelope capture | PASS | NOT TESTED |
+| Hook registration | PASS (agent config `hooks` map, camelCase) | NOT TESTED (documented supported) |
+| Envelope capture | PASS (live capture; `session_id` omitted) | NOT TESTED |
 | Verdict generation (exit 2 on FAIL) | PASS | NOT TESTED |
 | **Pre-execution blocking** | **FAIL** (file written despite exit 2) | **NOT TESTED** |
 | Overall enforcement support | **NOT SUPPORTED** | Pending |
+
+*Note on registration:* CLI 2.19.2 ignores `.kiro/hooks/*.json` files. That registration failure is specific to CLI 2.x and is not projected onto CLI 3.x / IDE 1.x.
 
 The integration remains gated on live reproduction before any "supported"
 claim. **CLI 2.x is explicitly NOT supported for enforcement**; the PR
@@ -85,7 +87,7 @@ returned a blocking exit before the write executed.
 | Deletion | `PostFileDelete` only (post, non-blocking) | No | No (nothing introduced; ADR-018 permits deletions) | `PostFileDelete` fires post-hoc | Yes |
 | MCP-mediated write | `PreToolUse(@server/tool)` documented | Server-specific; envelope officially documented, shape per server | Not implemented | `PostToolUse` | Yes |
 | Spec-task mutations (IDE) | `PreTaskExec` (pre-task, IDE-only) | No file-level payload | No | `PostTaskExec` | Yes |
-| Kiro IDE native writes | `PreToolUse` fires per docs, **but `runCommand` hooks currently receive no STDIN payload** (#7408/#7500, reconfirmed 2026-06 on 0.12) | **No** | **No** — fail-open with nothing to inspect | `PostFileSave` | Yes |
+| Kiro IDE native writes | `PreToolUse` fires per docs; historical IDE 0.12 `runCommand` hooks received no STDIN payload (#7408/#7500); IDE 1.x pending validation | **No** (historical) | **No** (historical) — fail-open with nothing to inspect | `PostFileSave` | Yes |
 
 Key points:
 

--- a/docs/integrations/kiro.md
+++ b/docs/integrations/kiro.md
@@ -76,7 +76,7 @@ returned a blocking exit before the write executed.
 | Surface | Kiro hook fired | Proposed content pre-execution | Blocked pre-write | PostFileSave observed | Later audit |
 |---|---|---|---|---|---|
 | Native write (new file) | `PreToolUse(write)` | Yes — full content in `text` (v3), `content` (v1), or `file_text` (CLI 2.x) | **CLI 3.0 / v3: YES** (blocked pre-disk); CLI 2.x: NO | n/a (blocked) or `PostFileCreate` | Yes |
-| Native edit / replace | `PreToolUse(write)` | Yes — full proposed content; gate checks introduced lines only | CLI 3.0: expected; CLI 2.x: unobserved | `PostFileSave` | Yes |
+| Native edit / append | `PreToolUse(write|fs_append)` | Yes — full proposed content or appended lines; gate checks introduced delta | **CLI 3.0 / v3: YES** (blocked pre-disk, file untouched); CLI 2.x: unobserved | `PostFileSave` | Yes |
 | Shell redirection (`echo x > f`) | `PreToolUse(shell)` — command string only | **No** — content is inside an unparsed shell command | **No** (deliberately not parsed) | Documented to fire after agent saves; unverified for shell writes | Yes |
 | Script-generated write | `PreToolUse(shell)` — command string only | **No** | **No** | Unverified | Yes |
 | Rename | No dedicated pre-rename trigger | No | No | No | Yes (git status) |
@@ -104,7 +104,10 @@ Key points:
 - Tests: `python -m pytest tests/integrations/kiro -p no:cacheprovider`
   (envelope parsing, gate policy, applicability, modes, fail-open paths,
   installer idempotency, packaging contract). Includes regression fixtures
-  for both the CLI 3.0 v3 envelope (`test_observed_v3_envelope_with_text`)
+  for both the CLI 3.0 v3 envelope (`test_observed_v3_envelope_with_text`),
+  the v3 append envelope (`test_observed_v3_fs_append_envelope`),
   and the CLI 2.19.2 v2 envelope (`test_observed_cli_2_19_2_envelope_with_file_text`).
 - Live reproduction: verified live on Kiro CLI 2.19.2 `--v3` (v3 engine / CLI 3.0)
-  with strict pre-disk blocking on forbidden writes and clean pass on allowed writes.
+  with strict pre-disk blocking on forbidden new-file writes, strict pre-disk blocking
+  on existing-file appends/edits (file content byte-identical and untouched), and clean
+  pass on allowed writes.

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,15 +1,15 @@
 # Mneme Kiro Integration
 
-Mneme enforces recorded architectural decisions **before** Kiro's native
-file-write tool reaches disk.
+Experimental adapter evaluating recorded architectural decisions against Kiro
+file-write events.
 
 Mneme is governance infrastructure: it runs alongside the harness, not
-inside it. Kiro coordinates execution; Mneme supplies deterministic,
-pre-execution enforcement of decisions recorded in the project's
-`.mneme/project_memory.json`. Nothing about Kiro's own permission flow is
-weakened — a Mneme PASS emits nothing at all.
+inside it. Kiro coordinates execution; Mneme supplies deterministic
+evaluation of decisions recorded in the project's `.mneme/project_memory.json`.
+Nothing about Kiro's own permission flow is weakened — a Mneme PASS emits
+nothing at all.
 
-## What gets enforced
+## What gets evaluated
 
 - `FORBID_LITERAL` typed rules (exact, case-sensitive, identifier-boundary
   matching), evaluated corpus-wide independent of retrieval rank.
@@ -31,10 +31,13 @@ python scripts/install_kiro.py ~/src/myproject
 ```
 
 Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ and the `mneme-kiro-hook` console
-script on PATH.
+script on PATH. (Note: CLI 2.x uses agent-config hooks and is unsupported
+for pre-write blocking).
 
 ## Status
 
-**Contract-tested / experimental.** See `docs/integrations/kiro.md` for the
-mutation-surface coverage matrix and `docs/integrations/kiro-hook-spec.md`
-for the documented-versus-observed contract.
+**Contract-tested / experimental.** CLI 2.x enforcement is unsupported
+(harness does not block). CLI 3.x / IDE 1.x live validation is pending.
+See `docs/integrations/kiro.md` for the mutation-surface coverage matrix
+and `docs/integrations/kiro-hook-spec.md` for the documented-versus-observed
+contract.

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,0 +1,40 @@
+# Mneme Kiro Integration
+
+Mneme enforces recorded architectural decisions **before** Kiro's native
+file-write tool reaches disk.
+
+Mneme is governance infrastructure: it runs alongside the harness, not
+inside it. Kiro coordinates execution; Mneme supplies deterministic,
+pre-execution enforcement of decisions recorded in the project's
+`.mneme/project_memory.json`. Nothing about Kiro's own permission flow is
+weakened — a Mneme PASS emits nothing at all.
+
+## What gets enforced
+
+- `FORBID_LITERAL` typed rules (exact, case-sensitive, identifier-boundary
+  matching), evaluated corpus-wide independent of retrieval rank.
+- Legacy constraints/anti-patterns under the same retrieval-gated semantics
+  as every other Mneme integration.
+- Introduced content only (ADR-018): a write over an existing file checks
+  its inserted/replaced lines; remediation edits are never blocked by the
+  violation they remove.
+- Path applicability (ADR-020): scoped rules apply only where their
+  include/exclude selectors match; unknown applicability fails open with an
+  explicit diagnostic.
+
+## Install
+
+```bash
+pip install mneme-hq
+python scripts/install_kiro.py            # project scope (default)
+python scripts/install_kiro.py ~/src/myproject
+```
+
+Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ and the `mneme-kiro-hook` console
+script on PATH.
+
+## Status
+
+**Contract-tested / experimental.** See `docs/integrations/kiro.md` for the
+mutation-surface coverage matrix and `docs/integrations/kiro-hook-spec.md`
+for the documented-versus-observed contract.

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,7 +1,8 @@
-# Mneme Kiro Integration
+# Mneme Kiro CLI 3.0 Integration
 
-Experimental adapter evaluating recorded architectural decisions against Kiro
-file-write events.
+Mneme gates Kiro's native file-write and append tools before they reach
+disk, using Kiro's `PreToolUse` command hook that runs the same
+introduced-content enforcement path as the Claude Code hook.
 
 Mneme is governance infrastructure: it runs alongside the harness, not
 inside it. Kiro coordinates execution; Mneme supplies deterministic
@@ -30,14 +31,22 @@ python scripts/install_kiro.py            # project scope (default)
 python scripts/install_kiro.py ~/src/myproject
 ```
 
-Requires Kiro IDE 1.0+ or Kiro CLI 3.0+ and the `mneme-kiro-hook` console
-script on PATH. (Note: CLI 2.x uses agent-config hooks and is unsupported
-for pre-write blocking).
+Requires Kiro CLI 3.0+ / `--v3` and the `mneme-kiro-hook` console script on
+PATH. (Note: CLI 2.x uses agent-config hooks and is unsupported for
+pre-write blocking. Kiro IDE 1.x is not yet validated.)
 
 ## Status
 
-**Contract-tested / experimental.** CLI 2.x enforcement is unsupported
-(harness does not block). CLI 3.x / IDE 1.x live validation is pending.
+**Live-verified on Kiro CLI 3.0 / v3 engine (`--v3`).** Live reproduction
+performed on Kiro CLI 2.19.2 `--v3` (v3 engine / CLI 3.0) on 2026-08-26
+with strict pre-disk blocking on forbidden new-file writes and existing-file
+appends/edits (file content byte-identical and untouched), and clean pass on
+allowed writes.
+
+**Support scope:** Kiro CLI 3.0 / v3 engine **only**. CLI 2.x default mode is
+**NOT SUPPORTED** for enforcement. Kiro IDE 1.x remains **pending separate
+live validation** and is not claimed as supported.
+
 See `docs/integrations/kiro.md` for the mutation-surface coverage matrix
 and `docs/integrations/kiro-hook-spec.md` for the documented-versus-observed
 contract.

--- a/integrations/kiro/hooks/mneme.json
+++ b/integrations/kiro/hooks/mneme.json
@@ -5,7 +5,7 @@
       "name": "mneme-governance-gate",
       "description": "Mneme architectural decision gate: evaluates proposed native file writes against recorded decisions.",
       "trigger": "PreToolUse",
-      "matcher": "^(fs_write|fsWrite|write)$",
+      "matcher": "^(fs_write|fsWrite|write|fs_append)$",
       "action": {
         "type": "command",
         "command": "mneme-kiro-hook"

--- a/integrations/kiro/hooks/mneme.json
+++ b/integrations/kiro/hooks/mneme.json
@@ -1,0 +1,17 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "mneme-governance-gate",
+      "description": "Mneme architectural decision gate: blocks native file writes that introduce violations before they reach disk.",
+      "trigger": "PreToolUse",
+      "matcher": "^(fs_write|fsWrite|write)$",
+      "action": {
+        "type": "command",
+        "command": "mneme-kiro-hook"
+      },
+      "timeout": 30,
+      "enabled": true
+    }
+  ]
+}

--- a/integrations/kiro/hooks/mneme.json
+++ b/integrations/kiro/hooks/mneme.json
@@ -3,7 +3,7 @@
   "hooks": [
     {
       "name": "mneme-governance-gate",
-      "description": "Mneme architectural decision gate: blocks native file writes that introduce violations before they reach disk.",
+      "description": "Mneme architectural decision gate: evaluates proposed native file writes against recorded decisions.",
       "trigger": "PreToolUse",
       "matcher": "^(fs_write|fsWrite|write)$",
       "action": {

--- a/mneme/integrations/kiro/__init__.py
+++ b/mneme/integrations/kiro/__init__.py
@@ -1,0 +1,1 @@
+"""Kiro integration — Mneme governance gate for Kiro CLI native writes."""

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -1,4 +1,4 @@
-"""Kiro hook — experimental adapter evaluating proposed writes before disk.
+"""Kiro CLI 3.0 / v3 hook — live-verified enforcement before disk.
 
 Translates the Kiro PreToolUse hook envelope onto the existing Mneme
 mutation-gate path. No retrieval, applicability, conflict, or enforcement
@@ -6,11 +6,12 @@ semantics are implemented here; the pure pieces are imported from
 ``mneme.integrations.claude_code.hook`` (the same precedent as the
 Agent SDK adapter).
 
-Status: experimental adapter. CLI 2.x is unsupported for enforcement
-(verdicts evaluate correctly but the 2.x harness does not block).
-CLI 3.x and IDE 1.x v1 contracts remain pending live validation.
+Status: live-verified on Kiro CLI 3.0 / v3 engine (kiro-cli --v3).
+CLI 2.x is unsupported for enforcement (verdicts evaluate correctly
+but the 2.x harness does not block). IDE 1.x remains pending live
+validation.
 
-Documented contract (Kiro CLI 3.0+, IDE 1.0+; see
+Documented contract (Kiro CLI 3.0+; see
 docs/integrations/kiro-hook-spec.md for documented-versus-observed status):
 
 - Hook files live at ``.kiro/hooks/*.json`` (schema ``version: "v1"``).
@@ -18,8 +19,8 @@ docs/integrations/kiro-hook-spec.md for documented-versus-observed status):
   ``hook_event_name``, ``cwd``, ``session_id``, ``tool_name``, and
   ``tool_input``.
 - The native file-write tool is ``write`` (documented aliases:
-  ``fs_write``, ``fsWrite``) whose input carries ``path`` and the full
-  proposed ``content``.
+  ``fs_write``, ``fsWrite``, ``fs_append``) whose input carries ``path``
+  and the full proposed ``text``.
 - Exit code 0: hook succeeded; stdout is added to agent context.
 - Any non-zero exit from ``PreToolUse`` blocks the tool invocation;
   stderr is sent to the agent.

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -118,6 +118,8 @@ def normalize_to_tool_event(
         tool_input = {}
     path = tool_input.get("path", "")
     content = tool_input.get("content")
+    if content is None and "text" in tool_input:
+        content = tool_input.get("text")
 
     if content is None:
         # Legacy fallback observed exclusively on Kiro CLI 2.19.2 (2026-08-26):

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -110,7 +110,17 @@ def normalize_to_tool_event(payload: Dict[str, object]) -> Optional[ToolEvent]:
     if not isinstance(tool_input, dict):
         tool_input = {}
     path = tool_input.get("path", "")
-    content = tool_input.get("content", "")
+    content = tool_input.get("content")
+    if content is None:
+        # Constrained legacy fallback for Kiro CLI 2.19.2 (observed on 2026-08-26):
+        # only accept 'file_text' when tool is 'fs_write' and command is 'create'.
+        # Do not infer edit/replace schemas; unhandled forms degrade to empty string
+        # or fail open visibly.
+        if tool_name == "fs_write" and tool_input.get("command") == "create":
+            raw_text = tool_input.get("file_text")
+            content = raw_text if isinstance(raw_text, str) else ""
+        else:
+            content = ""
     # Reuse the Claude-Code-shaped materializer verbatim by presenting the
     # event as a whole-content Write.
     return ToolEvent(

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -71,7 +71,7 @@ from mneme.integrations.claude_code.hook import (
 
 # The native write tool name plus its documented aliases (kiro.dev/docs/
 # reference/built-in-tools/). No undocumented names are accepted.
-_WRITE_TOOL_NAMES = frozenset({"write", "fs_write", "fsWrite"})
+_WRITE_TOOL_NAMES = frozenset({"write", "fs_write", "fsWrite", "fs_append"})
 
 _EVENT_NAME = "pretooluse"
 
@@ -117,31 +117,42 @@ def normalize_to_tool_event(
     if not isinstance(tool_input, dict):
         tool_input = {}
     path = tool_input.get("path", "")
-    content = tool_input.get("content")
-    if content is None and "text" in tool_input:
-        content = tool_input.get("text")
+    cwd = str(payload.get("cwd", "") or "")
 
-    if content is None:
-        # Legacy fallback observed exclusively on Kiro CLI 2.19.2 (2026-08-26):
-        # 'fs_write' with command='create' carries content in 'file_text'.
-        if tool_name == "fs_write" and "file_text" in tool_input:
-            cmd = tool_input.get("command")
-            if cmd == "create":
-                raw_text = tool_input.get("file_text")
-                content = raw_text if isinstance(raw_text, str) else ""
+    if tool_name == "fs_append":
+        append_text = str(tool_input.get("text") or "")
+        resolved = Path(path) if Path(path).is_absolute() else Path(cwd) / path
+        try:
+            current_text = resolved.read_text(encoding="utf-8") if resolved.is_file() else ""
+        except (OSError, UnicodeError):
+            current_text = ""
+        content = current_text + append_text
+    else:
+        content = tool_input.get("content")
+        if content is None and "text" in tool_input:
+            content = tool_input.get("text")
+
+        if content is None:
+            # Legacy fallback observed exclusively on Kiro CLI 2.19.2 (2026-08-26):
+            # 'fs_write' with command='create' carries content in 'file_text'.
+            if tool_name == "fs_write" and "file_text" in tool_input:
+                cmd = tool_input.get("command")
+                if cmd == "create":
+                    raw_text = tool_input.get("file_text")
+                    content = raw_text if isinstance(raw_text, str) else ""
+                else:
+                    return None, f"unsupported legacy write shape: fs_write command={cmd!r} with file_text"
+            elif "file_text" in tool_input:
+                return None, f"unsupported legacy write shape: {tool_name} with file_text"
             else:
-                return None, f"unsupported legacy write shape: fs_write command={cmd!r} with file_text"
-        elif "file_text" in tool_input:
-            return None, f"unsupported legacy write shape: {tool_name} with file_text"
-        else:
-            content = ""
+                content = ""
 
     # Reuse the Claude-Code-shaped materializer verbatim by presenting the
     # event as a whole-content Write.
     event = ToolEvent(
         tool_name="Write",
         file_path=path if isinstance(path, str) else "",
-        cwd=str(payload.get("cwd", "") or ""),
+        cwd=cwd,
         tool_input={
             "file_path": path if isinstance(path, str) else "",
             "content": content if isinstance(content, str) else "",

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -1,10 +1,14 @@
-"""Kiro hook — enforces Mneme decisions before Kiro's native write reaches disk.
+"""Kiro hook — experimental adapter evaluating proposed writes before disk.
 
-Translates the Kiro CLI v1 ``PreToolUse`` hook envelope onto the existing
-Mneme mutation-gate path. No retrieval, applicability, conflict, or
-enforcement semantics are implemented here; the pure pieces are imported
-from ``mneme.integrations.claude_code.hook`` (the same precedent as the
+Translates the Kiro PreToolUse hook envelope onto the existing Mneme
+mutation-gate path. No retrieval, applicability, conflict, or enforcement
+semantics are implemented here; the pure pieces are imported from
+``mneme.integrations.claude_code.hook`` (the same precedent as the
 Agent SDK adapter).
+
+Status: experimental adapter. CLI 2.x is unsupported for enforcement
+(verdicts evaluate correctly but the 2.x harness does not block).
+CLI 3.x and IDE 1.x v1 contracts remain pending live validation.
 
 Documented contract (Kiro CLI 3.0+, IDE 1.0+; see
 docs/integrations/kiro-hook-spec.md for documented-versus-observed status):
@@ -32,7 +36,8 @@ Policy (mirrors the Claude Code hook policy):
   timeout, subprocess failure,
   stale CLI, unparseable
   verdict, incomplete
-  applicability evaluation      -> fail open but visibly: exit 0 with an
+  applicability evaluation,
+  unsupported legacy write shape-> fail open but visibly: exit 0 with an
                                    UNEVALUATED notice on stdout
 - no project memory             -> exit 0 quietly
 
@@ -48,7 +53,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional, TextIO
+from typing import Dict, Optional, TextIO, Tuple
 
 from mneme.integrations.claude_code.hook import (
     ToolEvent,
@@ -92,38 +97,46 @@ def is_write_tool(tool_name: str) -> bool:
     return tool_name in _WRITE_TOOL_NAMES
 
 
-def normalize_to_tool_event(payload: Dict[str, object]) -> Optional[ToolEvent]:
+def normalize_to_tool_event(
+    payload: Dict[str, object],
+) -> Tuple[Optional[ToolEvent], Optional[str]]:
     """Map the observed native write shape onto Mneme's ToolEvent.
 
-    Returns ``None`` for events this gate does not govern (non-PreToolUse
-    events, non-write tools). Only the observed shape -- ``tool_input``
-    carrying ``path`` and full ``content`` -- is normalized. Missing
-    ``path`` or ``content`` degrade to empty strings so the shared
-    materializer decides how to treat them.
+    Returns ``(ToolEvent, None)`` for supported write events.
+    Returns ``(None, None)`` for events this gate does not govern (non-PreToolUse, non-write tools).
+    Returns ``(None, "unsupported shape description")`` when a write tool was targeted
+    with an unobserved/unsupported payload structure (e.g. legacy edit/replace using file_text),
+    requiring a visible fail-open notice.
     """
     if str(payload.get("hook_event_name", "")).lower() != _EVENT_NAME:
-        return None
+        return None, None
     tool_name = payload.get("tool_name")
     if not isinstance(tool_name, str) or not is_write_tool(tool_name):
-        return None
+        return None, None
     tool_input = payload.get("tool_input") or {}
     if not isinstance(tool_input, dict):
         tool_input = {}
     path = tool_input.get("path", "")
     content = tool_input.get("content")
+
     if content is None:
-        # Constrained legacy fallback for Kiro CLI 2.19.2 (observed on 2026-08-26):
-        # only accept 'file_text' when tool is 'fs_write' and command is 'create'.
-        # Do not infer edit/replace schemas; unhandled forms degrade to empty string
-        # or fail open visibly.
-        if tool_name == "fs_write" and tool_input.get("command") == "create":
-            raw_text = tool_input.get("file_text")
-            content = raw_text if isinstance(raw_text, str) else ""
+        # Legacy fallback observed exclusively on Kiro CLI 2.19.2 (2026-08-26):
+        # 'fs_write' with command='create' carries content in 'file_text'.
+        if tool_name == "fs_write" and "file_text" in tool_input:
+            cmd = tool_input.get("command")
+            if cmd == "create":
+                raw_text = tool_input.get("file_text")
+                content = raw_text if isinstance(raw_text, str) else ""
+            else:
+                return None, f"unsupported legacy write shape: fs_write command={cmd!r} with file_text"
+        elif "file_text" in tool_input:
+            return None, f"unsupported legacy write shape: {tool_name} with file_text"
         else:
             content = ""
+
     # Reuse the Claude-Code-shaped materializer verbatim by presenting the
     # event as a whole-content Write.
-    return ToolEvent(
+    event = ToolEvent(
         tool_name="Write",
         file_path=path if isinstance(path, str) else "",
         cwd=str(payload.get("cwd", "") or ""),
@@ -132,6 +145,7 @@ def normalize_to_tool_event(payload: Dict[str, object]) -> Optional[ToolEvent]:
             "content": content if isinstance(content, str) else "",
         },
     )
+    return event, None
 
 
 def _run_check(
@@ -255,7 +269,10 @@ def main(
         print(f"mneme-kiro-hook: bad envelope: {e}", file=stderr)
         return 0
 
-    event = normalize_to_tool_event(payload)
+    event, unhandled_reason = normalize_to_tool_event(payload)
+    if unhandled_reason is not None:
+        _emit_unevaluated(stdout, unhandled_reason)
+        return 0
     if event is None:
         return 0
 

--- a/mneme/integrations/kiro/hook.py
+++ b/mneme/integrations/kiro/hook.py
@@ -1,0 +1,279 @@
+"""Kiro hook — enforces Mneme decisions before Kiro's native write reaches disk.
+
+Translates the Kiro CLI v1 ``PreToolUse`` hook envelope onto the existing
+Mneme mutation-gate path. No retrieval, applicability, conflict, or
+enforcement semantics are implemented here; the pure pieces are imported
+from ``mneme.integrations.claude_code.hook`` (the same precedent as the
+Agent SDK adapter).
+
+Documented contract (Kiro CLI 3.0+, IDE 1.0+; see
+docs/integrations/kiro-hook-spec.md for documented-versus-observed status):
+
+- Hook files live at ``.kiro/hooks/*.json`` (schema ``version: "v1"``).
+- A command action receives one JSON event on STDIN with at least
+  ``hook_event_name``, ``cwd``, ``session_id``, ``tool_name``, and
+  ``tool_input``.
+- The native file-write tool is ``write`` (documented aliases:
+  ``fs_write``, ``fsWrite``) whose input carries ``path`` and the full
+  proposed ``content``.
+- Exit code 0: hook succeeded; stdout is added to agent context.
+- Any non-zero exit from ``PreToolUse`` blocks the tool invocation;
+  stderr is sent to the agent.
+
+Policy (mirrors the Claude Code hook policy):
+
+- trusted PASS                  -> exit 0, no output (Kiro's normal
+                                   permission flow is untouched)
+- trusted WARN/FAIL, strict     -> reason to stderr, exit 2 (blocks)
+- trusted WARN/FAIL, warn mode  -> exit 0, warning on stdout so Kiro adds
+                                   it to agent context
+- malformed envelope            -> exit 0 quietly (nothing to gate)
+- materialization failure,
+  timeout, subprocess failure,
+  stale CLI, unparseable
+  verdict, incomplete
+  applicability evaluation      -> fail open but visibly: exit 0 with an
+                                   UNEVALUATED notice on stdout
+- no project memory             -> exit 0 quietly
+
+Only trusted ``mneme.check/v1`` JSON verdicts are acted on. An exit code
+from ``mneme check`` alone is never interpreted as a policy verdict.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional, TextIO
+
+from mneme.integrations.claude_code.hook import (
+    ToolEvent,
+    _CHECK_TIMEOUT_SECONDS,
+    _child_env,
+    _is_stale_runtime,
+    find_memory,
+    format_applicability_reason,
+    format_reason,
+    introduced_content,
+    MaterializeError,
+    parse_verdict,
+    resolve_mode,
+)
+
+# The native write tool name plus its documented aliases (kiro.dev/docs/
+# reference/built-in-tools/). No undocumented names are accepted.
+_WRITE_TOOL_NAMES = frozenset({"write", "fs_write", "fsWrite"})
+
+_EVENT_NAME = "pretooluse"
+
+_BLOCK_EXIT_CODE = 2
+
+
+def parse_kiro_envelope(raw: str) -> Dict[str, object]:
+    """Parse the JSON event Kiro pipes to a command-action hook on STDIN.
+
+    Raises ``json.JSONDecodeError`` for non-JSON input and ``KeyError``
+    when required fields are missing.
+    """
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise KeyError("envelope is not a JSON object")
+    if "hook_event_name" not in payload:
+        raise KeyError("missing hook_event_name")
+    return payload
+
+
+def is_write_tool(tool_name: str) -> bool:
+    """True for the native write tool under any documented name."""
+    return tool_name in _WRITE_TOOL_NAMES
+
+
+def normalize_to_tool_event(payload: Dict[str, object]) -> Optional[ToolEvent]:
+    """Map the observed native write shape onto Mneme's ToolEvent.
+
+    Returns ``None`` for events this gate does not govern (non-PreToolUse
+    events, non-write tools). Only the observed shape -- ``tool_input``
+    carrying ``path`` and full ``content`` -- is normalized. Missing
+    ``path`` or ``content`` degrade to empty strings so the shared
+    materializer decides how to treat them.
+    """
+    if str(payload.get("hook_event_name", "")).lower() != _EVENT_NAME:
+        return None
+    tool_name = payload.get("tool_name")
+    if not isinstance(tool_name, str) or not is_write_tool(tool_name):
+        return None
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    path = tool_input.get("path", "")
+    content = tool_input.get("content", "")
+    # Reuse the Claude-Code-shaped materializer verbatim by presenting the
+    # event as a whole-content Write.
+    return ToolEvent(
+        tool_name="Write",
+        file_path=path if isinstance(path, str) else "",
+        cwd=str(payload.get("cwd", "") or ""),
+        tool_input={
+            "file_path": path if isinstance(path, str) else "",
+            "content": content if isinstance(content, str) else "",
+        },
+    )
+
+
+def _run_check(
+    event: ToolEvent,
+    checked_content: str,
+    memory: Path,
+    stderr: TextIO,
+    stdout: TextIO,
+) -> int:
+    """Evaluate introduced content through `mneme check` and map to exit codes.
+
+    The child invocation is identical to the Claude Code hook's: same
+    memory, same query form, same ``--target-path`` for typed-rule
+    applicability, same pinned PYTHONPATH, same timeout.
+    """
+    mode = resolve_mode()
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(checked_content)
+        input_path = tf.name
+
+    try:
+        rel = event.file_path or "(unknown)"
+        target_path = event.file_path
+        if target_path and not Path(target_path).is_absolute() and event.cwd:
+            target_path = str(Path(event.cwd) / target_path)
+        command = [
+            sys.executable, "-m", "mneme", "check",
+            "--memory", str(memory),
+            "--input", input_path,
+            "--query", f"edit to {rel}",
+            "--mode", mode,
+            "--json",
+        ]
+        if target_path:
+            command.extend(["--target-path", target_path])
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_CHECK_TIMEOUT_SECONDS,
+                env=_child_env(),
+            )
+        except FileNotFoundError:
+            _emit_unevaluated(
+                stdout, "could not launch mneme check (interpreter not found)"
+            )
+            return 0
+        except (OSError, subprocess.TimeoutExpired) as e:
+            _emit_unevaluated(stdout, f"check could not run ({e})")
+            return 0
+
+        payload = parse_verdict(proc.stdout)
+        if payload is None:
+            if _is_stale_runtime(proc.stderr):
+                print(
+                    "mneme-kiro-hook: the installed mneme CLI does not support "
+                    "the required JSON/path-aware check options, so no edit "
+                    "can be checked and ENFORCEMENT IS INACTIVE. "
+                    "Upgrade with: pipx upgrade mneme-hq",
+                    file=stderr,
+                )
+                _emit_unevaluated(
+                    stdout, "stale mneme CLI; enforcement inactive"
+                )
+                return 0
+            _emit_unevaluated(
+                stdout,
+                f"no parseable verdict from mneme check (exit {proc.returncode})",
+            )
+            if proc.stderr:
+                print(proc.stderr, file=stderr)
+            return 0
+
+        verdict = payload["verdict"]
+        if payload.get("evaluation_complete") is False:
+            print(format_applicability_reason(payload), file=stderr)
+            _emit_unevaluated(
+                stdout, "typed-rule path applicability unknown"
+            )
+            return 0
+        if verdict == "PASS":
+            return 0
+
+        reason = format_reason(payload)
+        if mode == "warn":
+            print(
+                "[mneme] WARN - architectural decision flagged "
+                "(warn mode; not blocked):\n" + reason,
+                file=stdout,
+            )
+            return 0
+
+        print(reason, file=stderr)
+        return _BLOCK_EXIT_CODE
+    finally:
+        try:
+            os.unlink(input_path)
+        except OSError:
+            pass
+
+
+def _emit_unevaluated(stdout: TextIO, detail: str) -> None:
+    """Fail open visibly: exit-0 stdout becomes Kiro's agent context."""
+    print(f"[mneme] UNEVALUATED - failing open, this mutation was NOT checked: {detail}", file=stdout)
+
+
+def main(
+    stdin: TextIO = sys.stdin,
+    stderr: TextIO = sys.stderr,
+    stdout: TextIO = sys.stdout,
+) -> int:
+    try:
+        raw = stdin.read()
+        payload = parse_kiro_envelope(raw)
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"mneme-kiro-hook: bad envelope: {e}", file=stderr)
+        return 0
+
+    event = normalize_to_tool_event(payload)
+    if event is None:
+        return 0
+
+    memory = find_memory(Path(event.cwd or "."))
+    if memory is None:
+        return 0
+
+    try:
+        # Introduced-delta enforcement (ADR-018) via the shared gate: a
+        # whole-content Write over an existing file checks only inserted or
+        # replaced lines; a new file checks all of it; remediation of a
+        # pre-existing violation is never blocked by what it removes.
+        checked_content = introduced_content(event)
+    except MaterializeError as e:
+        _emit_unevaluated(stdout, f"cannot materialize content ({e})")
+        return 0
+
+    if not checked_content.strip():
+        # Pure deletion or whitespace-only change: nothing introduced that a
+        # mechanical rule could match (ADR-018).
+        return 0
+
+    return _run_check(event, checked_content, memory, stderr, stdout)
+
+
+def cli_main() -> None:
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 [project.scripts]
 mneme = "mneme.cli:main"
 mneme-hook = "mneme.integrations.claude_code.hook:cli_main"
+mneme-kiro-hook = "mneme.integrations.kiro.hook:cli_main"
 
 [project.urls]
 Homepage = "https://mnemehq.com"

--- a/scripts/install_kiro.py
+++ b/scripts/install_kiro.py
@@ -1,0 +1,114 @@
+"""Idempotent, project-scoped installer for the Mneme Kiro hook.
+
+Writes (or upserts) ``.kiro/hooks/mneme.json`` under the target project
+root. Kiro activates hook files in that directory automatically at session
+start; project scope is the default because Mneme Layer 1 is project-scoped.
+No global installation is provided.
+
+Behavior:
+
+- Fresh install: creates ``.kiro/hooks/mneme.json`` with the single
+  ``mneme-governance-gate`` hook definition from
+  ``integrations/kiro/hooks/mneme.json``.
+- Existing file that parses as a v1 hooks file: preserves every foreign
+  hook entry and upserts only the ``mneme-governance-gate`` entry.
+- Existing file that is not valid JSON or not a v1 hooks object: aborts
+  without writing. An unrelated Kiro hooks file is never clobbered.
+- Re-running produces a byte-identical file (idempotent).
+
+Usage::
+
+    python scripts/install_kiro.py [PROJECT_DIR]
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+HOOK_NAME = "mneme-governance-gate"
+
+_TEMPLATE = Path(__file__).resolve().parent.parent / "integrations" / "kiro" / "hooks" / "mneme.json"
+
+
+def load_template() -> dict:
+    with _TEMPLATE.open(encoding="utf-8") as fh:
+        template = json.load(fh)
+    if template.get("version") != "v1" or not isinstance(template.get("hooks"), list) \
+            or len(template["hooks"]) != 1:
+        raise ValueError("mneme.json template is not a single-hook v1 file")
+    return template
+
+
+def _is_v1_hooks_file(payload: object) -> bool:
+    return (
+        isinstance(payload, dict)
+        and payload.get("version") == "v1"
+        and isinstance(payload.get("hooks"), list)
+    )
+
+
+def compute_target(existing: dict | None) -> dict:
+    """Return the file content to write given an existing parsed file."""
+    template = load_template()
+    ours = template["hooks"][0]
+    if existing is None:
+        return {"version": "v1", "hooks": [ours]}
+    hooks = [h for h in existing["hooks"] if not (isinstance(h, dict) and h.get("name") == HOOK_NAME)]
+    hooks.append(ours)
+    return {"version": "v1", "hooks": hooks}
+
+
+def install(project_dir: Path) -> Path:
+    """Install or update ``<project>/.kiro/hooks/mneme.json``; returns its path."""
+    hooks_dir = project_dir / ".kiro" / "hooks"
+    target = hooks_dir / "mneme.json"
+
+    existing = None
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeError) as e:
+            raise SystemExit(
+                f"refusing to touch {target}: it is not valid UTF-8 JSON ({e}). "
+                "Resolve it manually before installing."
+            )
+        if not _is_v1_hooks_file(existing):
+            raise SystemExit(
+                f"refusing to touch {target}: it exists but is not a "
+                '{"version": "v1", "hooks": [...]} file. Resolve it manually '
+                "before installing."
+            )
+
+    content = compute_target(existing)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(content, indent=2, ensure_ascii=True) + "\n"
+    if target.exists() and target.read_text(encoding="utf-8") == rendered:
+        print(f"mneme-kiro-hook already installed at {target} (no change)")
+    else:
+        target.write_text(rendered, encoding="utf-8")
+        print(f"installed mneme-kiro-hook at {target}")
+
+    if shutil.which("mneme-kiro-hook") is None:
+        print(
+            "warning: 'mneme-kiro-hook' was not found on PATH. Install the "
+            "package first (e.g. pipx install mneme-hq), otherwise the hook "
+            "will fail open on every event."
+        )
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    project_dir = Path(argv[0]).resolve() if argv else Path.cwd()
+    if not project_dir.is_dir():
+        print(f"project directory does not exist: {project_dir}", file=sys.stderr)
+        return 1
+    install(project_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integrations/kiro/fixtures/project_memory.json
+++ b/tests/integrations/kiro/fixtures/project_memory.json
@@ -1,0 +1,46 @@
+{
+  "meta": {
+    "name": "kiro-integration-test-project",
+    "description": "Fixture for Kiro integration tests",
+    "version": "0.1.0",
+    "owner": "test",
+    "created": "2026-08-23"
+  },
+  "items": [],
+  "decisions": [
+    {
+      "id": "test_001",
+      "decision": "Use SQLite for local storage and database access",
+      "rationale": "single-file portability",
+      "scope": ["storage", "database"],
+      "constraints": ["no postgres"],
+      "anti_patterns": ["postgres", "Postgres", "psycopg2"]
+    },
+    {
+      "id": "test_002",
+      "decision": "Do not call the legacy client directly from application code",
+      "rationale": "all access must go through the compatibility facade",
+      "scope": ["compatibility"],
+      "rules": [
+        {
+          "type": "FORBID_LITERAL",
+          "value": "legacy_client.connect("
+        }
+      ]
+    },
+    {
+      "id": "test_003",
+      "decision": "The experimental marker may appear only under src/, never in generated code",
+      "rationale": "generated output is regenerated upstream",
+      "scope": ["generation"],
+      "rules": [
+        {
+          "type": "FORBID_LITERAL",
+          "value": "EXPERIMENTAL_MARKER_XY",
+          "include_paths": ["src/**"],
+          "exclude_paths": ["src/generated/**"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integrations/kiro/test_e2e.py
+++ b/tests/integrations/kiro/test_e2e.py
@@ -1,0 +1,144 @@
+"""End-to-end tests through the real mneme CLI.
+
+Skipped when mneme is not importable/runnable in the current interpreter
+(fresh CI before `pip install -e .`).
+
+The envelopes here mirror the observed Kiro CLI write shape: tool_name
+``fs_write`` with ``tool_input.path`` and full ``tool_input.content``.
+"""
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mneme.integrations.kiro.hook import main
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+VIOLATION = "legacy_client.connect("
+
+requires_mneme = pytest.mark.skipif(
+    subprocess.run(
+        [sys.executable, "-m", "mneme", "--help"], capture_output=True
+    ).returncode != 0,
+    reason="mneme CLI not runnable via sys.executable -m mneme",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MNEME_MEMORY", raising=False)
+    monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _envelope(cwd, path, content):
+    return json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(cwd),
+        "tool_name": "fs_write",
+        "tool_input": {"path": str(path), "content": content},
+    })
+
+
+@requires_mneme
+def test_violating_write_blocks_before_disk(project):
+    target = project / "service.py"
+    rc = main(
+        stdin=io.StringIO(_envelope(project, target, f"x = 1\n{VIOLATION}\n")),
+        stderr=io.StringIO(),
+    )
+    assert rc != 0, "a typed-literal violation must block the native write"
+    assert not target.exists(), "nothing may reach disk on a block"
+
+
+@requires_mneme
+def test_compliant_write_allowed(project):
+    target = project / "service.py"
+    out, err = io.StringIO(), io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(project, target, "x = 1\ny = 2\n")),
+        stderr=err, stdout=out,
+    )
+    assert rc == 0
+    assert out.getvalue() == "", "PASS must stay silent"
+
+
+@requires_mneme
+def test_remediation_allowed_end_to_end(project):
+    target = project / "dirty.py"
+    target.write_text(f"a\n{VIOLATION}\nb\n", encoding="utf-8")
+    rc = main(
+        stdin=io.StringIO(_envelope(project, target, "a\nb\n")),
+        stderr=io.StringIO(), stdout=io.StringIO(),
+    )
+    assert rc == 0
+
+
+@requires_mneme
+def test_preexisting_violation_does_not_block_unrelated_edit(project):
+    target = project / "dirty.py"
+    target.write_text(f"{VIOLATION}\nrest\n", encoding="utf-8")
+    rc = main(
+        stdin=io.StringIO(_envelope(project, target, f"{VIOLATION}\nrest\nmore_ok\n")),
+        stderr=io.StringIO(), stdout=io.StringIO(),
+    )
+    assert rc == 0
+
+
+@requires_mneme
+def test_violation_blocks_under_generic_filename(project):
+    """ADR-017: enforcement must not depend on lexical filename overlap."""
+    err = io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(project, project / "handler.py", VIOLATION + "\n")),
+        stderr=err,
+    )
+    assert rc != 0
+    assert "test_002" in err.getvalue() or VIOLATION in err.getvalue()
+
+
+@requires_mneme
+def test_scoped_rule_enforced_under_include_path(project):
+    src = project / "src"
+    src.mkdir()
+    err = io.StringIO()
+    envelope = _envelope(project, src / "app.py", "EXPERIMENTAL_MARKER_XY\n")
+    rc = main(stdin=io.StringIO(envelope), stderr=err)
+    assert rc != 0
+
+
+@requires_mneme
+def test_corrupt_memory_fails_open_against_real_cli(project):
+    (project / ".mneme" / "project_memory.json").write_text(
+        "{ this is not valid json", encoding="utf-8"
+    )
+    out, err = io.StringIO(), io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(project, project / "f.py", VIOLATION)),
+        stderr=err, stdout=out,
+    )
+    assert rc == 0, "a crashing check must never hard-block a write"
+    assert "UNEVALUATED" in out.getvalue()
+
+
+@requires_mneme
+def test_warn_mode_surfaces_warning_through_stdout(project, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    out, err = io.StringIO(), io.StringIO()
+    rc = main(
+        stdin=io.StringIO(_envelope(project, project / "f.py", VIOLATION + "\n")),
+        stderr=err, stdout=out,
+    )
+    assert rc == 0
+    assert "[mneme] WARN" in out.getvalue()

--- a/tests/integrations/kiro/test_entry_point.py
+++ b/tests/integrations/kiro/test_entry_point.py
@@ -1,0 +1,18 @@
+"""Console-script availability for the Kiro hook."""
+import tomllib
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_entry_point_target_exposes_cli_main():
+    from mneme.integrations.kiro import hook
+
+    assert callable(hook.cli_main)
+    assert callable(hook.main)
+
+
+def test_pyproject_declares_kiro_entry_point():
+    with (PACKAGE_ROOT / "pyproject.toml").open("rb") as fh:
+        scripts = tomllib.load(fh)["project"]["scripts"]
+    assert scripts["mneme-kiro-hook"] == "mneme.integrations.kiro.hook:cli_main"

--- a/tests/integrations/kiro/test_envelope.py
+++ b/tests/integrations/kiro/test_envelope.py
@@ -62,6 +62,7 @@ def test_write_tool_names():
     assert is_write_tool("write")
     assert is_write_tool("fs_write")
     assert is_write_tool("fsWrite")
+    assert is_write_tool("fs_append")
 
 
 def test_non_write_tools_rejected():
@@ -85,10 +86,34 @@ def test_normalizes_fs_write_to_whole_content_write():
 
 
 def test_all_documented_aliases_normalize():
-    for tool in ("write", "fs_write", "fsWrite"):
+    for tool in ("write", "fs_write", "fsWrite", "fs_append"):
         event, unhandled = normalize_to_tool_event(json.loads(_write_envelope(tool=tool)))
         assert unhandled is None
         assert event is not None, tool
+
+
+def test_observed_v3_fs_append_envelope(tmp_path):
+    """Kiro CLI 3.0 (observed live 2026-08-26) uses 'fs_append' with 'text' when appending
+    to an existing file. The adapter resolves the existing file and materializes current + text."""
+    target_file = tmp_path / "v3_existing.md"
+    target_file.write_text("# Initial Notes\n", encoding="utf-8")
+
+    envelope = {
+        "session_id": "sess_1d2bf653-6d1f-4d2e-b4a7-d108fb094b88",
+        "hook_event_name": "PreToolUse",
+        "cwd": str(tmp_path),
+        "tool_name": "fs_append",
+        "tool_input": {
+            "path": str(target_file),
+            "text": "## Installation\n\nRun: pip install mneme-hq\n"
+        }
+    }
+    event, unhandled = normalize_to_tool_event(envelope)
+    assert unhandled is None
+    assert event is not None
+    assert event.tool_name == "Write"
+    assert event.file_path == str(target_file)
+    assert event.tool_input["content"] == "# Initial Notes\n## Installation\n\nRun: pip install mneme-hq\n"
 
 
 def test_non_pretooluse_events_are_skipped():

--- a/tests/integrations/kiro/test_envelope.py
+++ b/tests/integrations/kiro/test_envelope.py
@@ -74,7 +74,8 @@ def test_non_write_tools_rejected():
 # --- normalize_to_tool_event ---
 
 def test_normalizes_fs_write_to_whole_content_write():
-    event = normalize_to_tool_event(json.loads(_write_envelope()))
+    event, unhandled = normalize_to_tool_event(json.loads(_write_envelope()))
+    assert unhandled is None
     assert event is not None
     assert event.tool_name == "Write"
     assert event.file_path == "src/app.py"
@@ -85,14 +86,17 @@ def test_normalizes_fs_write_to_whole_content_write():
 
 def test_all_documented_aliases_normalize():
     for tool in ("write", "fs_write", "fsWrite"):
-        event = normalize_to_tool_event(json.loads(_write_envelope(tool=tool)))
+        event, unhandled = normalize_to_tool_event(json.loads(_write_envelope(tool=tool)))
+        assert unhandled is None
         assert event is not None, tool
 
 
 def test_non_pretooluse_events_are_skipped():
     payload = json.loads(_write_envelope())
     payload["hook_event_name"] = "postToolUse"
-    assert normalize_to_tool_event(payload) is None
+    event, unhandled = normalize_to_tool_event(payload)
+    assert event is None
+    assert unhandled is None
 
 
 def test_shell_tool_is_never_normalized():
@@ -101,13 +105,16 @@ def test_shell_tool_is_never_normalized():
     payload = json.loads(_write_envelope())
     payload["tool_name"] = "shell"
     payload["tool_input"] = {"command": "echo x > file.txt"}
-    assert normalize_to_tool_event(payload) is None
+    event, unhandled = normalize_to_tool_event(payload)
+    assert event is None
+    assert unhandled is None
 
 
 def test_missing_tool_input_degrades_to_empty_strings():
     payload = json.loads(_write_envelope())
     del payload["tool_input"]
-    event = normalize_to_tool_event(payload)
+    event, unhandled = normalize_to_tool_event(payload)
+    assert unhandled is None
     assert event is not None
     assert event.file_path == ""
     assert event.tool_input["content"] == ""
@@ -116,7 +123,8 @@ def test_missing_tool_input_degrades_to_empty_strings():
 def test_non_string_path_and_content_are_tolerated():
     payload = json.loads(_write_envelope())
     payload["tool_input"] = {"path": 42, "content": None}
-    event = normalize_to_tool_event(payload)
+    event, unhandled = normalize_to_tool_event(payload)
+    assert unhandled is None
     assert event is not None
     assert event.file_path == ""
     assert event.tool_input["content"] == ""
@@ -125,11 +133,11 @@ def test_non_string_path_and_content_are_tolerated():
 def test_observed_cli_2_19_2_envelope_with_file_text():
     """CLI 2.19.2 (kiro-cli-chat 2.19.2) sends tool_input with 'file_text' instead
     of 'content' for fs_write create. This regression fixture captures the exact
-    live envelope observed during manual reproduction on 2026-08-26."""
+    live envelope structure observed during manual reproduction on 2026-08-26
+    (note: CLI 2.x omits session_id)."""
     envelope = {
         "hook_event_name": "preToolUse",
         "cwd": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live",
-        "session_id": "abc123",
         "tool_name": "fs_write",
         "tool_input": {
             "command": "create",
@@ -137,7 +145,8 @@ def test_observed_cli_2_19_2_envelope_with_file_text():
             "file_text": "pip install mneme-hq"
         }
     }
-    event = normalize_to_tool_event(envelope)
+    event, unhandled = normalize_to_tool_event(envelope)
+    assert unhandled is None
     assert event is not None
     assert event.tool_name == "Write"
     assert event.file_path == "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\test_block.md"
@@ -147,7 +156,7 @@ def test_observed_cli_2_19_2_envelope_with_file_text():
 def test_cli_2_19_2_envelope_requires_create_command():
     """The file_text key is only honored with tool_name='fs_write' and command='create'.
     Other commands (edit, replace) or write tool aliases do not assume file_text,
-    ensuring unsupported legacy operations degrade cleanly without inventing schemas."""
+    ensuring unsupported legacy operations fail open visibly via unhandled reason."""
     envelope = {
         "hook_event_name": "preToolUse",
         "cwd": "/repo",
@@ -158,11 +167,12 @@ def test_cli_2_19_2_envelope_requires_create_command():
             "file_text": "new content"
         }
     }
-    event = normalize_to_tool_event(envelope)
-    assert event is not None
-    assert event.tool_input["content"] == ""
+    event, unhandled = normalize_to_tool_event(envelope)
+    assert event is None
+    assert unhandled is not None
+    assert "unsupported legacy write shape: fs_write command='edit' with file_text" in unhandled
 
-    # Also confirm other aliases like 'write' or 'fsWrite' do not fall back to file_text
+    # Also confirm other aliases like 'write' or 'fsWrite' with file_text fail open visibly
     envelope_alias = {
         "hook_event_name": "preToolUse",
         "cwd": "/repo",
@@ -173,9 +183,32 @@ def test_cli_2_19_2_envelope_requires_create_command():
             "file_text": "new content"
         }
     }
-    event_alias = normalize_to_tool_event(envelope_alias)
-    assert event_alias is not None
-    assert event_alias.tool_input["content"] == ""
+    event_alias, unhandled_alias = normalize_to_tool_event(envelope_alias)
+    assert event_alias is None
+    assert unhandled_alias is not None
+    assert "unsupported legacy write shape: write with file_text" in unhandled_alias
+
+
+# --- main(): malformed envelopes fail open quietly, unsupported shapes fail open visibly ---
+
+def test_main_unsupported_legacy_edit_fails_open_visibly(tmp_path):
+    from unittest.mock import patch
+    envelope = json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(tmp_path),
+        "tool_name": "fs_write",
+        "tool_input": {
+            "command": "edit",
+            "path": str(tmp_path / "app.py"),
+            "file_text": "import os"
+        }
+    })
+    stdout = io.StringIO()
+    with patch("mneme.integrations.kiro.hook.subprocess.run") as mrun:
+        rc = main(stdin=io.StringIO(envelope), stdout=stdout, stderr=io.StringIO())
+    assert rc == 0
+    mrun.assert_not_called()
+    assert "[mneme] UNEVALUATED - failing open, this mutation was NOT checked: unsupported legacy write shape: fs_write command='edit' with file_text" in stdout.getvalue()
 
 
 # --- main(): malformed envelopes fail open quietly ---

--- a/tests/integrations/kiro/test_envelope.py
+++ b/tests/integrations/kiro/test_envelope.py
@@ -1,0 +1,158 @@
+"""Envelope parser tests, pinned to the Phase A evidence.
+
+The envelope shape mirrors the documented Kiro v1 hook event
+(kiro.dev/docs/hooks/types/, MCP example): ``hook_event_name``, ``cwd``,
+``session_id``, ``tool_name``, ``tool_input``. The native write tool's
+``tool_input`` carries ``path`` and the full proposed ``content``
+(observed Kiro CLI shape; see docs/integrations/kiro-hook-spec.md for the
+documented-versus-observed status). No field name here is invented.
+"""
+import io
+import json
+
+from mneme.integrations.kiro.hook import (
+    is_write_tool,
+    main,
+    normalize_to_tool_event,
+    parse_kiro_envelope,
+)
+
+
+def _write_envelope(tool="fs_write", cwd="/repo", path="src/app.py", content="x = 1\n"):
+    return json.dumps({
+        "hook_event_name": "preToolUse",
+        "session_id": "abc123",
+        "cwd": cwd,
+        "tool_name": tool,
+        "tool_input": {"path": path, "content": content},
+    })
+
+
+# --- parse_kiro_envelope ---
+
+def test_parses_documented_envelope():
+    payload = parse_kiro_envelope(_write_envelope())
+    assert payload["hook_event_name"] == "preToolUse"
+    assert payload["tool_name"] == "fs_write"
+    assert payload["cwd"] == "/repo"
+    assert payload["session_id"] == "abc123"
+
+
+def test_malformed_json_raises():
+    import pytest
+    with pytest.raises(json.JSONDecodeError):
+        parse_kiro_envelope("this is not json{")
+
+
+def test_non_object_payload_raises():
+    import pytest
+    with pytest.raises(KeyError):
+        parse_kiro_envelope(json.dumps([1, 2, 3]))
+
+
+def test_missing_event_name_raises():
+    import pytest
+    with pytest.raises(KeyError):
+        parse_kiro_envelope(json.dumps({"tool_name": "fs_write"}))
+
+
+# --- tool recognition: only documented names ---
+
+def test_write_tool_names():
+    assert is_write_tool("write")
+    assert is_write_tool("fs_write")
+    assert is_write_tool("fsWrite")
+
+
+def test_non_write_tools_rejected():
+    assert not is_write_tool("shell")
+    assert not is_write_tool("execute_bash")
+    assert not is_write_tool("read")
+    assert not is_write_tool("@mcp/write_file")
+
+
+# --- normalize_to_tool_event ---
+
+def test_normalizes_fs_write_to_whole_content_write():
+    event = normalize_to_tool_event(json.loads(_write_envelope()))
+    assert event is not None
+    assert event.tool_name == "Write"
+    assert event.file_path == "src/app.py"
+    assert event.cwd == "/repo"
+    assert event.tool_input["file_path"] == "src/app.py"
+    assert event.tool_input["content"] == "x = 1\n"
+
+
+def test_all_documented_aliases_normalize():
+    for tool in ("write", "fs_write", "fsWrite"):
+        event = normalize_to_tool_event(json.loads(_write_envelope(tool=tool)))
+        assert event is not None, tool
+
+
+def test_non_pretooluse_events_are_skipped():
+    payload = json.loads(_write_envelope())
+    payload["hook_event_name"] = "postToolUse"
+    assert normalize_to_tool_event(payload) is None
+
+
+def test_shell_tool_is_never_normalized():
+    """PreToolUse(shell) fires for redirections and scripts; this gate does
+    not parse shell commands (documented unsupported surface)."""
+    payload = json.loads(_write_envelope())
+    payload["tool_name"] = "shell"
+    payload["tool_input"] = {"command": "echo x > file.txt"}
+    assert normalize_to_tool_event(payload) is None
+
+
+def test_missing_tool_input_degrades_to_empty_strings():
+    payload = json.loads(_write_envelope())
+    del payload["tool_input"]
+    event = normalize_to_tool_event(payload)
+    assert event is not None
+    assert event.file_path == ""
+    assert event.tool_input["content"] == ""
+
+
+def test_non_string_path_and_content_are_tolerated():
+    payload = json.loads(_write_envelope())
+    payload["tool_input"] = {"path": 42, "content": None}
+    event = normalize_to_tool_event(payload)
+    assert event is not None
+    assert event.file_path == ""
+    assert event.tool_input["content"] == ""
+
+
+# --- main(): malformed envelopes fail open quietly ---
+
+def test_main_bad_json_returns_zero_without_checking(tmp_path):
+    from unittest.mock import patch
+    with patch("mneme.integrations.kiro.hook.subprocess.run") as mrun:
+        rc = main(stdin=io.StringIO("not json{"), stderr=io.StringIO())
+    assert rc == 0
+    mrun.assert_not_called()
+
+
+def test_main_post_tool_use_returns_zero(tmp_path):
+    from unittest.mock import patch
+    payload = json.loads(_write_envelope(cwd=str(tmp_path)))
+    payload["hook_event_name"] = "postToolUse"
+    with patch("mneme.integrations.kiro.hook.subprocess.run") as mrun:
+        rc = main(stdin=io.StringIO(json.dumps(payload)), stderr=io.StringIO())
+    assert rc == 0
+    mrun.assert_not_called()
+
+
+def test_main_shell_tool_returns_zero_without_parsing_command(tmp_path):
+    """A shell redirection must not be interpreted as a write (no shell
+    parsing in this integration)."""
+    from unittest.mock import patch
+    envelope = json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(tmp_path),
+        "tool_name": "shell",
+        "tool_input": {"command": f"echo legacy_client.connect( > {tmp_path}/a.py"},
+    })
+    with patch("mneme.integrations.kiro.hook.subprocess.run") as mrun:
+        rc = main(stdin=io.StringIO(envelope), stderr=io.StringIO())
+    assert rc == 0
+    mrun.assert_not_called()

--- a/tests/integrations/kiro/test_envelope.py
+++ b/tests/integrations/kiro/test_envelope.py
@@ -130,6 +130,27 @@ def test_non_string_path_and_content_are_tolerated():
     assert event.tool_input["content"] == ""
 
 
+def test_observed_v3_envelope_with_text():
+    """Kiro CLI 3.0 / v3 engine (observed live 2026-08-26) sends tool_input with 'text'
+    alongside 'path', with PascalCase 'PreToolUse' and 'session_id' present."""
+    envelope = {
+        "session_id": "sess_32f5f263-bcf2-4b63-8d69-89fafd057df7",
+        "hook_event_name": "PreToolUse",
+        "cwd": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live",
+        "tool_name": "fs_write",
+        "tool_input": {
+            "path": "c:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\v3_test_block.md",
+            "text": "pip install mneme-hq"
+        }
+    }
+    event, unhandled = normalize_to_tool_event(envelope)
+    assert unhandled is None
+    assert event is not None
+    assert event.tool_name == "Write"
+    assert event.file_path == "c:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\v3_test_block.md"
+    assert event.tool_input["content"] == "pip install mneme-hq"
+
+
 def test_observed_cli_2_19_2_envelope_with_file_text():
     """CLI 2.19.2 (kiro-cli-chat 2.19.2) sends tool_input with 'file_text' instead
     of 'content' for fs_write create. This regression fixture captures the exact

--- a/tests/integrations/kiro/test_envelope.py
+++ b/tests/integrations/kiro/test_envelope.py
@@ -122,6 +122,62 @@ def test_non_string_path_and_content_are_tolerated():
     assert event.tool_input["content"] == ""
 
 
+def test_observed_cli_2_19_2_envelope_with_file_text():
+    """CLI 2.19.2 (kiro-cli-chat 2.19.2) sends tool_input with 'file_text' instead
+    of 'content' for fs_write create. This regression fixture captures the exact
+    live envelope observed during manual reproduction on 2026-08-26."""
+    envelope = {
+        "hook_event_name": "preToolUse",
+        "cwd": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live",
+        "session_id": "abc123",
+        "tool_name": "fs_write",
+        "tool_input": {
+            "command": "create",
+            "path": "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\test_block.md",
+            "file_text": "pip install mneme-hq"
+        }
+    }
+    event = normalize_to_tool_event(envelope)
+    assert event is not None
+    assert event.tool_name == "Write"
+    assert event.file_path == "C:\\Users\\hi\\AppData\\Local\\Temp\\opencode\\kiro-live\\test_block.md"
+    assert event.tool_input["content"] == "pip install mneme-hq"
+
+
+def test_cli_2_19_2_envelope_requires_create_command():
+    """The file_text key is only honored with tool_name='fs_write' and command='create'.
+    Other commands (edit, replace) or write tool aliases do not assume file_text,
+    ensuring unsupported legacy operations degrade cleanly without inventing schemas."""
+    envelope = {
+        "hook_event_name": "preToolUse",
+        "cwd": "/repo",
+        "tool_name": "fs_write",
+        "tool_input": {
+            "command": "edit",
+            "path": "/repo/src/app.py",
+            "file_text": "new content"
+        }
+    }
+    event = normalize_to_tool_event(envelope)
+    assert event is not None
+    assert event.tool_input["content"] == ""
+
+    # Also confirm other aliases like 'write' or 'fsWrite' do not fall back to file_text
+    envelope_alias = {
+        "hook_event_name": "preToolUse",
+        "cwd": "/repo",
+        "tool_name": "write",
+        "tool_input": {
+            "command": "create",
+            "path": "/repo/src/app.py",
+            "file_text": "new content"
+        }
+    }
+    event_alias = normalize_to_tool_event(envelope_alias)
+    assert event_alias is not None
+    assert event_alias.tool_input["content"] == ""
+
+
 # --- main(): malformed envelopes fail open quietly ---
 
 def test_main_bad_json_returns_zero_without_checking(tmp_path):

--- a/tests/integrations/kiro/test_failopen.py
+++ b/tests/integrations/kiro/test_failopen.py
@@ -1,0 +1,250 @@
+"""Fail-open boundaries, mode resolution, and child invocation contract."""
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mneme.integrations.kiro.hook import main
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+VIOLATION = "legacy_client.connect("
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MNEME_MEMORY", raising=False)
+    monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+
+
+def _project(tmp_path):
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _envelope(cwd, path="f.py", content="x\n"):
+    return json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(cwd),
+        "tool_name": "fs_write",
+        "tool_input": {"path": path, "content": content},
+    })
+
+
+def _verdict(verdict="FAIL", evaluation_complete=True):
+    payload = {
+        "schema": "mneme.check/v1",
+        "verdict": verdict,
+        "mode": "strict",
+        "violations": [{
+            "decision_id": "test_002",
+            "severity": verdict,
+            "rule_type": "FORBID_LITERAL",
+            "rule": VIOLATION,
+            "trigger": VIOLATION,
+        }],
+        "freshness": [],
+    }
+    if not evaluation_complete:
+        payload["evaluation_complete"] = False
+        payload["applicability"] = [{
+            "decision_id": "test_003",
+            "rule_type": "FORBID_LITERAL",
+            "rule_value": "EXPERIMENTAL_MARKER_XY",
+            "outcome": "UNKNOWN",
+            "reason": "outside policy root",
+        }]
+    return json.dumps(payload)
+
+
+def _gate(tmp_path, stdout="", stderr="", exc=None, envelope=None):
+    fake = MagicMock(returncode=0, stdout=stdout, stderr=stderr)
+    out, err = io.StringIO(), io.StringIO()
+
+    def _runner(command, **kwargs):
+        if exc is not None:
+            raise exc
+        return fake
+
+    with patch("mneme.integrations.kiro.hook.subprocess.run", _runner):
+        rc = main(stdin=io.StringIO(envelope or _envelope(tmp_path)), stderr=err, stdout=out)
+    return rc, out.getvalue(), err.getvalue()
+
+
+# --- modes ---
+
+def test_strict_mode_blocks_warn_verdict(tmp_path):
+    project = _project(tmp_path)
+    rc, out, err = _gate(project, stdout=_verdict("WARN"))
+    assert rc != 0
+    assert out == ""
+
+
+def test_strict_mode_blocks_fail_verdict_with_reason_on_stderr(tmp_path):
+    project = _project(tmp_path)
+    rc, out, err = _gate(project, stdout=_verdict("FAIL"))
+    assert rc != 0
+    assert VIOLATION in err or "test_002" in err
+    assert out == ""
+
+
+def test_warn_mode_returns_zero_and_surfaces_warning_to_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+    project = _project(tmp_path)
+    rc, out, _ = _gate(project, stdout=_verdict("FAIL"))
+    assert rc == 0
+    assert "[mneme] WARN" in out
+    assert "test_002" in out or VIOLATION in out
+
+
+def test_invalid_hook_mode_falls_back_to_strict(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEME_HOOK_MODE", "bogus")
+    project = _project(tmp_path)
+    rc, _, _ = _gate(project, stdout=_verdict("FAIL"))
+    assert rc != 0
+
+
+def test_pass_verdict_does_not_weaken_kiro_permission_flow(tmp_path):
+    """PASS emits nothing: Kiro's own permission prompts stay in effect."""
+    project = _project(tmp_path)
+    rc, out, _ = _gate(project, stdout=_verdict("PASS"))
+    assert rc == 0
+    assert out == ""
+
+
+# --- no memory -> quiet allow ---
+
+def test_no_project_memory_quiet_zero(tmp_path):
+    rc, out, _ = _gate(tmp_path, envelope=_envelope(tmp_path))
+    assert rc == 0
+    assert out == ""
+
+
+# --- fail-open boundaries, all visibly ---
+
+def test_subprocess_timeout_fails_open_visibly(tmp_path):
+    project = _project(tmp_path)
+    rc, out, _ = _gate(
+        project, exc=subprocess.TimeoutExpired(cmd="mneme", timeout=10)
+    )
+    assert rc == 0
+    assert "UNEVALUATED" in out
+
+
+def test_subprocess_oserror_fails_open_visibly(tmp_path):
+    project = _project(tmp_path)
+    rc, out, _ = _gate(project, exc=OSError("permission denied"))
+    assert rc == 0
+    assert "UNEVALUATED" in out
+
+
+def test_interpreter_missing_fails_open_visibly(tmp_path):
+    project = _project(tmp_path)
+    rc, out, _ = _gate(project, exc=FileNotFoundError(sys.executable))
+    assert rc == 0
+    assert "UNEVALUATED" in out
+
+
+def test_unparseable_verdict_fails_open_visibly(tmp_path):
+    project = _project(tmp_path)
+    rc, out, err = _gate(
+        project,
+        stdout="Traceback (most recent call last): ...",
+        stderr="crash detail",
+    )
+    assert rc == 0
+    assert "UNEVALUATED" in out
+    assert "crash detail" in err
+
+
+def test_wrong_schema_verdict_is_not_trusted(tmp_path):
+    """JSON without the mneme.check/v1 schema is not a verdict; a bare exit
+    code is never one either."""
+    project = _project(tmp_path)
+    bogus = json.dumps({"verdict": "FAIL"})
+    rc, out, _ = _gate(project, stdout=bogus)
+    assert rc == 0
+    assert "UNEVALUATED" in out
+
+
+def test_stale_cli_detected_and_reported_visibly(tmp_path):
+    project = _project(tmp_path)
+    stale = "unrecognized arguments: --json --target-path"
+    rc, out, err = _gate(project, stderr=stale)
+    assert rc == 0
+    assert "ENFORCEMENT IS INACTIVE" in err
+    assert "UNEVALUATED" in out
+
+
+def test_incomplete_applicability_fails_open_visibly(tmp_path):
+    project = _project(tmp_path)
+    rc, out, err = _gate(project, stdout=_verdict(evaluation_complete=False))
+    assert rc == 0
+    assert "UNEVALUATED" in out
+    assert "unknown" in err.lower()
+
+
+def test_materialization_failure_fails_open_visibly(tmp_path):
+    from mneme.integrations.claude_code.hook import MaterializeError
+    project = _project(tmp_path)
+    out, err = io.StringIO(), io.StringIO()
+    with patch(
+        "mneme.integrations.kiro.hook.introduced_content",
+        side_effect=MaterializeError("cannot read target"),
+    ), patch("mneme.integrations.kiro.hook.subprocess.run") as mrun:
+        rc = main(stdin=io.StringIO(_envelope(project)), stderr=err, stdout=out)
+    assert rc == 0
+    assert "UNEVALUATED" in out.getvalue()
+    mrun.assert_not_called()
+
+
+# --- diagnostics are ASCII-safe ---
+
+def test_diagnostics_are_ascii(tmp_path):
+    project = _project(tmp_path)
+    rc, out, err = _gate(project, stdout=_verdict())
+    assert (out + err).isascii()
+
+
+# --- child invocation contract ---
+
+def test_check_invocation_contract(tmp_path):
+    """sys.executable -m mneme check with memory/query/mode/json options and
+    the resolved absolute --target-path."""
+    project = _project(tmp_path)
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    commands = []
+
+    def _runner(command, **kwargs):
+        commands.append(list(command))
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    envelope = json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(tmp_path),
+        "tool_name": "write",
+        "tool_input": {"path": "abs_check.py", "content": "a\n"},
+    })
+    with patch("mneme.integrations.kiro.hook.subprocess.run", _runner):
+        main(stdin=io.StringIO(envelope), stderr=io.StringIO())
+
+    command = commands[0]
+    assert command[:4] == [sys.executable, "-m", "mneme", "check"]
+    assert command[command.index("--memory") + 1] == str(mem)
+    assert command[command.index("--query") + 1] == "edit to abs_check.py"
+    assert "--json" in command and "--mode" in command
+    target = Path(command[command.index("--target-path") + 1])
+    assert target.is_absolute()
+
+
+def test_child_env_pins_package_root(tmp_path):
+    from mneme.integrations.claude_code.hook import _child_env as expected_env
+    from mneme.integrations.kiro.hook import _child_env as kiro_env
+    # The Kiro hook reuses the Claude hook's pinned-PYTHONPATH environment.
+    assert kiro_env is expected_env

--- a/tests/integrations/kiro/test_gate.py
+++ b/tests/integrations/kiro/test_gate.py
@@ -1,0 +1,225 @@
+"""Mutation-gate policy tests for the Kiro hook (subprocess mocked).
+
+Every verdict-level test drives main() through the same code path Kiro
+invokes and pins the documented exit-code contract: 0 = allow, non-zero =
+block; fail-open outcomes are always visible on stdout.
+"""
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mneme.integrations.kiro.hook import main
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+
+VIOLATION = "legacy_client.connect("
+COMPLIANT = "from compat import facade\nfacade.open_session()\n"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MNEME_MEMORY", raising=False)
+    monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+
+
+def _project(tmp_path):
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _envelope(cwd, path, content, tool="fs_write"):
+    return json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(cwd),
+        "tool_name": tool,
+        "tool_input": {"path": str(path), "content": content},
+    })
+
+
+def _verdict(verdict="FAIL", evaluation_complete=True):
+    payload = {
+        "schema": "mneme.check/v1",
+        "verdict": verdict,
+        "mode": "strict",
+        "violations": [{
+            "decision_id": "test_002",
+            "decision_text": "Do not call the legacy client directly",
+            "severity": verdict,
+            "rule_type": "FORBID_LITERAL",
+            "rule": VIOLATION,
+            "trigger": VIOLATION,
+        }],
+        "freshness": [],
+    }
+    if not evaluation_complete:
+        payload["evaluation_complete"] = False
+        payload["applicability"] = [{
+            "decision_id": "test_003",
+            "rule_type": "FORBID_LITERAL",
+            "rule_value": "EXPERIMENTAL_MARKER_XY",
+            "outcome": "UNKNOWN",
+            "reason": "outside policy root",
+        }]
+    return json.dumps(payload)
+
+
+class _Capture:
+    """subprocess.run stand-in that records the command and returns a fixed
+    CompletedProcess."""
+
+    def __init__(self, stdout="", stderr="", exc=None):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exc = exc
+        self.commands = []
+
+    def __call__(self, command, **kwargs):
+        self.commands.append(list(command))
+        input_path = command[command.index("--input") + 1]
+        self._record_input(len(self.commands) - 1, input_path)
+        if self.exc is not None:
+            raise self.exc
+        return MagicMock(returncode=0, stdout=self.stdout, stderr=self.stderr)
+
+    def checked_text(self, index=0):
+        """The text handed to `mneme check` via --input, captured at call
+        time (the hook deletes the temp file after the child exits)."""
+        command = self.commands[index]
+        input_path = command[command.index("--input") + 1]
+        return self._checked[index]
+
+    def _record_input(self, index, path):
+        self._checked[index] = Path(path).read_text(encoding="utf-8")
+
+    _checked = None
+
+    def __init__(self, stdout="", stderr="", exc=None):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exc = exc
+        self.commands = []
+        self._checked = {}
+
+
+# --- forbidden literal introduced into a new file -> blocked before disk ---
+
+def test_forbidden_literal_in_new_file_blocked(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "new_file.py"
+    rc, out, err, _ = _gate(
+        project, _envelope(project, target, f"x = 1\n{VIOLATION}\n"),
+        stdout=_verdict(),
+    )
+    assert rc != 0
+    assert VIOLATION in err or "test_002" in err
+    assert out == ""
+    assert not target.exists(), "the hook must not touch disk on a block"
+
+
+# --- forbidden literal introduced through an edit -> blocked ---
+
+def test_forbidden_literal_introduced_by_edit_blocked(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "existing.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    rc, _, err, _ = _gate(
+        project, _envelope(project, target, f"x = 1\n{VIOLATION}\n"),
+        stdout=_verdict(),
+    )
+    assert rc != 0
+
+
+def test_edit_gate_checks_introduced_lines_only(tmp_path):
+    """ADR-018 through the Kiro shape: only inserted lines reach the checker."""
+    project = _project(tmp_path)
+    target = tmp_path / "app.py"
+    target.write_text("keep_a\nkeep_b\nkeep_c\n", encoding="utf-8")
+    proposed = "keep_a\nkeep_b\nkeep_c\nNEW_INTRODUCED_LINE\n"
+    cap = _Capture(stdout=_verdict())
+    with patch("mneme.integrations.kiro.hook.subprocess.run", cap):
+        rc = main(stdin=io.StringIO(_envelope(project, target, proposed)),
+                  stderr=io.StringIO())
+    assert rc == 2
+    assert cap.checked_text() == "NEW_INTRODUCED_LINE"
+
+
+# --- compliant write -> allowed ---
+
+def test_compliant_write_allowed(tmp_path):
+    project = _project(tmp_path)
+    rc, out, _, _ = _gate(
+        project, _envelope(project, tmp_path / "ok.py", COMPLIANT),
+        stdout=_verdict("PASS"),
+    )
+    assert rc == 0
+    assert out == "", "PASS must not inject anything into agent context"
+
+
+# --- pure deletion / remediation -> allowed ---
+
+def test_remediation_of_violation_allowed(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "dirty.py"
+    target.write_text(f"a\n{VIOLATION}\nb\n", encoding="utf-8")
+    rc, _, _, _ = _gate(
+        project, _envelope(project, target, "a\nb\n"), stdout=_verdict("PASS")
+    )
+    assert rc == 0
+
+
+def test_pure_deletion_allowed(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "gone.py"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    cap = _Capture()
+    with patch("mneme.integrations.kiro.hook.subprocess.run", cap):
+        rc = main(stdin=io.StringIO(_envelope(project, target, "")),
+                  stderr=io.StringIO())
+    assert rc == 0
+    assert not cap.commands, "a deletion introduces nothing to check"
+
+
+# --- pre-existing violation plus unrelated edit -> allowed ---
+
+def test_preexisting_violation_plus_unrelated_edit_allowed(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "dirty.py"
+    target.write_text(f"{VIOLATION}\nrest\n", encoding="utf-8")
+    cap = _Capture(stdout=_verdict("PASS"))
+    with patch("mneme.integrations.kiro.hook.subprocess.run", cap):
+        rc = main(
+            stdin=io.StringIO(_envelope(project, target, f"{VIOLATION}\nrest\nmore\n")),
+            stderr=io.StringIO(),
+        )
+    assert rc == 0
+    checked = cap.checked_text()
+    assert VIOLATION not in checked, (
+        "pre-existing violation must not be attributed to an unrelated edit"
+    )
+    assert "more" in checked
+
+
+# --- ADR-017/019: generic filename still enforces a typed literal ---
+
+def test_generic_filename_still_enforces_typed_literal(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "service.py"  # zero lexical overlap with the decisions
+    rc, _, _, _ = _gate(
+        project, _envelope(project, target, f"x\n{VIOLATION}\n"), stdout=_verdict()
+    )
+    assert rc != 0
+
+
+def _gate(cwd, envelope, stdout="", stderr=""):
+    """Run main() against a mocked mneme check; returns (rc, out, err, mock)."""
+    fake = MagicMock(returncode=0, stdout=stdout, stderr=stderr)
+    out, err = io.StringIO(), io.StringIO()
+    with patch("mneme.integrations.kiro.hook.subprocess.run", return_value=fake) as mrun:
+        rc = main(stdin=io.StringIO(envelope), stderr=err, stdout=out)
+    return rc, out.getvalue(), err.getvalue(), mrun

--- a/tests/integrations/kiro/test_gate_applicability.py
+++ b/tests/integrations/kiro/test_gate_applicability.py
@@ -1,0 +1,108 @@
+"""ADR-020 path applicability and path normalization through the Kiro gate."""
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mneme.integrations.kiro.hook import main
+
+FIXTURE = Path(__file__).parent / "fixtures" / "project_memory.json"
+MARKER = "EXPERIMENTAL_MARKER_XY"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MNEME_MEMORY", raising=False)
+    monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+
+
+def _project(tmp_path):
+    (tmp_path / ".mneme").mkdir()
+    (tmp_path / ".mneme" / "project_memory.json").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _envelope(cwd, path, content):
+    return json.dumps({
+        "hook_event_name": "preToolUse",
+        "cwd": str(cwd),
+        "tool_name": "fs_write",
+        "tool_input": {"path": str(path), "content": content},
+    })
+
+
+def _run(tmp_path, envelope):
+    """Returns (rc, cap) where cap records every child invocation."""
+    commands = []
+
+    def _run_check(command, **kwargs):
+        commands.append(list(command))
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    out, err = io.StringIO(), io.StringIO()
+    with patch("mneme.integrations.kiro.hook.subprocess.run", _run_check):
+        rc = main(stdin=io.StringIO(envelope), stderr=err, stdout=out)
+    return rc, out.getvalue(), err.getvalue(), commands
+
+
+def _checked_text(command):
+    input_path = command[command.index("--input") + 1]
+    return Path(input_path).read_text(encoding="utf-8")
+
+
+def test_include_path_match_enforced(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "src" / "app.py"
+    target.parent.mkdir()
+    rc, _, _, _ = _run(project, _envelope(project, target, MARKER + "\n"))
+    assert rc == 0  # mocked child returns no verdict -> fail open; the point
+    # of this test is that the scoped rule was *evaluated*, i.e. the child was
+    # invoked with the resolved absolute target path:
+    _, _, _, commands = _run(project, _envelope(project, target, MARKER + "\n"))
+    command = commands[0]
+    assert "--target-path" in command
+    assert Path(command[command.index("--target-path") + 1]).is_absolute()
+
+
+def test_exclude_path_not_checked_as_violation(tmp_path):
+    """A generated file under src/generated/ is excluded from the scoped rule;
+    the marker there must not be attributed as an introduction."""
+    project = _project(tmp_path)
+    generated = tmp_path / "src" / "generated" / "out.py"
+    generated.parent.mkdir(parents=True)
+    rc, out, _, commands = _run(project, _envelope(project, generated, MARKER + "\n"))
+    # With a real CLI this is a trusted PASS; with the mock it fails open on
+    # stdout. Either way the hook never blocks: assert exit 0.
+    assert rc == 0
+
+
+def test_nonmatching_path_outside_include_not_blocked_by_scoped_rule(tmp_path):
+    project = _project(tmp_path)
+    target = tmp_path / "docs" / "notes.md"
+    target.parent.mkdir()
+    rc, _, _, _ = _run(project, _envelope(project, target, MARKER + "\n"))
+    assert rc == 0
+
+
+def test_relative_path_resolved_against_event_cwd(tmp_path):
+    project = _project(tmp_path)
+    (tmp_path / "src").mkdir()
+    envelope = _envelope(str(tmp_path), "src/rel_app.py", "x\ny\n")
+    rc, _, _, commands = _run(project, envelope)
+    assert rc == 0
+    command = commands[0]
+    expected = str((tmp_path / "src" / "rel_app.py").resolve())
+    assert Path(command[command.index("--target-path") + 1]) == Path(expected)
+
+
+def test_query_uses_real_target_name(tmp_path):
+    project = _project(tmp_path)
+    envelope = _envelope(str(project), "src/named.py", "a\n")
+    rc, _, _, commands = _run(project, envelope)
+    command = commands[0]
+    query = command[command.index("--query") + 1]
+    assert query == "edit to src/named.py"

--- a/tests/integrations/kiro/test_installer.py
+++ b/tests/integrations/kiro/test_installer.py
@@ -21,8 +21,8 @@ def test_template_matches_documented_kiro_schema():
     assert hook["name"] == HOOK_NAME
     assert hook["trigger"] == "PreToolUse"
     # Matcher is a regex over the tool name covering the canonical name and
-    # its documented aliases only.
-    assert hook["matcher"] == "^(fs_write|fsWrite|write)$"
+    # its documented aliases plus append.
+    assert hook["matcher"] == "^(fs_write|fsWrite|write|fs_append)$"
     assert hook["action"]["type"] == "command"
     assert hook["action"]["command"] == "mneme-kiro-hook"
     assert hook["enabled"] is True

--- a/tests/integrations/kiro/test_installer.py
+++ b/tests/integrations/kiro/test_installer.py
@@ -1,0 +1,126 @@
+"""Installer contract: idempotent, project-scoped, never clobbers foreign hooks."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.install_kiro import HOOK_NAME, compute_target, install
+
+TEMPLATE = Path(__file__).resolve().parents[3] / "integrations" / "kiro" / "hooks" / "mneme.json"
+
+
+# --- hook JSON schema and matcher (documented v1 field reference) ---
+
+def test_template_matches_documented_kiro_schema():
+    template = json.loads(TEMPLATE.read_text(encoding="utf-8"))
+    assert template["version"] == "v1"
+    assert isinstance(template["hooks"], list) and len(template["hooks"]) == 1
+    hook = template["hooks"][0]
+    assert hook["name"] == HOOK_NAME
+    assert hook["trigger"] == "PreToolUse"
+    # Matcher is a regex over the tool name covering the canonical name and
+    # its documented aliases only.
+    assert hook["matcher"] == "^(fs_write|fsWrite|write)$"
+    assert hook["action"]["type"] == "command"
+    assert hook["action"]["command"] == "mneme-kiro-hook"
+    assert hook["enabled"] is True
+    assert isinstance(hook.get("timeout", 60), int)
+
+
+def test_compute_target_fresh():
+    content = compute_target(None)
+    assert content["hooks"][0]["name"] == HOOK_NAME
+
+
+def test_compute_target_preserves_foreign_hooks_and_upserts_ours():
+    existing = {
+        "version": "v1",
+        "hooks": [
+            {"name": "lint-on-save", "trigger": "PostFileSave",
+             "action": {"type": "command", "command": "npx eslint --fix"}},
+            {"name": HOOK_NAME, "trigger": "PreToolUse",
+             "action": {"type": "command", "command": "/old/stale/path"}},
+        ],
+    }
+    content = compute_target(existing)
+    names = [h["name"] for h in content["hooks"]]
+    assert names.count(HOOK_NAME) == 1
+    assert "lint-on-save" in names
+    ours = next(h for h in content["hooks"] if h["name"] == HOOK_NAME)
+    assert ours["action"]["command"] == "mneme-kiro-hook"
+
+
+# --- installation behavior ---
+
+@pytest.fixture
+def project(tmp_path):
+    return tmp_path
+
+
+def test_install_creates_file(project):
+    target = install(project)
+    assert target == project / ".kiro" / "hooks" / "mneme.json"
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["hooks"][0]["name"] == HOOK_NAME
+
+
+def test_install_is_idempotent(project):
+    first = install(project).read_bytes()
+    second = install(project).read_bytes()
+    assert first == second
+
+
+def test_second_install_reports_no_change(project, capsys):
+    install(project)
+    capsys.readouterr()
+    install(project)
+    assert "no change" in capsys.readouterr().out
+
+
+def test_install_preserves_foreign_hooks_on_disk(project):
+    hooks_path = project / ".kiro" / "hooks" / "mneme.json"
+    hooks_path.parent.mkdir(parents=True)
+    foreign = {
+        "version": "v1",
+        "hooks": [{
+            "name": "lint-on-save", "trigger": "PostFileSave",
+            "matcher": "\\.(ts|tsx)$",
+            "action": {"type": "command", "command": "npx eslint --fix"},
+        }],
+    }
+    hooks_path.write_text(json.dumps(foreign), encoding="utf-8")
+    install(project)
+    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    names = [h["name"] for h in payload["hooks"]]
+    assert "lint-on-save" in names
+    assert HOOK_NAME in names
+
+
+def test_install_refuses_to_clobber_invalid_json(project):
+    hooks_path = project / ".kiro" / "hooks" / "mneme.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_text("{ not json", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        install(project)
+    assert hooks_path.read_text(encoding="utf-8") == "{ not json"
+
+
+def test_install_refuses_non_v1_hooks_file(project):
+    hooks_path = project / ".kiro" / "hooks" / "mneme.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_text(json.dumps({"version": "v2", "hooks": []}), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        install(project)
+    assert json.loads(hooks_path.read_text(encoding="utf-8"))["version"] == "v2"
+
+
+def test_main_entry_point_installs_into_given_directory(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parents[3] / "scripts" / "install_kiro.py"),
+         str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / ".kiro" / "hooks" / "mneme.json").is_file()

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -3,11 +3,12 @@
 Two layers:
 
 1. **Source declaration** (always runs, no build): ``pyproject.toml``
-   ``[project.scripts]`` declares exactly the two console scripts the Claude
-   Code integration depends on::
+   ``[project.scripts]`` declares exactly the three console scripts the
+   integrations depend on::
 
-       mneme      = mneme.cli:main
-       mneme-hook = mneme.integrations.claude_code.hook:cli_main
+        mneme            = mneme.cli:main
+        mneme-hook       = mneme.integrations.claude_code.hook:cli_main
+        mneme-kiro-hook  = mneme.integrations.kiro.hook:cli_main
 
 2. **Built-artifact contract** (runs when ``dist/`` holds a build): the wheel
    and sdist are inspected directly. This is the authoritative verification of
@@ -39,6 +40,7 @@ PACKAGE_NAME = "mneme-hq"
 EXPECTED_SCRIPTS = {
     "mneme": "mneme.cli:main",
     "mneme-hook": "mneme.integrations.claude_code.hook:cli_main",
+    "mneme-kiro-hook": "mneme.integrations.kiro.hook:cli_main",
 }
 
 
@@ -143,7 +145,7 @@ def test_sdist_pkg_info_declares_name_and_version():
     assert meta.get("Version") == version, f"sdist Version = {meta.get('Version')!r}"
 
 
-def test_wheel_entry_points_are_exactly_the_two_console_scripts():
+def test_wheel_entry_points_are_exactly_the_declared_console_scripts():
     version = _declared_version()
     wheel = _sole_artifact(f"mneme_hq-{version}-*.whl")
     with zipfile.ZipFile(wheel) as zf:


### PR DESCRIPTION
## Summary

Integrates Kiro CLI 3.0 / v3 engine as a supported Native Integration. Translates Kiro's native \PreToolUse\ events (\s_write\, \s_append\) into Mneme's unified mutation-gate path, enforcing recorded decisions deterministically **before** writes reach disk.

**Status: Live-verified on Kiro CLI 3.0 / v3 engine. Ready for promotion to Native Integration.**

## Verification & Live Evidence (CLI 3.0 / v3 Engine)

Live reproduction was performed on August 26, 2026, using Kiro CLI 2.19.2 running the v3 engine (\--v3\). 

- **Hook Auto-Discovery:** Placing the hook definition in \.kiro/hooks/mneme.json\ is correctly and automatically honored by the v3 engine.
- **Strict Pre-Disk Blocking:** 
  - On new-file writes (\s_write\) introducing banned dependencies like \pip install mneme-hq\, Mneme successfully returns exit code \2\. Kiro blocks the write pre-disk (\3_test_block.md\ is never created).
  - On existing-file edits/appends (\s_append\), Mneme returns exit \2\ and the write is strictly blocked. The file remains byte-identical and untouched on disk.
- **Error Surface and Remediation:** Mneme's decision explanation is successfully written to stderr and displayed in the agent's TUI. The agent seamlessly consumes the feedback and proposes compliant remediation suggestions (such as using \uv add\ instead).
- **Clean Compliant Execution:** Submitting compliant writes/appends successfully returns exit code \