### PR TITLE
feat: Google Antigravity pre-tool adapter reusing Mneme hook enforcement

### DIFF
--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -1,0 +1,88 @@
+# Mneme for Google Antigravity
+
+Deterministic architectural enforcement for [Google Antigravity](https://antigravity.google/)
+agents at the pre-tool gate. The same introduced-delta enforcement that powers
+the Claude Code hook, exposed through Antigravity's native `PreToolUse` hook
+transport.
+
+Verified against Antigravity 2.8.1 (IDE); contract per the official Hooks
+documentation.
+
+---
+
+## Architecture
+
+The adapter (`mneme/integrations/antigravity/adapter.py`) is a thin
+translation layer. It implements no governance semantics of its own:
+
+```text
+Antigravity PreToolUse payload
+    -> ToolEvent translation (Antigravity args -> canonical Write/Edit/MultiEdit)
+    -> introduced-content materialization + `mneme check`   (existing)
+    -> {"decision": "deny"} + Mneme's reason, or {} (no opinion)
+```
+
+Tool mapping:
+
+| Antigravity tool | Canonical gate | Translated arguments |
+|---|---|---|
+| `write_to_file` | Write | `TargetFile`, `CodeContent` |
+| `replace_file_content` | Edit | `TargetFile`, `TargetContent` -> `ReplacementContent` |
+| `multi_replace_file_content` | MultiEdit | `ReplacementChunks[].TargetContent` -> `.ReplacementContent` |
+
+Materialization, introduced-delta selection (ADR-018), memory discovery,
+mode resolution, verdict parsing, and reason formatting are imported from
+the existing Claude Code hook module. Read-only tools never reach the gate.
+
+## Usage
+
+Create `.agents/hooks.json` inside a governed project (one with
+`.mneme/project_memory.json`):
+
+```json
+{
+  "mneme": {
+    "PreToolUse": [
+      {
+        "matcher": "write_to_file|replace_file_content|multi_replace_file_content",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m mneme.integrations.antigravity",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The command needs `mneme-hq` importable; point `PYTHONPATH` at your install
+or invoke an installed console wrapper. Enforcement mode follows the shared
+resolution (`MNEME_HOOK_MODE`, then `"strict"`).
+
+## Policy
+
+Antigravity's response contract differs from Claude Code's in one important
+way: emitting `"allow"` **auto-grants** the tool call, bypassing the normal
+permission flow. This adapter therefore has only two outputs:
+
+| Mneme outcome | Adapter output |
+|---|---|
+| Trusted PASS / SKIP | `{}` — no opinion; Antigravity's own permission flow stays in charge |
+| Trusted WARN/FAIL, strict mode | `{"decision": "deny", "reason": <violation report>}` |
+| Trusted WARN/FAIL, warn mode | `{}`; violation report on stderr (never blocks) |
+| Unparseable verdict / operational failure / incomplete evaluation | `{}` (fail open), reason on stderr |
+
+Every code path writes exactly one JSON object to stdout: Antigravity fails
+**closed** on hook output it cannot parse, so the adapter must always emit
+well-formed JSON even when it has no opinion.
+
+## What this integration is not
+
+- Not a second enforcement implementation. If `mneme check` changes,
+  this adapter follows automatically.
+- Not a guidance surface. No DecisionRetriever dependency, no context
+  injection; retrieval remains a separate layer.
+- Not a provider framework or generic hook abstraction.

--- a/mneme/integrations/antigravity/__main__.py
+++ b/mneme/integrations/antigravity/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from mneme.integrations.antigravity.adapter import cli_main
+
+if __name__ == "__main__":
+    cli_main()

--- a/mneme/integrations/antigravity/adapter.py
+++ b/mneme/integrations/antigravity/adapter.py
@@ -1,0 +1,315 @@
+"""Google Antigravity integration — deterministic enforcement at the pre-tool gate.
+
+Maps Antigravity's ``PreToolUse`` hook events onto existing Mneme surfaces:
+
+    PreToolUse (write_to_file | replace_file_content | multi_replace_file_content)
+        -> ToolEvent translation (Antigravity args -> canonical Write/Edit/MultiEdit)
+        -> introduced-content materialization + `mneme check`
+           (the same enforcement path as the Claude Code hook)
+        -> {"decision": "deny"} + Mneme's reason, or {} (no opinion)
+
+No retrieval, applicability, conflict, or enforcement semantics are
+implemented here. The pure pieces are imported from
+``mneme.integrations.claude_code.hook``; this module only translates
+between Antigravity's hook transport and that existing behavior.
+
+Policy:
+
+- trusted PASS              -> no opinion: stdout {} keeps Antigravity's
+                               normal permission flow in charge. Emitting
+                               "allow" would auto-grant the tool call and
+                               weaken permissions a warning mode must not
+                               touch.
+- trusted WARN/FAIL,
+  strict mode               -> deny, reason = Mneme's violation report
+- trusted WARN/FAIL,
+  warn mode                 -> no decision; the report goes to stderr
+- unparseable verdict,
+  operational failure,
+  incomplete evaluation     -> fail open (no decision) but visibly: the
+                               reason goes to stderr
+
+Every code path writes exactly one JSON object to stdout. Antigravity
+fails closed on hook output it cannot parse, so the adapter must always
+emit well-formed JSON even when it has no opinion.
+
+Usage — ``.agents/hooks.json`` inside a governed project::
+
+    {
+      "mneme": {
+        "PreToolUse": [
+          {
+            "matcher": "write_to_file|replace_file_content|multi_replace_file_content",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "python -m mneme.integrations.antigravity",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    }
+
+Enforcement mode follows the shared resolution (``MNEME_HOOK_MODE``, then
+"strict").
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Dict, Optional, TextIO
+
+from mneme.integrations.claude_code.hook import (
+    ToolEvent,
+    _CHECK_TIMEOUT_SECONDS,
+    _child_env,
+    find_memory,
+    format_applicability_reason,
+    format_reason,
+    introduced_content,
+    MaterializeError,
+    parse_verdict,
+    resolve_mode,
+    should_check,
+)
+
+
+class BadHookEvent(ValueError):
+    """Raised when an Antigravity hook payload cannot be translated."""
+
+
+# Antigravity mutation tools -> canonical Claude-style tool names. The
+# canonical names select behavior in the shared materializer; this table is
+# pure payload translation, not new tool semantics.
+_TOOL_ALIASES = {
+    "write_to_file": "Write",
+    "replace_file_content": "Edit",
+    "multi_replace_file_content": "MultiEdit",
+}
+
+
+def translate_tool_call(name: str, args: Dict) -> tuple[str, str, Dict]:
+    """Translate one Antigravity tool call into ``(canonical_name, file_path, tool_input)``.
+
+    Raises :class:`BadHookEvent` for unmapped tools or malformed arguments.
+    """
+    canonical = _TOOL_ALIASES.get(name)
+    if canonical is None:
+        raise BadHookEvent(f"unmapped tool: {name!r}")
+    if not isinstance(args, dict):
+        raise BadHookEvent("toolCall.args must be an object")
+
+    file_path = args.get("TargetFile", "")
+    if not isinstance(file_path, str):
+        raise BadHookEvent("TargetFile must be a string")
+
+    if canonical == "Write":
+        tool_input = {
+            "file_path": file_path,
+            "content": args.get("CodeContent", ""),
+        }
+    elif canonical == "Edit":
+        tool_input = {
+            "file_path": file_path,
+            "old_string": args.get("TargetContent", ""),
+            "new_string": args.get("ReplacementContent", ""),
+        }
+    else:  # MultiEdit
+        chunks = args.get("ReplacementChunks", [])
+        if not isinstance(chunks, list):
+            raise BadHookEvent("ReplacementChunks must be a list")
+        edits = []
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                raise BadHookEvent("ReplacementChunks entries must be objects")
+            edits.append(
+                {
+                    "old_string": chunk.get("TargetContent", ""),
+                    "new_string": chunk.get("ReplacementContent", ""),
+                }
+            )
+        tool_input = {"file_path": file_path, "edits": edits}
+
+    return canonical, file_path, tool_input
+
+
+def parse_hook_event(raw: str) -> Optional[ToolEvent]:
+    """Parse one Antigravity PreToolUse stdin payload.
+
+    Returns ``None`` for read-only or otherwise unmapped tool calls (the
+    gate has no opinion on them). Raises ``BadHookEvent`` for mutating
+    calls whose arguments cannot be translated safely -- callers must fail
+    open rather than guess at content they cannot reconstruct.
+    """
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise BadHookEvent("hook payload must be an object")
+    call = payload.get("toolCall")
+    if not isinstance(call, dict):
+        raise BadHookEvent("missing toolCall")
+    name = call.get("name", "")
+    args = call.get("args") or {}
+
+    if name not in _TOOL_ALIASES:
+        return None
+    canonical, file_path, tool_input = translate_tool_call(name, args)
+
+    workspaces = payload.get("workspacePaths") or []
+    cwd = workspaces[0] if workspaces and isinstance(workspaces[0], str) else ""
+    return ToolEvent(
+        tool_name=canonical,
+        file_path=file_path,
+        cwd=cwd,
+        tool_input=tool_input,
+    )
+
+
+CheckRunner = Callable[..., subprocess.CompletedProcess]
+
+
+def run_check(event: ToolEvent, content: str, memory: Path, mode: str, check_runner: CheckRunner):
+    """Run `mneme check` exactly as the existing integrations do."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(content)
+        input_path = tf.name
+
+    rel = event.file_path or "(unknown)"
+    target_path = event.file_path
+    if target_path and not Path(target_path).is_absolute() and event.cwd:
+        target_path = str(Path(event.cwd) / target_path)
+
+    command = [
+        sys.executable, "-m", "mneme", "check",
+        "--memory", str(memory),
+        "--input", input_path,
+        "--query", f"edit to {rel}",
+        "--mode", mode,
+        "--json",
+    ]
+    if target_path:
+        command.extend(["--target-path", target_path])
+
+    try:
+        return check_runner(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CHECK_TIMEOUT_SECONDS,
+            env=_child_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    finally:
+        try:
+            os.unlink(input_path)
+        except OSError:
+            pass
+
+
+def emit(obj: Dict, stdout: TextIO) -> None:
+    json.dump(obj, stdout)
+    stdout.write("\n")
+
+
+def main(
+    stdin: TextIO = sys.stdin,
+    stderr: TextIO = sys.stderr,
+    stdout: TextIO = sys.stdout,
+    check_runner: Optional[CheckRunner] = None,
+) -> int:
+    """One Antigravity hook invocation: stdin JSON -> stdout JSON."""
+    try:
+        event = parse_hook_event(stdin.read())
+    except (json.JSONDecodeError, BadHookEvent) as e:
+        print(f"mneme-antigravity: bad hook event, failing open: {e}", file=stderr)
+        emit({}, stdout)
+        return 0
+
+    if event is None or not should_check(event.tool_name):
+        emit({}, stdout)
+        return 0
+
+    memory = find_memory(Path(event.cwd or "."))
+    if memory is None:
+        # Same policy as every other integration: outside any governed
+        # project, the gate has no opinion.
+        emit({}, stdout)
+        return 0
+
+    try:
+        checked_content = introduced_content(event)
+    except MaterializeError as e:
+        print(
+            f"mneme-antigravity: cannot materialize content, failing open: {e}",
+            file=stderr,
+        )
+        emit({}, stdout)
+        return 0
+
+    if not checked_content.strip():
+        emit({}, stdout)
+        return 0
+
+    mode = resolve_mode()
+    proc = run_check(event, checked_content, memory, mode, check_runner or subprocess.run)
+
+    if proc is None:
+        print(
+            "mneme-antigravity: could not run mneme check. Failing open.",
+            file=stderr,
+        )
+        emit({}, stdout)
+        return 0
+
+    payload = parse_verdict(proc.stdout)
+    if payload is None:
+        print(
+            "mneme-antigravity: no parseable verdict from mneme check "
+            f"(exit {proc.returncode}). Failing open.",
+            file=stderr,
+        )
+        if proc.stderr:
+            print(proc.stderr, file=stderr)
+        emit({}, stdout)
+        return 0
+
+    verdict = payload["verdict"]
+    if payload.get("evaluation_complete") is False:
+        print(format_applicability_reason(payload), file=stderr)
+        emit({}, stdout)
+        return 0
+
+    if verdict == "PASS":
+        emit({}, stdout)
+        return 0
+
+    reason = format_reason(payload)
+    if mode == "warn":
+        print(
+            "[mneme] WARN - architectural decision flagged (warn mode; "
+            f"not blocked):\n{reason}",
+            file=stderr,
+        )
+        emit({}, stdout)
+        return 0
+
+    emit({"decision": "deny", "reason": reason}, stdout)
+    return 0
+
+
+def cli_main() -> None:
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/tests/integrations/antigravity/test_adapter_gate.py
+++ b/tests/integrations/antigravity/test_adapter_gate.py
@@ -1,0 +1,281 @@
+"""Gate tests: verdict translation through the shared Mneme enforcement path."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mneme.integrations.antigravity import adapter
+
+
+def _write_event(tmp_path, content="FORBIDDEN_TOKEN here\n"):
+    return adapter.ToolEvent(
+        tool_name="Write",
+        file_path=str(tmp_path / "new.py"),
+        cwd=str(tmp_path),
+        tool_input={"file_path": str(tmp_path / "new.py"), "content": content},
+    )
+
+
+def _hook_input(event):
+    return json.dumps(
+        {
+            "toolCall": {
+                "name": "write_to_file",
+                "args": {
+                    "TargetFile": event.file_path,
+                    "CodeContent": event.tool_input["content"],
+                },
+            },
+            "workspacePaths": [event.cwd],
+        }
+    )
+
+
+def _verdict(verdict="FAIL", evaluation_complete=True):
+    return SimpleNamespace(
+        returncode=2 if verdict != "PASS" else 0,
+        stdout=json.dumps(
+            {
+                "schema": "mneme.check/v1",
+                "verdict": verdict,
+                "mode": "strict",
+                "evaluation_complete": evaluation_complete,
+                "violations": [
+                    {
+                        "decision_id": "D1",
+                        "decision_text": "never do the bad thing",
+                        "severity": "FAIL",
+                        "rule": "no forbidden token",
+                        "trigger": "FORBIDDEN_TOKEN",
+                        "kind": "literal",
+                        "rule_type": "FORBID_LITERAL",
+                        "input_path": "",
+                        "selector": "",
+                    }
+                ],
+                "applicability": [],
+                "freshness": [],
+            }
+        )
+        if evaluation_complete or verdict == "PASS"
+        else json.dumps(
+            {
+                "schema": "mneme.check/v1",
+                "verdict": "WARN",
+                "mode": "strict",
+                "evaluation_complete": False,
+                "violations": [],
+                "applicability": [
+                    {
+                        "decision_id": "D2",
+                        "rule_type": "FORBID_LITERAL",
+                        "rule_value": "X",
+                        "outcome": "UNKNOWN",
+                        "reason": "path applicability unknown",
+                    }
+                ],
+                "freshness": [],
+            }
+        ),
+        stderr="",
+    )
+
+
+@pytest.fixture()
+def memory(tmp_path, monkeypatch):
+    """A minimal governed project: one typed literal rule."""
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir()
+    mem.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "decisions": [
+                    {
+                        "id": "D1",
+                        "text": "never do the bad thing",
+                        "rules": [{"type": "FORBID_LITERAL", "value": "FORBIDDEN_TOKEN"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(adapter, "find_memory", lambda start: mem)
+    return mem
+
+
+class _FakeIO:
+    def __init__(self, data=""):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+    def write(self, text):
+        self.data += text
+        return len(text)
+
+
+def _invoke(raw, check_runner=None):
+    stdin, stdout, stderr = _FakeIO(raw), _FakeIO(), _FakeIO()
+    code = adapter.main(stdin=stdin, stderr=stderr, stdout=stdout, check_runner=check_runner)
+    return code, stdout.data, stderr.data
+
+
+def _runner(result=None, error=None):
+    def run(*args, **kwargs):
+        if error is not None:
+            raise error
+        return result
+
+    return run
+
+
+class TestVerdictTranslation:
+    def test_compliant_mutation_is_not_blocked(self, tmp_path, memory):
+        code, out, _ = _invoke(
+            _hook_input(_write_event(tmp_path, "clean = True\n")),
+            check_runner=_runner(_verdict("PASS")),
+        )
+        assert code == 0
+        assert json.loads(out) == {}
+
+    def test_violating_mutation_is_denied_with_reason(self, tmp_path, memory):
+        code, out, _ = _invoke(
+            _hook_input(_write_event(tmp_path)),
+            check_runner=_runner(_verdict("FAIL")),
+        )
+        assert code == 0
+        payload = json.loads(out)
+        assert payload["decision"] == "deny"
+        assert "D1" in payload["reason"]
+        assert "FORBIDDEN_TOKEN" in payload["reason"]
+
+    def test_block_response_is_the_only_active_decision(self, tmp_path, memory):
+        """PASS must not emit decision=allow: that would auto-grant in Antigravity."""
+        _, out, _ = _invoke(
+            _hook_input(_write_event(tmp_path, "ok\n")),
+            check_runner=_runner(_verdict("PASS")),
+        )
+        assert "allow" not in json.loads(out)
+
+
+class TestFailureSemantics:
+    def test_unparseable_verdict_fails_open_visibly(self, tmp_path, memory):
+        crash = SimpleNamespace(returncode=1, stdout="Traceback...", stderr="boom")
+        code, out, err = _invoke(
+            _hook_input(_write_event(tmp_path)),
+            check_runner=_runner(crash),
+        )
+        assert code == 0
+        assert json.loads(out) == {}
+        assert "Failing open" in err
+
+    def test_check_launch_failure_fails_open(self, tmp_path, memory):
+        code, out, err = _invoke(
+            _hook_input(_write_event(tmp_path)),
+            check_runner=_runner(error=OSError("no interpreter")),
+        )
+        assert code == 0
+        assert json.loads(out) == {}
+        assert "could not run" in err
+
+    def test_incomplete_evaluation_fails_open(self, tmp_path, memory):
+        code, out, err = _invoke(
+            _hook_input(_write_event(tmp_path)),
+            check_runner=_runner(_verdict(evaluation_complete=False)),
+        )
+        assert code == 0
+        assert json.loads(out) == {}
+        assert "unknown" in err
+
+    def test_malformed_hook_input_fails_open(self, memory):
+        code, out, err = _invoke("not json")
+        assert code == 0
+        assert json.loads(out) == {}
+        assert "bad hook event" in err
+
+
+class TestModeSemantics:
+    def test_warn_mode_never_blocks(self, tmp_path, memory, monkeypatch):
+        monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+        code, out, err = _invoke(
+            _hook_input(_write_event(tmp_path)),
+            check_runner=_runner(_verdict("FAIL")),
+        )
+        assert code == 0
+        assert "decision" not in json.loads(out)
+        assert "not blocked" in err
+
+    def test_strict_is_default(self, tmp_path, memory, monkeypatch):
+        monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+        seen = {}
+
+        def runner(command, **kwargs):
+            seen["mode"] = command[command.index("--mode") + 1]
+            return _verdict("PASS")
+
+        _, _, _ = _invoke(_hook_input(_write_event(tmp_path)), check_runner=runner)
+        assert seen["mode"] == "strict"
+
+
+class TestNoOpinionPaths:
+    def test_read_only_tool_emits_empty_object(self, memory):
+        raw = json.dumps(
+            {"toolCall": {"name": "view_file", "args": {"AbsolutePath": "x"}}}
+        )
+        code, out, _ = _invoke(raw)
+        assert code == 0
+        assert json.loads(out) == {}
+
+    def test_no_memory_has_no_opinion(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(adapter, "find_memory", lambda start: None)
+        code, out, _ = _invoke(_hook_input(_write_event(tmp_path)))
+        assert code == 0
+        assert json.loads(out) == {}
+
+
+class TestCheckInvocation:
+    def test_invokes_shared_cli_contract(self, tmp_path, memory):
+        seen = {}
+
+        def runner(command, **kwargs):
+            seen.update(kwargs)
+            seen["command"] = command
+            return _verdict("PASS")
+
+        event = _write_event(tmp_path)
+        _invoke(_hook_input(event), check_runner=runner)
+        cmd = seen["command"]
+        assert cmd[1:3] == ["-m", "mneme"]
+        assert "--json" in cmd
+        assert "--target-path" in cmd
+        assert event.file_path in cmd
+        assert seen["timeout"] == adapter._CHECK_TIMEOUT_SECONDS
+
+
+class TestAdapterIndependence:
+    def test_adapter_does_not_depend_on_decision_retriever(self):
+        """Enforcement glue must stay retrieval-free (retrieval/enforcement separation)."""
+        import ast
+        from pathlib import Path
+
+        source = Path(adapter.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                names = {a.name for a in node.names}
+                assert "DecisionRetriever" not in names
+                assert node.module != "mneme.decision_retriever"
+                assert not node.module.startswith("mneme.context_builder")
+            elif isinstance(node, ast.Import):
+                for a in node.names:
+                    assert "retriever" not in a.name
+
+    def test_every_exit_path_emits_parseable_json(self, memory):
+        for raw in ("not json", "", "{}", "null"):
+            _, out, _ = _invoke(raw)
+            if out:
+                json.loads(out)

--- a/tests/integrations/antigravity/test_adapter_parse.py
+++ b/tests/integrations/antigravity/test_adapter_parse.py
@@ -1,0 +1,129 @@
+"""Translation tests: Antigravity PreToolUse payloads -> canonical ToolEvents."""
+
+import json
+
+import pytest
+
+from mneme.integrations.antigravity.adapter import BadHookEvent, parse_hook_event
+
+
+def _payload(tool_name, args, workspaces=("c:/ws/proj",)):
+    return {
+        "toolCall": {"name": tool_name, "args": args},
+        "stepIdx": 3,
+        "conversationId": "conv-1",
+        "workspacePaths": list(workspaces),
+        "modelName": "gemini-test",
+    }
+
+
+class TestWriteToFile:
+    def test_maps_to_write_with_complete_content(self):
+        event = parse_hook_event(
+            json.dumps(
+                _payload(
+                    "write_to_file",
+                    {
+                        "TargetFile": "c:/ws/proj/src/mod.py",
+                        "CodeContent": "x = 1\n",
+                        "Overwrite": False,
+                    },
+                )
+            )
+        )
+        assert event.tool_name == "Write"
+        assert event.file_path == "c:/ws/proj/src/mod.py"
+        assert event.tool_input["content"] == "x = 1\n"
+        assert event.cwd == "c:/ws/proj"
+
+    def test_missing_workspace_paths_gives_empty_cwd(self):
+        event = parse_hook_event(
+            json.dumps(_payload("write_to_file", {"TargetFile": "a.py"}, workspaces=[]))
+        )
+        assert event.cwd == ""
+
+
+class TestReplaceFileContent:
+    def test_maps_to_edit(self):
+        event = parse_hook_event(
+            json.dumps(
+                _payload(
+                    "replace_file_content",
+                    {
+                        "TargetFile": "c:/ws/proj/src/mod.py",
+                        "TargetContent": "old line",
+                        "ReplacementContent": "new line",
+                    },
+                )
+            )
+        )
+        assert event.tool_name == "Edit"
+        assert event.tool_input["old_string"] == "old line"
+        assert event.tool_input["new_string"] == "new line"
+
+
+class TestMultiReplaceFileContent:
+    def test_maps_chunks_to_sequential_edits(self):
+        event = parse_hook_event(
+            json.dumps(
+                _payload(
+                    "multi_replace_file_content",
+                    {
+                        "TargetFile": "c:/ws/proj/src/mod.py",
+                        "ReplacementChunks": [
+                            {"TargetContent": "a", "ReplacementContent": "b"},
+                            {"TargetContent": "c", "ReplacementContent": "d"},
+                        ],
+                    },
+                )
+            )
+        )
+        assert event.tool_name == "MultiEdit"
+        assert event.tool_input["edits"] == [
+            {"old_string": "a", "new_string": "b"},
+            {"old_string": "c", "new_string": "d"},
+        ]
+
+    def test_non_list_chunks_raise(self):
+        with pytest.raises(BadHookEvent):
+            parse_hook_event(
+                json.dumps(
+                    _payload(
+                        "multi_replace_file_content",
+                        {"TargetFile": "f", "ReplacementChunks": "nope"},
+                    )
+                )
+            )
+
+
+class TestReadOnlyAndMalformed:
+    @pytest.mark.parametrize(
+        "tool_name,args",
+        [
+            ("view_file", {"AbsolutePath": "c:/x"}),
+            ("list_dir", {"DirectoryPath": "c:/x"}),
+            ("grep_search", {"SearchPath": "c:/x", "Query": "q"}),
+            ("run_command", {"CommandLine": "echo hi", "Cwd": "c:/x"}),
+        ],
+    )
+    def test_read_only_and_unmapped_tools_return_none(self, tool_name, args):
+        assert parse_hook_event(json.dumps(_payload(tool_name, args))) is None
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            parse_hook_event("this is not json")
+
+    def test_missing_tool_call_raises(self):
+        with pytest.raises(BadHookEvent):
+            parse_hook_event(json.dumps({"stepIdx": 0}))
+
+    def test_non_object_payload_raises(self):
+        with pytest.raises(BadHookEvent):
+            parse_hook_event(json.dumps([1, 2, 3]))
+
+    def test_mutating_tool_with_bad_args_raises(self):
+        """A Write whose TargetFile is not a string must not be guessed at."""
+        with pytest.raises(BadHookEvent):
+            parse_hook_event(
+                json.dumps(_payload("write_to_file", {"TargetFile": 42}))
+            )

--- a/tests/integrations/antigravity/test_integration_identity.py
+++ b/tests/integrations/antigravity/test_integration_identity.py
@@ -1,0 +1,77 @@
+"""Integration-identity tests: the Antigravity adapter must reuse, not copy, Mneme.
+
+Mirrors tests/integrations/agent_sdk/test_integration_identity.py: pins that
+the adapter imports the shared enforcement semantics and implements no
+retrieval, matching, or scoring logic of its own.
+"""
+
+import ast
+from pathlib import Path
+
+ADAPTER = (
+    Path(__file__).resolve().parents[3] / "mneme" / "integrations" / "antigravity" / "adapter.py"
+)
+
+# Symbols that ARE the existing semantics. The adapter must import them,
+# never redefine them.
+REQUIRED_IMPORTS = [
+    "introduced_content",
+    "find_memory",
+    "resolve_mode",
+    "parse_verdict",
+    "format_reason",
+    "format_applicability_reason",
+]
+
+
+def test_adapter_imports_existing_semantics():
+    source = ADAPTER.read_text(encoding="utf-8")
+    for name in REQUIRED_IMPORTS:
+        assert name in source, f"adapter must reuse {name} from core"
+
+
+def test_adapter_defines_no_matching_or_scoring_logic():
+    """No tokenization/scoring/matching reimplementation may appear."""
+    tree = ast.parse(ADAPTER.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            names.add(f"re.{node.func.attr}")
+    for token in ("SequenceMatcher", "get_opcodes"):
+        assert token not in names, f"duplicated diff/matching logic: {token}"
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "import re" not in src, "adapter must not do regex rule matching"
+    for bad in ("score =", "weight", "stopword"):
+        assert bad not in src, f"duplicated retrieval scoring: {bad}"
+
+
+def test_adapter_has_no_retrieval_dependency():
+    """The enforcement adapter must never call DecisionRetriever."""
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "DecisionRetriever" not in src
+    assert "decision_retriever" not in src
+    assert "MemoryStore" not in src
+    assert "format_decisions" not in src
+
+
+def test_claude_code_hook_module_untouched_surface():
+    """The Claude Code hook keeps its own entry points and constants."""
+    from mneme.integrations.claude_code import hook
+
+    for attr in (
+        "main",
+        "cli_main",
+        "parse_event",
+        "should_check",
+        "materialize_proposed_content",
+        "introduced_content",
+        "find_memory",
+        "resolve_mode",
+        "parse_verdict",
+        "format_reason",
+    ):
+        assert hasattr(hook, attr), f"hook surface changed: {attr}"


### PR DESCRIPTION
## Summary

Minimal Google Antigravity integration: a `PreToolUse` hook adapter that reuses Mneme's existing enforcement path. Transport-only glue; no governance semantics added.

```text
Antigravity PreToolUse payload
  -> Antigravity-specific normalizer (write_to_file/replace_file_content/multi_replace_file_content
     -> canonical Write/Edit/MultiEdit ToolEvent)
  -> existing Mneme enforcement (introduced-content + `mneme check --json`, shared with Claude Code hook)
  -> {"decision": "deny", "reason": ...} or {} (no opinion)
```

## Reuse (no new engines)

- Imports the shared surface from `mneme/integrations/claude_code/hook.py`: `ToolEvent`, `should_check`, `find_memory`, `resolve_mode`, `introduced_content` (ADR-018), `MaterializeError`, `parse_verdict`, `format_reason`, `format_applicability_reason`, `_child_env`, `_CHECK_TIMEOUT_SECONDS`
- No DecisionRetriever / MemoryStore dependency (AST-pinned by identity tests, mirroring the agent-sdk convention)
- Retrieval/enforcement separation preserved; ConflictDetector, rule selection, and benchmark semantics untouched

## Response policy (Antigravity-specific)

- deny is the only active decision (`{"decision":"deny","reason":...}`)
- PASS/SKIP emits `{}` — never `"allow"`, which in Antigravity auto-grants and would weaken permissions
- every path emits parseable JSON because Antigravity fails closed on unparseable hook output (verified live)

## Phase-0 verified runtime contract (Antigravity IDE 2.8.1)

- hooks.json in `.agents/`; PreToolUse fires before execution with full proposed content
- stdin JSON envelope `{toolCall:{name,args}, workspacePaths, ...}` -> stdout JSON decision
- live deny prevented a filesystem mutation (verified absent); live compliant mutation landed; malformed hook output blocks

## Tests

31 focused tests (translation, gate verdicts, fail-open semantics, modes, no-opinion paths, invocation contract, identity pins). Full suite: 780 passed / 5 skipped vs attached-equivalent baseline 749/5 (+31 new; zero regressions).

## Live dogfood evidence

Governed fixture (`FORBID_LITERAL LEGACY_SQL_HELPER`), real headless Antigravity sessions:

- compliant write -> no opinion -> file created
- violating write -> deny + DATA-001 reason -> target file absent from filesystem
- same tool/workspace permitted through Antigravity's own permission layer in the PASS case, blocked only by Mneme in the FAIL case (layer separation)

## Out of scope (unchanged)

No context injection / guidance work, no SDK integration, no MCP, no generic adapter framework, no benchmark changes.
