### PR TITLE
fix: phrase-sequence matching for multi-term legacy anti-patterns (ADR-017 amendment)

### DIFF
--- a/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
+++ b/docs/adr/ADR-017-enforcement-scope-vs-retrieval-scope.md
@@ -11,6 +11,8 @@ scope: enforcement.retrieval_separation
 
 **Status:** Accepted
 **Date:** 2026-08-08
+**Amended:** 2026-08-24 — phrase-sequence matching for multi-term legacy
+anti-patterns (see Amendment below)
 **Deciders:** Theo Valmis
 
 ---
@@ -135,6 +137,64 @@ block, and would have made strict mode unusable.
   than silently absorbed.
 - Enforcement remains scoped to the tools the PreToolUse hook covers. This ADR
   does not change which edits reach the checker.
+
+## Amendment (2026-08-24): Phrase-Sequence Matching for Multi-Term Legacy Anti-Patterns
+
+### Context of amendment
+
+Dogfooding reproduced the #150 nuisance inside the retrieval-gated tier this
+ADR deliberately preserved. `check_prompt` decomposed each multi-term
+anti-pattern into individual terms and FAILed on the first whole-word hit, so
+ordinary planning prose containing tokens such as `awin`, `live`,
+`category`, or `slug` failed checks whenever a rule-bearing decision was
+retrieved — including via path-token overlap that pulled the very rule into
+its own gated tier. An agent reacted to one such block by writing through a
+shell surface instead (the shell behavior is governed by ADR-021 and is not
+addressed here). Separately, the `\b` boundary matcher could never match a
+rule's own underscore identifier spelling (`assume_awin_awin_us_same_source`
+contains no standalone term), so such rules had no true-positive form at all.
+
+This ADR settled *where* multi-term rules apply; it did not settle *how they
+match*. The disjunctive within-rule semantics were preserved as containment,
+not endorsed. This amendment settles them.
+
+### Amended decision
+
+7. **Multi-term legacy anti-patterns match as a complete ordered term
+   sequence.** Both rule and input are normalized identically: lowercased
+   alphanumeric runs, with whitespace, underscores, hyphens, and punctuation
+   acting as equivalent separators. Every alphanumeric token of the rule —
+   including short tokens and stopword-like words such as `and` — participates
+   in the template; nothing is dropped. A violation requires that complete
+   sequence to occur together and in order in the checked text.
+
+8. **Single-term rules keep their existing whole-word behavior**, and remain
+   enforced corpus-wide per Decision 3 above.
+
+9. **Nothing else moves.** Retrieval gating for multi-term legacy rules stays
+   exactly as decided above. Constraint matching ("no X" WARN semantics),
+   typed `FORBID_LITERAL` (ADR-019), path applicability (ADR-020),
+   retrieval scoring and cutoffs, `ConflictDetector`, and the ADR-021
+   shell/Stop boundaries are unchanged by this amendment.
+
+### Consequences of the amendment
+
+- Benign prose that merely contains an ordinary token from a rule passes;
+  content carrying the rule's canonical or identifier spelling fails.
+  The dogfood false-positive class is closed, and identifier-form rules gain
+  their first true positives.
+- Accepted limitation, documented rather than hidden: morphological variants
+  ("assumes" vs "assume") and filler words between terms break the match.
+  These strict legacy semantics intentionally trade recall for lower
+  false-positive risk. Whole-file audit and ConflictDetector use separate
+  evaluation paths and are not guaranteed to recover phrase-sequence misses.
+- Tests that pinned the disjunctive gated-tier behavior were updated to the
+  amended contract; failing-first regressions from the incident turn green
+  under it.
+- The frozen enforcement benchmark was re-run unchanged: 7/7 scenarios,
+  Layer 2 pass rate 100%.
+- Issue #150 narrows: this class of within-tier false positive is resolved;
+  code-aware matching remains open there.
 
 ## Related
 

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -12,7 +12,9 @@ happens to share no token with the decision's scope. See ADR-017.
 
 Severity semantics:
     A typed FORBID_LITERAL match is a FAIL.
-    FAIL  — input contains a term from a decision's anti_patterns list.
+    FAIL  — input contains a single-term anti-pattern term, or the complete
+            ordered term sequence of a multi-term anti-pattern (ADR-017
+            amendment, 2026-08-24).
     WARN  — input mentions a term that a "no X" constraint forbids.
     PASS  — no violations found.
 
@@ -49,7 +51,10 @@ class Violation:
     decision_text: str
     severity: Severity
     rule: str     # the constraint or anti_pattern string that triggered
-    trigger: str  # the specific term found in the input
+    trigger: str  # the matched term (single-term rules) or the matched rule
+                  # expression (multi-term phrase match). For a phrase match
+                  # this is the rule's text as authored; it need not appear
+                  # verbatim in the input, since separators normalize away.
     kind: str = "legacy"
     rule_type: str | None = None
     input_path: str | None = None
@@ -89,6 +94,36 @@ def _word_in_text(term: str, text: str) -> bool:
     return bool(re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE))
 
 
+def _phrase_tokens(text: str) -> list[str]:
+    """All lowercased alphanumeric tokens of a phrase, in order.
+
+    Rule and input use exactly the same normalization: whitespace,
+    underscores, hyphens, and punctuation separate tokens identically, and
+    nothing is dropped -- stopwords and short tokens included. Every token in
+    the rule is therefore required to occur in the input, so
+    ``assume_awin_awin_us_same_source`` normalizes to the same sequence as
+    "assume awin awin us same source", while "foo bar" can never satisfy a
+    rule stating "foo and bar".
+    """
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def _phrase_in_text(phrase: list[str], text: str) -> bool:
+    """True if the complete ordered token sequence occurs contiguously.
+
+    A multi-term legacy anti-pattern is prose describing a pattern, not a bag
+    of independent forbidden words (ADR-017 amendment). Requiring the whole
+    sequence together and in order prevents benign prose that merely contains
+    one ordinary term -- `awin`, `live`, `content` -- from failing the check,
+    while still matching the rule's canonical or identifier spelling.
+    """
+    if not phrase:
+        return False
+    tokens = re.findall(r"[a-z0-9]+", text.lower())
+    n = len(phrase)
+    return any(tokens[i:i + n] == phrase for i in range(len(tokens) - n + 1))
+
+
 def _top_nonzero(scored: list[ScoredDecision], top: int) -> list[ScoredDecision]:
     kept: list[ScoredDecision] = []
     seen: set[str] = set()
@@ -114,11 +149,13 @@ def _is_literal_rule(text: str, min_len: int = 3) -> bool:
     against every decision in the corpus.
 
     Multi-term rules are the opposite. ``"open() without encoding= in Python"``
-    explodes into {open, without, encoding, python}, any one of which fires on
-    its own -- so the rule reports a violation on prose that merely contains
-    the word "open". Evaluating those corpus-wide turns a documented
-    false-positive nuisance (#150) into a repo-wide edit block, so they stay
-    behind retrieval until a typed literal vocabulary replaces them (#250).
+    is prose describing a pattern. Treating its terms as independent forbidden
+    words made any single occurrence -- a bare "open", "without", or "content"
+    -- fail benign prose (#150, and the 2026-08 dogfood false positives).
+    They stay retrieval-gated here, and since the ADR-017 amendment they
+    additionally match only as a complete ordered phrase (see
+    ``_phrase_in_text``), so the gated tier no longer fires on incidental
+    tokens either.
     """
     return len(_rule_terms(text, min_len=min_len)) == 1
 
@@ -164,7 +201,9 @@ def check_prompt(
 
     Unambiguous literal rules are checked against every decision supplied,
     regardless of retrieval score; multi-term rules are checked only for the
-    top-N retrieved decisions. See ``_enforcement_scope``.
+    top-N retrieved decisions, and there they match their complete ordered
+    term sequence rather than any single term (ADR-017 amendment). See
+    ``_enforcement_scope``.
 
     Args:
         input_text: The prompt or content to validate.
@@ -225,17 +264,28 @@ def check_prompt(
         for ap in d.anti_patterns:
             if literal_only and not _is_literal_rule(ap):
                 continue
-            for term in _rule_terms(ap):
-                if _word_in_text(term, input_text):
-                    violations.append(Violation(
-                        decision_id=d.id,
-                        decision_text=d.decision,
-                        severity=Severity.FAIL,
-                        rule=ap,
-                        trigger=term,
-                        kind="anti_pattern",
-                    ))
-                    break  # one violation per anti_pattern entry
+            if _is_literal_rule(ap):
+                # One significant term: term matching and literal matching
+                # coincide, so the pre-existing whole-word behaviour is kept.
+                trigger = next(
+                    (t for t in _rule_terms(ap) if _word_in_text(t, input_text)),
+                    None,
+                )
+            else:
+                # Multi-term: the complete ordered phrase must be present.
+                if _phrase_in_text(_phrase_tokens(ap), input_text):
+                    trigger = ap
+                else:
+                    trigger = None
+            if trigger is not None:
+                violations.append(Violation(
+                    decision_id=d.id,
+                    decision_text=d.decision,
+                    severity=Severity.FAIL,
+                    rule=ap,
+                    trigger=trigger,
+                    kind="anti_pattern",
+                ))
 
         for constraint in d.constraints:
             # Only handle "no X" style constraints.

--- a/tests/test_anti_pattern_token_fp.py
+++ b/tests/test_anti_pattern_token_fp.py
@@ -1,0 +1,113 @@
+"""Failing-first regression evidence for the legacy anti-pattern token false positive.
+
+Dogfood incident: ``mneme check`` FAILs benign planning/documentation prose
+because a multi-term legacy anti-pattern is decomposed into individual content
+terms and fires when ANY single term appears
+(``mneme/enforcer.py::check_prompt``, anti_patterns loop).
+
+These tests pin the expected semantics WITHOUT changing production behavior:
+
+    A/B. A multi-term anti-pattern must not describe a violation merely because
+         benign prose contains one ordinary token from it (``awin`` /
+         ``live`` / ``category`` / ``slug``).
+    C.   The genuine pattern (the full phrase describing the forbidden
+         approach) still FAILs, so any future fix cannot over-weaken.
+    D.   Typed FORBID_LITERAL keeps its deterministic exact-match FAIL and is
+         out of scope for any weakening.
+
+Current state at base 3a47cc1c: A and B FAIL against the implementation,
+proving the defect. C and D pass and guard the eventual semantic fix.
+See ADR-017 (multi-term rules remain retrieval-gated) and issue #150.
+"""
+import pytest
+
+from mneme.decision_retriever import ScoredDecision
+from mneme.enforcer import Severity, check_prompt
+from mneme.schemas import Decision, Rule
+
+
+def _scored(decision: Decision, score: float = 1.0) -> ScoredDecision:
+    return ScoredDecision(decision=decision, score=score)
+
+
+AWIN = Decision(
+    id="awin-001",
+    decision="Affiliate attribution must resolve to one source per market.",
+    rationale="duplicate tracking pixels caused double attribution",
+    scope=["affiliate"],
+    constraints=[],
+    # The reported incident identifier, verbatim shape: underscores split into
+    # separate terms by _rule_terms(), so bare "awin" prose triggers a FAIL.
+    anti_patterns=["assume_awin_awin_us_same_source"],
+)
+
+SLUG = Decision(
+    id="slug-001",
+    decision="URL slugs are derived once at publish time.",
+    rationale="mutating routes breaks external links",
+    scope=["publishing"],
+    constraints=[],
+    anti_patterns=["regenerate live category slug on every request"],
+)
+
+
+def test_multi_term_anti_pattern_does_not_fail_on_benign_awin_mention():
+    """A: benign planning prose mentioning 'awin' is not the anti-pattern."""
+    result = check_prompt(
+        "Plan: we will track the awin programme per market and review "
+        "attribution weekly.\n",
+        [_scored(AWIN)],
+    )
+    assert result.violations == []
+    assert result.verdict == Severity.PASS
+
+
+def test_multi_term_anti_pattern_does_not_fail_on_live_category_slug_prose():
+    """B: same defect class for other ordinary tokens from the incident."""
+    result = check_prompt(
+        "The documentation describes how each live category page receives "
+        "its slug before launch.\n",
+        [_scored(SLUG)],
+    )
+    assert result.violations == []
+    assert result.verdict == Severity.PASS
+
+
+def test_genuine_anti_pattern_phrase_still_fails():
+    """C: content actually carrying the forbidden pattern must keep failing.
+
+    This is the case the legacy rule exists for. Any semantic repair to the
+    term-level matcher has to preserve this verdict.
+
+    Note: the rule's own underscore-joined spelling never matches -- ``\\b``
+    boundaries see ``assume_awin`` as one token, so no extracted term occurs.
+    The genuine case therefore expresses the pattern in ordinary words, the
+    only form the legacy matcher has ever been able to detect.
+    """
+    result = check_prompt(
+        "Attribution logic assumes awin and awin us are the same source "
+        "for every market.\n",
+        [_scored(AWIN)],
+    )
+    fail = [v for v in result.violations if v.severity == Severity.FAIL]
+    assert len(fail) >= 1
+    assert result.verdict == Severity.FAIL
+
+
+def test_typed_forbid_literal_keeps_deterministic_fail():
+    """D: FORBID_LITERAL stays exact, case-sensitive, and retrieval-independent."""
+    decision = Decision(
+        id="ADR-901",
+        decision="Use the published install command only",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install mneme-legacy")],
+    )
+    # Score 0.0: typed rules enforce regardless of retrieval tier (ADR-019).
+    result = check_prompt(
+        "run pip install mneme-legacy to reproduce\n",
+        [_scored(decision, score=0.0)],
+    )
+    [violation] = result.violations
+    assert violation.kind == "typed_rule"
+    assert violation.rule_type == "FORBID_LITERAL"
+    assert violation.trigger == "pip install mneme-legacy"
+    assert result.verdict == Severity.FAIL

--- a/tests/test_anti_pattern_token_fp.py
+++ b/tests/test_anti_pattern_token_fp.py
@@ -1,22 +1,25 @@
-"""Failing-first regression evidence for the legacy anti-pattern token false positive.
+"""Regression tests for the legacy anti-pattern token false positive.
 
-Dogfood incident: ``mneme check`` FAILs benign planning/documentation prose
-because a multi-term legacy anti-pattern is decomposed into individual content
-terms and fires when ANY single term appears
+Dogfood incident: ``mneme check`` FAILed benign planning/documentation prose
+because a multi-term legacy anti-pattern was decomposed into individual content
+terms and fired when ANY single term appeared
 (``mneme/enforcer.py::check_prompt``, anti_patterns loop).
 
-These tests pin the expected semantics WITHOUT changing production behavior:
+Semantics pinned here (ADR-017 amendment, 2026-08-24):
 
-    A/B. A multi-term anti-pattern must not describe a violation merely because
-         benign prose contains one ordinary token from it (``awin`` /
-         ``live`` / ``category`` / ``slug``).
-    C.   The genuine pattern (the full phrase describing the forbidden
-         approach) still FAILs, so any future fix cannot over-weaken.
+    A/B. A multi-term anti-pattern does not fire on benign prose that merely
+         contains one ordinary token from it (``awin`` / ``live`` /
+         ``category`` / ``slug``).
+    C.   The genuine pattern -- the complete ordered term sequence -- still
+         FAILs, so no future repair may over-weaken.
+    #4   The rule's own underscore identifier spelling is detectable
+         (separator equivalence).
+    #5   Terms scattered through prose or reordered never match.
     D.   Typed FORBID_LITERAL keeps its deterministic exact-match FAIL and is
          out of scope for any weakening.
 
-Current state at base 3a47cc1c: A and B FAIL against the implementation,
-proving the defect. C and D pass and guard the eventual semantic fix.
+History: tests A and B were committed failing-first at base 3a47cc1c and
+turned green by the phrase-sequence matcher; C and D guarded that change.
 See ADR-017 (multi-term rules remain retrieval-gated) and issue #150.
 """
 import pytest
@@ -76,22 +79,86 @@ def test_multi_term_anti_pattern_does_not_fail_on_live_category_slug_prose():
 def test_genuine_anti_pattern_phrase_still_fails():
     """C: content actually carrying the forbidden pattern must keep failing.
 
-    This is the case the legacy rule exists for. Any semantic repair to the
-    term-level matcher has to preserve this verdict.
-
-    Note: the rule's own underscore-joined spelling never matches -- ``\\b``
-    boundaries see ``assume_awin`` as one token, so no extracted term occurs.
-    The genuine case therefore expresses the pattern in ordinary words, the
-    only form the legacy matcher has ever been able to detect.
+    This is the case the legacy rule exists for. The phrase-sequence matcher
+    (ADR-017 amendment) requires the complete ordered term sequence, so a
+    genuine violation states the pattern as the rule states it.
     """
     result = check_prompt(
-        "Attribution logic assumes awin and awin us are the same source "
+        "Attribution logic will assume awin awin us same source behavior "
         "for every market.\n",
         [_scored(AWIN)],
     )
     fail = [v for v in result.violations if v.severity == Severity.FAIL]
     assert len(fail) >= 1
+    assert fail[0].trigger == AWIN.anti_patterns[0]
     assert result.verdict == Severity.FAIL
+
+
+def test_underscore_identifier_form_of_rule_matches():
+    """Gate: the rule's own identifier spelling is now detectable.
+
+    Under the previous whole-term matcher, ``\\b`` boundaries saw
+    ``assume_awin_awin_us_same_source`` as one token and no extracted term
+    could ever occur inside it, so the rule was blind to its literal form.
+    Separator equivalence (``_`` = whitespace) fixes that.
+    """
+    result = check_prompt(
+        "Migration notes: legacy pixel assume_awin_awin_us_same_source "
+        "retained for this locale.\n",
+        [_scored(AWIN)],
+    )
+    fail = [v for v in result.violations if v.severity == Severity.FAIL]
+    assert len(fail) >= 1
+    assert result.verdict == Severity.FAIL
+
+
+def test_scattered_or_reordered_terms_do_not_match():
+    """Gate: same terms scattered through prose or out of order never match.
+
+    All significant terms are present, but not together-and-in-order, so no
+    violation fires even though the decision sits in the retrieval-gated tier.
+    """
+    scattered = (
+        "We assume teams document the source of each feed. Another "
+        "awin market uses the same schema, and one more awin variant "
+        "is planned.\n"
+    )
+    result = check_prompt(scattered, [_scored(AWIN)])
+    assert result.violations == []
+    assert result.verdict == Severity.PASS
+
+    reordered = "same source assume awin us awin mapping\n"
+    result = check_prompt(reordered, [_scored(AWIN)])
+    assert result.violations == []
+    assert result.verdict == Severity.PASS
+
+
+def test_internal_stopwords_are_part_of_the_phrase_template():
+    """Gate: rule and input normalize identically -- nothing is dropped.
+
+    A stopword-like word inside a multi-term rule is part of the complete
+    sequence: its canonical spaced form and its separator-equivalent compound
+    form both match, while the same tokens without it never do. This keeps
+    the matcher exactly as broad as the phrase the rule states.
+    """
+    rule = Decision(
+        id="fb-001",
+        decision="Foo and bar must stay together",
+        rationale="splitting them breaks ordering guarantees",
+        scope=["widgets"],
+        constraints=[],
+        anti_patterns=["foo and bar"],
+    )
+
+    canonical = check_prompt("config uses foo and bar here\n", [_scored(rule)])
+    assert canonical.verdict == Severity.FAIL
+
+    identifier = check_prompt("config uses foo_and_bar here\n", [_scored(rule)])
+    assert identifier.verdict == Severity.FAIL
+
+    incomplete = check_prompt("config uses foo bar here\n", [_scored(rule)])
+    assert incomplete.violations == []
+    assert incomplete.verdict == Severity.PASS
 
 
 def test_typed_forbid_literal_keeps_deterministic_fail():

--- a/tests/test_check_modes.py
+++ b/tests/test_check_modes.py
@@ -49,8 +49,8 @@ def _input(tmp_path: Path, content: str) -> Path:
 _PASS_TEXT = "Store everything as flat JSON files on disk."
 # WARN: mentions a term from a 'no X' constraint, no anti-pattern
 _WARN_TEXT = "Should we use postgres for the storage backend?"
-# FAIL: contains a term from anti_patterns
-_FAIL_TEXT = "Let us introduce an ORM for the storage layer."
+# FAIL: carries the complete ordered phrase of a multi-term anti_pattern
+_FAIL_TEXT = "Let us introduce ORM for the storage layer."
 
 
 # ── strict mode (explicit) ────────────────────────────────────────────────────

--- a/tests/test_drift_detection.py
+++ b/tests/test_drift_detection.py
@@ -55,7 +55,9 @@ def test_drift_sqlalchemy_introduction_is_failed():
 def test_drift_migration_layer_is_failed():
     """AI output that adds a migration layer violates the storage anti_pattern."""
     scored, top = _retrieve("storage persistence")
-    output = "To support schema evolution, let's add a migration layer using Alembic."
+    # Phrase matching requires the rule's complete ordered sequence
+    # (ADR-017 amendment), so the input carries its own wording.
+    output = "To support schema evolution, the plan is to add migration layer tooling using Alembic."
     result = check_prompt(output, scored, top=top)
     assert result.verdict == Severity.FAIL
 
@@ -63,7 +65,9 @@ def test_drift_migration_layer_is_failed():
 def test_drift_orm_mention_is_failed():
     """Direct ORM suggestion against JSON-only storage decision."""
     scored, top = _retrieve("storage backend")
-    output = "Wrap the JSON reads with an ORM so we get type safety automatically."
+    # Multi-term anti-patterns match as their complete ordered phrase
+    # (ADR-017 amendment), so the input carries the rule's own wording.
+    output = "The plan is to introduce ORM data mappers over the JSON store."
     result = check_prompt(output, scored, top=top)
     assert result.verdict == Severity.FAIL
 
@@ -92,7 +96,8 @@ def test_drift_sentence_transformers_is_failed():
 def test_drift_vector_database_is_failed():
     """Adding a vector database violates the deterministic-retrieval decision."""
     scored, top = _retrieve("retrieval ranking")
-    output = "Let's introduce a vector database like Pinecone for retrieval."
+    # Phrase matching requires the rule's complete ordered sequence.
+    output = "The plan is to add vector database storage like Pinecone for retrieval."
     result = check_prompt(output, scored, top=top)
     assert result.verdict == Severity.FAIL
 
@@ -177,8 +182,9 @@ def test_cursor_output_following_rules_passes():
 def test_drift_cursor_retrieval_output_adds_embeddings():
     """Cursor suggestion to add embeddings to retrieval violates the determinism decision."""
     scored, top = _retrieve("retrieval ranking")
+    # Phrase matching requires the rule's complete ordered sequence.
     cursor_output = (
-        "Replace keyword scoring with embeddings from sentence-transformers "
+        "Replace keyword scoring with embeddings: add sentence-transformers "
         "for higher recall."
     )
     result = check_prompt(cursor_output, scored, top=top)

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -86,13 +86,15 @@ def test_clean_input_returns_pass():
 
 def test_anti_pattern_match_returns_fail():
     scored = [_scored(STORAGE)]
-    result = check_prompt("We should introduce an ORM for database access.", scored)
+    # Multi-term anti-patterns match as a complete ordered phrase
+    # (ADR-017 amendment); the input carries the rule's own wording.
+    result = check_prompt("We should introduce ORM for database access.", scored)
     assert result.verdict == Severity.FAIL
 
 
 def test_anti_pattern_violation_has_fail_severity():
     scored = [_scored(STORAGE)]
-    result = check_prompt("introduce an ORM layer", scored)
+    result = check_prompt("introduce ORM layer", scored)
     fail_violations = [v for v in result.violations if v.severity == Severity.FAIL]
     assert len(fail_violations) >= 1
 
@@ -112,7 +114,7 @@ def test_constraint_violation_has_warn_severity():
 
 def test_fail_verdict_when_both_anti_pattern_and_constraint_violated():
     scored = [_scored(STORAGE)]
-    result = check_prompt("Use postgres with an ORM layer.", scored)
+    result = check_prompt("Use postgres and introduce ORM.", scored)
     assert result.verdict == Severity.FAIL
 
 
@@ -174,13 +176,16 @@ def test_zero_score_decision_still_enforces_its_literal_rules():
 def test_zero_score_decision_does_not_apply_multi_term_rules():
     """The #150 guardrail: corpus-wide enforcement is literal rules only.
 
-    A multi-term rule explodes into individual tokens, any one of which fires
-    on its own. Applying those to every decision would turn documented
-    false-positive noise into a repo-wide edit block, so they remain gated.
+    Before the 2026-08-24 ADR-017 amendment, a multi-term rule exploded into
+    individual tokens, any one of which fired on its own; applying those to
+    every decision would have turned documented false-positive noise into a
+    repo-wide edit block. Multi-term rules therefore remain retrieval-gated,
+    and that gating is unchanged by the amendment -- a zero-score decision's
+    multi-term rules are still not applied at all.
     """
     scored = [_scored(STORAGE, score=0.0)]
-    # "introduce" alone would trigger the "introduce ORM" anti_pattern under
-    # the pre-#254 disjunctive matcher had the decision been retrieved.
+    # "introduce" alone triggered the "introduce ORM" anti_pattern under the
+    # pre-amendment disjunctive matcher had the decision been retrieved.
     result = check_prompt("Let me introduce the new reporting feature.", scored)
     assert result.verdict == Severity.PASS
 
@@ -204,7 +209,9 @@ def test_top_n_limits_decisions_checked():
 
 def test_case_insensitive_anti_pattern_match():
     scored = [_scored(STORAGE)]
-    result = check_prompt("We will INTRODUCE an ORM framework.", scored)
+    # Phrase matching is case-insensitive; the input carries the rule's
+    # own wording ("introduce ORM") in a different case (ADR-017 amendment).
+    result = check_prompt("We will INTRODUCE ORM frameworks.", scored)
     assert result.verdict == Severity.FAIL
 
 
@@ -429,7 +436,7 @@ def test_check_cmd_pass_exits_zero(tmp_path):
 
 def test_check_cmd_fail_exits_two(tmp_path):
     mem = _memory_file(tmp_path)
-    inp = _input_file(tmp_path, "We should introduce an ORM for our storage layer.")
+    inp = _input_file(tmp_path, "We should introduce ORM for our storage layer.")
     exit_code = main([
         "check",
         "--memory", str(mem),
@@ -461,7 +468,7 @@ def test_check_cmd_prints_verdict(tmp_path, capsys):
 
 def test_check_cmd_prints_fail_verdict(tmp_path, capsys):
     mem = _memory_file(tmp_path)
-    inp = _input_file(tmp_path, "introduce an ORM now.")
+    inp = _input_file(tmp_path, "introduce ORM now.")
     main(["check", "--memory", str(mem), "--input", str(inp), "--query", "storage"])
     out = capsys.readouterr().out
     assert "FAIL" in out
@@ -469,7 +476,7 @@ def test_check_cmd_prints_fail_verdict(tmp_path, capsys):
 
 def test_check_cmd_prints_triggering_decision_id(tmp_path, capsys):
     mem = _memory_file(tmp_path)
-    inp = _input_file(tmp_path, "introduce an ORM for storage.")
+    inp = _input_file(tmp_path, "introduce ORM for storage.")
     main(["check", "--memory", str(mem), "--input", str(inp), "--query", "storage"])
     out = capsys.readouterr().out
     assert "storage_json" in out
@@ -477,7 +484,7 @@ def test_check_cmd_prints_triggering_decision_id(tmp_path, capsys):
 
 def test_check_cmd_prints_triggering_rule(tmp_path, capsys):
     mem = _memory_file(tmp_path)
-    inp = _input_file(tmp_path, "introduce an ORM for storage.")
+    inp = _input_file(tmp_path, "introduce ORM for storage.")
     main(["check", "--memory", str(mem), "--input", str(inp), "--query", "storage"])
     out = capsys.readouterr().out
     assert "introduce ORM" in out or "orm" in out.lower()
@@ -512,7 +519,7 @@ def test_check_cmd_respects_top_flag(tmp_path):
 
 def test_check_cmd_reads_input_from_file(tmp_path):
     mem = _memory_file(tmp_path)
-    inp = _input_file(tmp_path, "introduce an ORM here")
+    inp = _input_file(tmp_path, "introduce ORM here")
     exit_code = main([
         "check",
         "--memory", str(mem),


### PR DESCRIPTION
## Summary

Fixes the dogfooding false-positive class in deterministic enforcement: `mneme check` FAILed benign planning/documentation prose because multi-term legacy anti-patterns were decomposed into individual terms and fired on ANY single whole-word hit inside the retrieval-gated tier (e.g. ordinary tokens such as `awin`, `live`, `content`, `changes`). The same `\b`-boundary matcher was additionally unable to ever match a rule's own underscore identifier spelling.

## Root cause

`check_prompt()` applied disjunctive term matching to every gated legacy anti-pattern. ADR-017 deliberately preserved that behavior as #150 containment when separating enforcement from retrieval scope, but never endorsed it as correct within-rule semantics. This PR settles that remaining half.

## Change

- Multi-term legacy anti-patterns now match as a **complete ordered phrase**: rule and input normalize identically (`[a-z0-9]+` runs, case-insensitive; whitespace/underscore/hyphen/punctuation are equivalent separators); every token participates — nothing is dropped. Single-term rules keep their existing whole-word corpus-wide behavior.
- Retrieval gating, constraint ("no X" WARN) semantics, typed `FORBID_LITERAL`, path selectors, retrieval scoring/cutoffs, `ConflictDetector`, and all integration surfaces are unchanged.
- `Violation.trigger` for a phrase match is now the matched rule expression (not necessarily literal input text). Observable in `mneme.check/v1`; adapters do not branch on it.
- ADR-017 amended in-body: decisions 7–9 record the phrase semantics, the preserved single-term behavior, the explicit non-changes, and an honest recall tradeoff statement (audit/ConflictDetector are separate paths, not guaranteed backstops).

## Evidence

- Failing-first regressions committed at base (`a0b5bd72`) reproduced the incident: benign prose FAILed with triggers `awin`, `live`, `content`, `any`, `changes`.
- After the fix: full suite 787 passed / 5 skipped; frozen benchmark unchanged at 7/7, Layer 2 pass rate 100%; original CLI reproductions all return PASS on identical benign content.
- New gates: identifier-form matching (`assume_awin_awin_us_same_source` → FAIL), scattered/reordered terms → PASS, internal-stopword completeness (`foo and bar` matches `foo and bar`/`foo_and_bar`, not `foo bar`).

## Test plan

- `python -m pytest tests -q`
- `python -m mneme benchmark examples/benchmarks --memory examples/project_memory.json`

Closes the false-positive half of #150; typed-rule work (#250/#254 lineage) unaffected.
