### PR TITLE
feat: enforcement-quality benchmark suite with partitioned FPR reporting (charter #318)

### DIFF
--- a/examples/benchmarks-enforcement-quality/README.md
+++ b/examples/benchmarks-enforcement-quality/README.md
@@ -1,0 +1,61 @@
+# Enforcement-Quality Benchmark Suite
+
+Frozen regression suite for **enforcement false positives and false negatives**,
+authorized by [charter #318](../../docs/plans/2026-08-24-benchmark-fpr-charter.md)
+and the `[layer1-freeze]` amendment (#319). Motivating defect: #317 — benign
+planning prose was FAILed because multi-term legacy anti-patterns fired on any
+single term.
+
+## Invocation
+
+```bash
+python -m mneme benchmark examples/benchmarks-enforcement-quality \
+  --memory examples/benchmarks-enforcement-quality/project_memory.json \
+  --json report.json --markdown report.md
+```
+
+The fixture memory is part of this frozen suite. Do **not** run this suite
+against `examples/project_memory.json`, and do not edit the memory or scenario
+files without a charter reference (see §7 of the charter).
+
+## Composition
+
+- 3 violation guards (`guard_*`, `scenario_type: "violation"` explicitly) — measure false
+  negatives; a verdict other than PASS means enforcement missed a forbidden
+  pattern.
+- 4 benign controls (`benign_*`, `scenario_type: "benign"`) — measure false
+  positives; a `FALSE_POSITIVE` verdict means Mneme blocked benign work.
+- Every scenario declares `expected_exposed_decision_ids`: its governing
+  rule must actually be in enforcement scope (positive-score top-K retrieval).
+  A clean run without exposure is `WEAK_RETRIEVAL` / uncheckable — never PASS —
+  for benign controls, and downgrades an otherwise-clean guard identically.
+
+## Metrics
+
+| metric | definition |
+|---|---|
+| violation catch rate | `violation_passed / violation_checkable` |
+| false-positive rate | `benign_blocked / benign_checkable` where checkable = `PASS_benign + FALSE_POSITIVE` |
+| uncheckable | benign scenarios that are MALFORMED or WEAK_RETRIEVAL (excluded from the FPR denominator, always rendered) |
+
+Current baseline at merge: catch rate 3/3, FPR 0/4, uncheckable 0.
+
+## Why TXT fixtures only (expected warnings)
+
+Running this suite emits one `UserWarning` per missing structured sibling
+(14 total). This is deliberate: the guards pin the *legacy enforcer* phrase
+matcher, which the assertion-DSL verifier does not exercise, and benign
+controls must flow through `check_prompt()` — the code under test — rather
+than the structured verifier. The canonical suite keeps its JSON siblings;
+this suite intentionally does not.
+
+## Scorecard
+
+Record these four signals per meaningful core change:
+
+```text
+Violation catch rate   target 100%
+False-positive rate    target ~0%   (#317 fixed it from >0%)
+Retrieval Recall@3     target 1.00  (canonical suite)
+Retrieval Precision@3  advisory     (fixture-shape constrained; see freeze doc)
+```

--- a/examples/benchmarks-enforcement-quality/benign_awin_programme/query.txt
+++ b/examples/benchmarks-enforcement-quality/benign_awin_programme/query.txt
@@ -1,0 +1,1 @@
+affiliate attribution programme weekly review

--- a/examples/benchmarks-enforcement-quality/benign_awin_programme/scenario.json
+++ b/examples/benchmarks-enforcement-quality/benign_awin_programme/scenario.json
@@ -1,0 +1,7 @@
+{
+  "name": "benign_awin_programme",
+  "category": "benign_control",
+  "description": "#317 regression: benign planning prose mentioning awin must not FAIL against the assume_awin_* rule.",
+  "scenario_type": "benign",
+  "expected_exposed_decision_ids": ["awin-001"]
+}

--- a/examples/benchmarks-enforcement-quality/benign_awin_programme/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_awin_programme/with_mneme.txt
@@ -1,0 +1,1 @@
+Plan: we will track the awin programme per market and review attribution weekly.

--- a/examples/benchmarks-enforcement-quality/benign_awin_programme/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_awin_programme/without_mneme.txt
@@ -1,0 +1,1 @@
+Plan: we will track the awin programme per market and review attribution weekly.

--- a/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/query.txt
+++ b/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/query.txt
@@ -1,0 +1,1 @@
+widgets configuration flags

--- a/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/scenario.json
+++ b/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/scenario.json
@@ -1,0 +1,7 @@
+{
+  "name": "benign_foo_bar_incomplete",
+  "category": "benign_control",
+  "description": "Same tokens without the internal stopword: foo bar must NOT satisfy the foo-and-bar phrase rule.",
+  "scenario_type": "benign",
+  "expected_exposed_decision_ids": ["fb-001"]
+}

--- a/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/with_mneme.txt
@@ -1,0 +1,1 @@
+Config uses foo bar here.

--- a/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_foo_bar_incomplete/without_mneme.txt
@@ -1,0 +1,1 @@
+Config uses foo bar here.

--- a/examples/benchmarks-enforcement-quality/benign_governance_docs/query.txt
+++ b/examples/benchmarks-enforcement-quality/benign_governance_docs/query.txt
@@ -1,0 +1,1 @@
+governance documentation review workflow

--- a/examples/benchmarks-enforcement-quality/benign_governance_docs/scenario.json
+++ b/examples/benchmarks-enforcement-quality/benign_governance_docs/scenario.json
@@ -1,0 +1,7 @@
+{
+  "name": "benign_governance_docs",
+  "category": "benign_control",
+  "description": "Benign governance documentation containing isolated trigger vocabulary (changes) must not FAIL.",
+  "scenario_type": "benign",
+  "expected_exposed_decision_ids": ["gov-001"]
+}

--- a/examples/benchmarks-enforcement-quality/benign_governance_docs/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_governance_docs/with_mneme.txt
@@ -1,0 +1,1 @@
+Documentation updates describe how reviewers approve content changes.

--- a/examples/benchmarks-enforcement-quality/benign_governance_docs/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_governance_docs/without_mneme.txt
@@ -1,0 +1,1 @@
+Documentation updates describe how reviewers approve content changes.

--- a/examples/benchmarks-enforcement-quality/benign_slug_prose/query.txt
+++ b/examples/benchmarks-enforcement-quality/benign_slug_prose/query.txt
@@ -1,0 +1,1 @@
+publishing slug documentation

--- a/examples/benchmarks-enforcement-quality/benign_slug_prose/scenario.json
+++ b/examples/benchmarks-enforcement-quality/benign_slug_prose/scenario.json
@@ -1,0 +1,7 @@
+{
+  "name": "benign_slug_prose",
+  "category": "benign_control",
+  "description": "#317 regression: benign prose containing live/category/slug must not FAIL against the slug rule.",
+  "scenario_type": "benign",
+  "expected_exposed_decision_ids": ["slug-001"]
+}

--- a/examples/benchmarks-enforcement-quality/benign_slug_prose/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_slug_prose/with_mneme.txt
@@ -1,0 +1,1 @@
+The documentation describes how each live category page receives its slug before launch.

--- a/examples/benchmarks-enforcement-quality/benign_slug_prose/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/benign_slug_prose/without_mneme.txt
@@ -1,0 +1,1 @@
+The documentation describes how each live category page receives its slug before launch.

--- a/examples/benchmarks-enforcement-quality/guard_awin_identifier/query.txt
+++ b/examples/benchmarks-enforcement-quality/guard_awin_identifier/query.txt
@@ -1,0 +1,1 @@
+affiliate attribution integration markets

--- a/examples/benchmarks-enforcement-quality/guard_awin_identifier/scenario.json
+++ b/examples/benchmarks-enforcement-quality/guard_awin_identifier/scenario.json
@@ -1,0 +1,9 @@
+{
+  "name": "guard_awin_identifier",
+  "category": "enforcement_quality",
+  "description": "Baseline carries the underscore identifier form of the awin rule; Mneme must FAIL it (separator-equivalent phrase match).",
+  "scenario_type": "violation",
+  "expected_failure_terms": ["assume_awin_awin_us_same_source"],
+  "expected_protected_decision_ids": ["awin-001"],
+  "expected_exposed_decision_ids": ["awin-001"]
+}

--- a/examples/benchmarks-enforcement-quality/guard_awin_identifier/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_awin_identifier/with_mneme.txt
@@ -1,0 +1,1 @@
+Each market resolves its own attribution source independently.

--- a/examples/benchmarks-enforcement-quality/guard_awin_identifier/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_awin_identifier/without_mneme.txt
@@ -1,0 +1,1 @@
+Integration assumes assume_awin_awin_us_same_source mapping across markets.

--- a/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/query.txt
+++ b/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/query.txt
@@ -1,0 +1,1 @@
+widgets configuration flags

--- a/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/scenario.json
+++ b/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/scenario.json
@@ -1,0 +1,9 @@
+{
+  "name": "guard_foo_and_bar_compound",
+  "category": "enforcement_quality",
+  "description": "Baseline enables foo_and_bar (underscore form of the internal-stopword rule); Mneme must FAIL it.",
+  "scenario_type": "violation",
+  "expected_failure_terms": ["foo and bar"],
+  "expected_protected_decision_ids": ["fb-001"],
+  "expected_exposed_decision_ids": ["fb-001"]
+}

--- a/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/with_mneme.txt
@@ -1,0 +1,1 @@
+Config keeps the two flags independent by default.

--- a/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_foo_and_bar_compound/without_mneme.txt
@@ -1,0 +1,1 @@
+The config enables foo_and_bar mode by default.

--- a/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/query.txt
+++ b/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/query.txt
@@ -1,0 +1,1 @@
+governance workflow review changes

--- a/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/scenario.json
+++ b/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/scenario.json
@@ -1,0 +1,9 @@
+{
+  "name": "guard_unreviewed_changes",
+  "category": "enforcement_quality",
+  "description": "Baseline ships unreviewed enforcement changes; Mneme must FAIL it via the gov-001 multi-term anti-pattern.",
+  "scenario_type": "violation",
+  "expected_failure_terms": ["unreviewed enforcement changes"],
+  "expected_protected_decision_ids": ["gov-001"],
+  "expected_exposed_decision_ids": ["gov-001"]
+}

--- a/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/with_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/with_mneme.txt
@@ -1,0 +1,1 @@
+All changes ship through PR review before merging.

--- a/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/without_mneme.txt
+++ b/examples/benchmarks-enforcement-quality/guard_unreviewed_changes/without_mneme.txt
@@ -1,0 +1,1 @@
+We will ship these unreviewed enforcement changes directly to production.

--- a/examples/benchmarks-enforcement-quality/project_memory.json
+++ b/examples/benchmarks-enforcement-quality/project_memory.json
@@ -1,0 +1,41 @@
+{
+  "meta": {
+    "name": "enforcement-quality-fixture",
+    "description": "Frozen fixture memory for the enforcement-quality benchmark suite. Rules mirror the #317 dogfood incident regressions and the phrase-matcher contract they pin. Test-only; not canonical governance.",
+    "version": "0.1.0"
+  },
+  "decisions": [
+    {
+      "id": "awin-001",
+      "decision": "Affiliate attribution must resolve to one source per market.",
+      "rationale": "Duplicate tracking pixels caused double attribution.",
+      "scope": ["affiliate", "attribution"],
+      "constraints": [],
+      "anti_patterns": ["assume_awin_awin_us_same_source"]
+    },
+    {
+      "id": "slug-001",
+      "decision": "URL slugs are derived once at publish time.",
+      "rationale": "Mutating routes breaks external links.",
+      "scope": ["publishing"],
+      "constraints": [],
+      "anti_patterns": ["regenerate live category slug on every request"]
+    },
+    {
+      "id": "fb-001",
+      "decision": "Foo and bar must stay together.",
+      "rationale": "Splitting them breaks ordering guarantees.",
+      "scope": ["widgets"],
+      "constraints": [],
+      "anti_patterns": ["foo and bar"]
+    },
+    {
+      "id": "gov-001",
+      "decision": "Governance or architectural changes go through PR review before merging.",
+      "rationale": "Unreviewed governance edits broke the main branch twice.",
+      "scope": ["workflow", "governance"],
+      "constraints": [],
+      "anti_patterns": ["unreviewed enforcement changes", "direct-to-main governance edits"]
+    }
+  ]
+}

--- a/mneme/benchmark.py
+++ b/mneme/benchmark.py
@@ -24,9 +24,21 @@ Verdict logic (Layer 2 — enforcement):
   PASS            — baseline has >= 1 violation; enhanced has 0 violations
   FAIL            — enhanced still has >= 1 violation
   WEAK            — baseline has 0 violations (scenario too weak to prove anything)
-  WEAK_RETRIEVAL  — enhanced is clean but expected decisions were missed by retrieval
+  WEAK_RETRIEVAL  — enhanced is clean but expected decisions were missed by retrieval;
+                    for benign scenarios: the governing rule was NOT in enforcement
+                    scope, so a clean run would be coincidental (uncheckable)
   MALFORMED       — a structured fixture exists but failed JSON parse, type
-                    validation, or referenced an unknown assertion type.
+                    validation, or referenced an unknown assertion type
+  FALSE_POSITIVE  — benign scenario: enhanced content triggered >= 1 violation
+
+Scenario types (charter docs/plans/2026-08-24-benchmark-fpr-charter.md):
+  "violation" (default when scenario.json omits scenario_type) follows the
+  five original verdict semantics above, byte-for-byte. A scenario that
+  declares "scenario_type": "benign" opts into the enforcement-quality
+  methodology: both sides are benign content, evaluation runs the enhanced
+  side through the enforcer, and the exposure contract
+  (expected_exposed_decision_ids) must be satisfied before a PASS counts.
+  Unknown scenario_type values are MALFORMED.
 
 Layer 1 (retrieval) is scored independently on each scenario per the v1.1
 methodology page (site/benchmark/index.html §03, §09). Layer 1 numbers are
@@ -55,6 +67,7 @@ class ScenarioVerdict(str, Enum):
     WEAK = "WEAK"
     WEAK_RETRIEVAL = "WEAK_RETRIEVAL"
     MALFORMED = "MALFORMED"
+    FALSE_POSITIVE = "FALSE_POSITIVE"
 
 
 @dataclass
@@ -72,6 +85,15 @@ class Scenario:
     # If non-empty, run_scenario short-circuits to ScenarioVerdict.MALFORMED
     # with this string in the explanation.
     malformed_reason: str = ""
+    # Enforcement-quality methodology (charter 2026-08-24). Absent
+    # scenario_type means "violation"; unknown values are MALFORMED. The
+    # exposure contract lists decision IDs that must be in enforcement scope
+    # (positive-score top-K retrieval) before a PASS counts -- for benign
+    # scenarios mandatorily, for violation scenarios optionally with
+    # identical semantics.
+    scenario_type: str = "violation"
+    scenario_type_declared: bool = False
+    expected_exposed_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -95,6 +117,14 @@ class ScenarioResult:
     layer1_recall: float = 1.0
     layer1_precision: float = 1.0
     layer1_irrelevant_injection: bool = False
+    # Enforcement-quality methodology (charter 2026-08-24). Defaults keep
+    # hand-built results on the legacy violation path with no extra output.
+    # methodology_opt_in mirrors Scenario.scenario_type_declared and gates
+    # emission of the new per-result fields.
+    scenario_type: str = "violation"
+    methodology_opt_in: bool = False
+    expected_exposed_ids: list[str] = field(default_factory=list)
+    exposed_decision_ids_hit: list[str] = field(default_factory=list)
 
 
 def _load_optional_structured(json_path: Path) -> tuple[StructuredOutput | None, str]:
@@ -145,6 +175,45 @@ def _load_optional_assertions(metadata: dict) -> tuple[list[Assertion], str]:
     return parsed, ""
 
 
+_SCENARIO_TYPES = ("violation", "benign")
+
+
+def _load_scenario_type(metadata: dict) -> tuple[str, bool, str]:
+    """Parse ``scenario_type`` from scenario.json.
+
+    Absent means "violation" (legacy fixtures never declare it). Unknown
+    values are a malformed scenario, never a silent fallback: a typo such as
+    "bening" must fail loudly rather than run under violation semantics.
+
+    Returns (value, declared, reason). ``declared`` records whether the key
+    was present at all: explicit opt-in is what gates emission of the new
+    per-result fields, independent of the parsed value.
+    """
+    raw = metadata.get("scenario_type")
+    if raw is None:
+        return "violation", False, ""
+    if raw not in _SCENARIO_TYPES:
+        return (
+            "violation",
+            True,
+            f"scenario.json 'scenario_type' must be one of {list(_SCENARIO_TYPES)}, "
+            f"got {raw!r}",
+        )
+    return raw, True, ""
+
+
+def _load_expected_exposed_ids(metadata: dict) -> tuple[list[str], str]:
+    """Parse the exposure contract from scenario.json."""
+    raw = metadata.get("expected_exposed_decision_ids")
+    if raw is None:
+        return [], ""
+    if not isinstance(raw, list) or not all(isinstance(v, str) for v in raw):
+        return [], (
+            "scenario.json 'expected_exposed_decision_ids' must be a list of strings"
+        )
+    return list(raw), ""
+
+
 def load_scenario(path: str | Path) -> Scenario:
     """Load a benchmark scenario from a directory.
 
@@ -166,8 +235,14 @@ def load_scenario(path: str | Path) -> Scenario:
         p / "with_mneme.json"
     )
     assertions, assertions_reason = _load_optional_assertions(metadata)
+    scenario_type, scenario_type_declared, type_reason = _load_scenario_type(metadata)
+    expected_exposed, exposed_reason = _load_expected_exposed_ids(metadata)
 
-    reasons = [r for r in (without_reason, with_reason, assertions_reason) if r]
+    reasons = [
+        r for r in
+        (without_reason, with_reason, assertions_reason, type_reason, exposed_reason)
+        if r
+    ]
     malformed_reason = "; ".join(reasons)
 
     return Scenario(
@@ -180,6 +255,9 @@ def load_scenario(path: str | Path) -> Scenario:
         with_mneme_structured=with_structured,
         assertions=assertions,
         malformed_reason=malformed_reason,
+        scenario_type=scenario_type,
+        scenario_type_declared=scenario_type_declared,
+        expected_exposed_ids=expected_exposed,
     )
 
 
@@ -342,6 +420,14 @@ class BenchmarkRunner:
                 layer1_recall=l1.recall,
                 layer1_precision=l1.precision,
                 layer1_irrelevant_injection=l1.irrelevant_injection,
+                scenario_type=scenario.scenario_type,
+                methodology_opt_in=scenario.scenario_type_declared,
+                expected_exposed_ids=scenario.expected_exposed_ids,
+            )
+
+        if scenario.scenario_type == "benign":
+            return self._run_benign_scenario(
+                scenario, l1, scored, name, category
             )
 
         # Layer 2: enforcement, per side, structured-or-TXT.
@@ -360,6 +446,18 @@ class BenchmarkRunner:
 
         protected_hit = [did for did in expected_ids if did in l1.retrieved_ids]
         intended_decisions_retrieved = (not expected_ids) or l1.recall == 1.0
+
+        # Exposure contract applies to violation scenarios too, with the same
+        # semantics as benign ones (charter §2.6): a declared-but-unsatisfied
+        # contract downgrades a clean run to WEAK_RETRIEVAL so a PASS can
+        # never rest on an unverified enforcement scope.
+        exposed_hit = [
+            d for d in scenario.expected_exposed_ids if d in l1.retrieved_ids
+        ]
+        exposure_satisfied = (
+            not scenario.expected_exposed_ids
+            or len(exposed_hit) == len(scenario.expected_exposed_ids)
+        )
 
         if baseline_count == 0:
             verdict = ScenarioVerdict.WEAK
@@ -380,6 +478,16 @@ class BenchmarkRunner:
             explanation = (
                 f"Enhanced response was clean, but intended decision(s) were not retrieved: "
                 f"{', '.join(missing)}. PASS may be coincidental."
+            )
+        elif not exposure_satisfied:
+            verdict = ScenarioVerdict.WEAK_RETRIEVAL
+            missing = [
+                d for d in scenario.expected_exposed_ids if d not in exposed_hit
+            ]
+            explanation = (
+                "Enhanced response was clean, but the exposure contract was "
+                f"unmet: governing decision(s) {', '.join(missing)} were not in "
+                "enforcement scope. PASS may be coincidental."
             )
         else:
             verdict = ScenarioVerdict.PASS
@@ -408,6 +516,96 @@ class BenchmarkRunner:
             layer1_recall=l1.recall,
             layer1_precision=l1.precision,
             layer1_irrelevant_injection=l1.irrelevant_injection,
+            scenario_type=scenario.scenario_type,
+            methodology_opt_in=scenario.scenario_type_declared,
+            expected_exposed_ids=scenario.expected_exposed_ids,
+            exposed_decision_ids_hit=exposed_hit,
+        )
+
+    def _run_benign_scenario(
+        self,
+        scenario: Scenario,
+        l1: Layer1Score,
+        scored: list[ScoredDecision],
+        name: str,
+        category: str,
+    ) -> ScenarioResult:
+        """Evaluate a benign (control) scenario against the enforcer.
+
+        Both sides carry benign content; only the enhanced side is evaluated
+        (a benign baseline proves nothing and must never read as WEAK).
+        The exposure contract decides whether a clean result is meaningful:
+        a benign scenario MUST declare one, and the governing rule's decision
+        must actually be in enforcement scope (positive-score top-K
+        retrieval). A missing contract or an unsatisfied one is
+        WEAK_RETRIEVAL / uncheckable -- never PASS.
+        """
+        enhanced_count, enhanced_triggers = self._evaluate_side(
+            scenario.with_mneme,
+            scenario.with_mneme_structured,
+            scenario.assertions,
+            scored,
+        )
+
+        expected_exposed = scenario.expected_exposed_ids
+        exposed_hit = [d for d in expected_exposed if d in l1.retrieved_ids]
+        uncheckable_reason = ""
+        if not expected_exposed:
+            uncheckable_reason = (
+                "it declares no exposure contract "
+                "(expected_exposed_decision_ids), so enforcement scope was "
+                "never proven"
+            )
+        elif len(exposed_hit) != len(expected_exposed):
+            missing = [d for d in expected_exposed if d not in exposed_hit]
+            uncheckable_reason = (
+                f"governing decision(s) {', '.join(missing)} were not in "
+                "enforcement scope (not in the retrieval-gated tier)"
+            )
+
+        if uncheckable_reason:
+            verdict = ScenarioVerdict.WEAK_RETRIEVAL
+            explanation = (
+                "Benign content produced no violations, but the scenario is "
+                f"uncheckable: {uncheckable_reason}. A PASS here would be "
+                "coincidental."
+            )
+        elif enhanced_count > 0:
+            verdict = ScenarioVerdict.FALSE_POSITIVE
+            explanation = (
+                f"Mneme blocked benign content: it triggered {enhanced_count} "
+                f"violation(s): {', '.join(enhanced_triggers[:3])}."
+            )
+        else:
+            verdict = ScenarioVerdict.PASS
+            explanation = (
+                "Benign content passed with governing decision(s) "
+                f"{', '.join(exposed_hit)} in enforcement scope."
+            )
+
+        return ScenarioResult(
+            name=name,
+            category=category,
+            verdict=verdict,
+            baseline_violation_count=0,
+            enhanced_violation_count=enhanced_count,
+            explanation=explanation,
+            baseline_triggers=[],
+            enhanced_triggers=enhanced_triggers,
+            protected_decision_ids_hit=[
+                d for d in l1.expected_ids if d in l1.retrieved_ids
+            ],
+            layer1_k=l1.k,
+            layer1_retrieved_ids=l1.retrieved_ids,
+            layer1_expected_ids=l1.expected_ids,
+            layer1_acceptable_ids=l1.acceptable_ids,
+            layer1_recall=l1.recall,
+            layer1_precision=l1.precision,
+            layer1_irrelevant_injection=l1.irrelevant_injection,
+            scenario_type=scenario.scenario_type,
+            methodology_opt_in=scenario.scenario_type_declared,
+            expected_exposed_ids=expected_exposed,
+            exposed_decision_ids_hit=exposed_hit,
         )
 
     def run_suite(self, benchmarks_dir: str | Path) -> list[ScenarioResult]:

--- a/mneme/benchmark_report.py
+++ b/mneme/benchmark_report.py
@@ -43,21 +43,40 @@ class BenchmarkSummary:
     irrelevant_injection_rate: float = 0.0
     layer1_scored_count: int = 0
     k: int = DEFAULT_MAX_DECISIONS
+    # Enforcement-quality partition (charter 2026-08-24). Legacy fields above
+    # aggregate violation scenarios only; benign controls report separately so
+    # a combined "violations caught" number can never render.
+    benign_total: int = 0
+    benign_passed: int = 0
+    benign_blocked: int = 0
+    benign_uncheckable: int = 0
+    false_positive_rate: float = 0.0
 
 
 def compute_summary(results: list[ScenarioResult]) -> BenchmarkSummary:
-    """Compute aggregate statistics from a list of results."""
-    passed = sum(1 for r in results if r.verdict == ScenarioVerdict.PASS)
-    failed = sum(1 for r in results if r.verdict == ScenarioVerdict.FAIL)
-    weak = sum(1 for r in results if r.verdict == ScenarioVerdict.WEAK)
+    """Compute aggregate statistics from a list of results.
+
+    Violation-scenario metrics (passed / failed / weak / weak_retrieval /
+    pass_rate / by_category) aggregate violation scenarios only. Benign
+    controls are reported through the dedicated enforcement-quality fields so
+    the two partitions can never merge into one headline.
+    """
+    violation_results = [
+        r for r in results if r.scenario_type == "violation"
+    ]
+    benign_results = [r for r in results if r.scenario_type == "benign"]
+
+    passed = sum(1 for r in violation_results if r.verdict == ScenarioVerdict.PASS)
+    failed = sum(1 for r in violation_results if r.verdict == ScenarioVerdict.FAIL)
+    weak = sum(1 for r in violation_results if r.verdict == ScenarioVerdict.WEAK)
     weak_retrieval = sum(
-        1 for r in results if r.verdict == ScenarioVerdict.WEAK_RETRIEVAL
+        1 for r in violation_results if r.verdict == ScenarioVerdict.WEAK_RETRIEVAL
     )
     checkable = passed + failed
     pass_rate = round(passed / checkable, 2) if checkable > 0 else 0.0
 
     by_category: dict[str, dict[str, int]] = {}
-    for r in results:
+    for r in violation_results:
         cat = r.category
         if cat not in by_category:
             by_category[cat] = {"pass": 0, "fail": 0, "total": 0}
@@ -66,6 +85,22 @@ def compute_summary(results: list[ScenarioResult]) -> BenchmarkSummary:
             by_category[cat]["pass"] += 1
         elif r.verdict == ScenarioVerdict.FAIL:
             by_category[cat]["fail"] += 1
+
+    benign_total = len(benign_results)
+    benign_passed = sum(
+        1 for r in benign_results if r.verdict == ScenarioVerdict.PASS
+    )
+    benign_blocked = sum(
+        1 for r in benign_results if r.verdict == ScenarioVerdict.FALSE_POSITIVE
+    )
+    benign_uncheckable = sum(
+        1 for r in benign_results
+        if r.verdict in (ScenarioVerdict.MALFORMED, ScenarioVerdict.WEAK_RETRIEVAL)
+    )
+    benign_checkable = benign_passed + benign_blocked
+    false_positive_rate = (
+        round(benign_blocked / benign_checkable, 4) if benign_checkable > 0 else 0.0
+    )
 
     # Layer 1 aggregates: only scenarios that declare expected protected
     # decisions contribute. Vacuous-true (no expected) cases are excluded
@@ -98,6 +133,11 @@ def compute_summary(results: list[ScenarioResult]) -> BenchmarkSummary:
         irrelevant_injection_rate=round(injection_rate, 3),
         layer1_scored_count=len(governed),
         k=k,
+        benign_total=benign_total,
+        benign_passed=benign_passed,
+        benign_blocked=benign_blocked,
+        benign_uncheckable=benign_uncheckable,
+        false_positive_rate=false_positive_rate,
     )
 
 
@@ -137,6 +177,13 @@ def format_terminal(results: list[ScenarioResult]) -> str:
         )
     )
     lines.append(f"  Pass rate: {s.pass_rate:.0%}")
+    if s.benign_total:
+        lines.append(
+            f"  Benign controls: false positives {s.benign_blocked}/"
+            f"{s.benign_passed + s.benign_blocked} checkable "
+            f"(FPR {s.false_positive_rate:.0%}), "
+            f"uncheckable {s.benign_uncheckable}/{s.benign_total}"
+        )
     if s.layer1_scored_count:
         lines.append("")
         lines.append(
@@ -199,6 +246,14 @@ def format_markdown(results: list[ScenarioResult]) -> str:
             f"_{s.weak} WEAK (baseline too soft), "
             f"{s.weak_retrieval} WEAK_RETRIEVAL (retrieval missed target)._"
         )
+    if s.benign_total:
+        lines.append("")
+        lines.append(
+            f"**Benign controls** — false positives {s.benign_blocked} / "
+            f"checkable {s.benign_passed + s.benign_blocked} "
+            f"(FPR {s.false_positive_rate:.0%}), "
+            f"uncheckable {s.benign_uncheckable} of {s.benign_total}."
+        )
     if s.layer1_scored_count:
         lines.append("")
         lines.append(
@@ -226,8 +281,18 @@ def format_json(results: list[ScenarioResult]) -> str:
     (verdict, baseline_violation_count, enhanced_violation_count, ...) are
     preserved. Layer 1 and Layer 2 are also exposed under namespaced
     `layer1` / `layer2` objects per the v1.1 methodology.
+
+    Enforcement-quality extension (charter 2026-08-24): scenarios that
+    declare `scenario_type` opt in — those result entries gain
+    `scenario_type` / `exposure` keys, and the summary gains an
+    `enforcement_quality` object. Legacy-only runs emit none of these, so
+    canonical output is byte-identical.
     """
     s = compute_summary(results)
+    opted_in = any(
+        r.methodology_opt_in and r.verdict != ScenarioVerdict.MALFORMED
+        for r in results
+    )
     payload = {
         "summary": {
             "total": s.total,
@@ -252,34 +317,50 @@ def format_json(results: list[ScenarioResult]) -> str:
                 "pass_rate": s.pass_rate,
             },
         },
-        "results": [
-            {
-                "name": r.name,
+        "results": [],
+    }
+    if opted_in:
+        payload["summary"]["enforcement_quality"] = {
+            "violation_passed": s.passed,
+            "violation_checkable": s.passed + s.failed,
+            "benign_total": s.benign_total,
+            "benign_blocked": s.benign_blocked,
+            "benign_checkable": s.benign_passed + s.benign_blocked,
+            "false_positive_rate": s.false_positive_rate,
+            "benign_uncheckable": s.benign_uncheckable,
+        }
+    for r in results:
+        entry = {
+            "name": r.name,
+            "verdict": r.verdict.value,
+            "baseline_violation_count": r.baseline_violation_count,
+            "enhanced_violation_count": r.enhanced_violation_count,
+            "baseline_triggers": r.baseline_triggers,
+            "enhanced_triggers": r.enhanced_triggers,
+            "explanation": r.explanation,
+            "layer1": {
+                "k": r.layer1_k,
+                "retrieved_ids": r.layer1_retrieved_ids,
+                "expected_ids": r.layer1_expected_ids,
+                "acceptable_ids": r.layer1_acceptable_ids,
+                "recall_at_k": r.layer1_recall,
+                "precision_at_k": r.layer1_precision,
+                "irrelevant_injection": r.layer1_irrelevant_injection,
+            },
+            "layer2": {
                 "verdict": r.verdict.value,
                 "baseline_violation_count": r.baseline_violation_count,
                 "enhanced_violation_count": r.enhanced_violation_count,
                 "baseline_triggers": r.baseline_triggers,
                 "enhanced_triggers": r.enhanced_triggers,
-                "explanation": r.explanation,
-                "layer1": {
-                    "k": r.layer1_k,
-                    "retrieved_ids": r.layer1_retrieved_ids,
-                    "expected_ids": r.layer1_expected_ids,
-                    "acceptable_ids": r.layer1_acceptable_ids,
-                    "recall_at_k": r.layer1_recall,
-                    "precision_at_k": r.layer1_precision,
-                    "irrelevant_injection": r.layer1_irrelevant_injection,
-                },
-                "layer2": {
-                    "verdict": r.verdict.value,
-                    "baseline_violation_count": r.baseline_violation_count,
-                    "enhanced_violation_count": r.enhanced_violation_count,
-                    "baseline_triggers": r.baseline_triggers,
-                    "enhanced_triggers": r.enhanced_triggers,
-                    "protected_decision_ids_hit": r.protected_decision_ids_hit,
-                },
+                "protected_decision_ids_hit": r.protected_decision_ids_hit,
+            },
+        }
+        if r.methodology_opt_in and r.verdict != ScenarioVerdict.MALFORMED:
+            entry["scenario_type"] = r.scenario_type
+            entry["exposure"] = {
+                "expected_ids": r.expected_exposed_ids,
+                "in_scope": r.exposed_decision_ids_hit,
             }
-            for r in results
-        ],
-    }
+        payload["results"].append(entry)
     return json.dumps(payload, indent=2)

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -414,7 +414,14 @@ def _cmd_benchmark(args: argparse.Namespace) -> int:
         out.write_text(format_markdown(results), encoding="utf-8")
         print(f"Markdown report written: {args.markdown}")
 
-    has_failures = any(r.verdict == ScenarioVerdict.FAIL for r in results)
+    # FALSE_POSITIVE is a failing benchmark condition (charter 2026-08-24):
+    # blocking benign content exits 1 just like a missed violation. MALFORMED
+    # deliberately remains exit-0 (frozen five-verdict exit semantics); it is
+    # surfaced through report output instead.
+    has_failures = any(
+        r.verdict in (ScenarioVerdict.FAIL, ScenarioVerdict.FALSE_POSITIVE)
+        for r in results
+    )
     return 1 if has_failures else 0
 
 

--- a/tests/test_enforcement_quality_benchmark.py
+++ b/tests/test_enforcement_quality_benchmark.py
@@ -1,0 +1,485 @@
+"""Tests for the enforcement-quality benchmark extension (charter 2026-08-24).
+
+Covers the charter contract end to end:
+
+- loader: absent scenario_type defaults to violation; unknown values are
+  MALFORMED (no silent fallback);
+- runner: benign PASS requires the exposure contract; exposure misses are
+  WEAK_RETRIEVAL / uncheckable, never PASS; blocked benign content is
+  FALSE_POSITIVE; the violation path is unchanged;
+- summary/report partitioning: violation metrics never absorb benign results,
+  legacy-only output stays byte-compatible (no new keys or lines), opt-in
+  output carries scenario_type / exposure / enforcement_quality;
+- CLI: FALSE_POSITIVE exits 1;
+- shipped suite: catch rate 3/3, FPR 0/4, uncheckable 0.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from mneme.benchmark import (
+    BenchmarkRunner,
+    ScenarioResult,
+    ScenarioVerdict,
+    load_scenario,
+)
+from mneme.benchmark_report import (
+    compute_summary,
+    format_json,
+    format_markdown,
+    format_terminal,
+)
+from mneme.cli import main
+from mneme.memory_store import MemoryStore
+from mneme.schemas import Decision
+
+SUITE = Path(__file__).parent.parent / "examples" / "benchmarks-enforcement-quality"
+
+MEMORY = {
+    "meta": {"name": "t", "description": "t"},
+    "decisions": [
+        {
+            "id": "rule-x",
+            "decision": "X policy",
+            "scope": ["widgets"],
+            "constraints": [],
+            "anti_patterns": ["foo and bar"],
+            "rationale": "",
+        },
+        {
+            "id": "rule-y",
+            "decision": "Y policy",
+            "scope": ["storage"],
+            "constraints": [],
+            "anti_patterns": ["zapdb"],
+            "rationale": "",
+        },
+    ],
+}
+
+
+def _write_scenario(
+    tmp_path: Path,
+    name: str,
+    *,
+    query: str,
+    content: str,
+    metadata: dict,
+) -> Path:
+    d = tmp_path / name
+    d.mkdir()
+    (d / "query.txt").write_text(query, encoding="utf-8")
+    (d / "without_mneme.txt").write_text(content, encoding="utf-8")
+    (d / "with_mneme.txt").write_text(content, encoding="utf-8")
+    (d / "scenario.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return d
+
+
+def _run(tmp_path: Path, scenarios: list[tuple]) -> list[ScenarioResult]:
+    for name, kwargs in scenarios:
+        _write_scenario(tmp_path, name, **kwargs)
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    runner = BenchmarkRunner(store)
+    return runner.run_suite(tmp_path)
+
+
+# ── loader ────────────────────────────────────────────────────────────────
+
+def test_loader_absent_scenario_type_defaults_to_violation(tmp_path):
+    d = _write_scenario(
+        tmp_path, "legacy", query="widgets configuration",
+        content="Config uses foo bar here.",
+        metadata={"name": "legacy"},
+    )
+    assert load_scenario(d).scenario_type == "violation"
+
+
+def test_loader_unknown_scenario_type_is_malformed(tmp_path):
+    d = _write_scenario(
+        tmp_path, "typo", query="widgets configuration",
+        content="Config uses foo bar here.",
+        metadata={"name": "typo", "scenario_type": "bening"},
+    )
+    scenario = load_scenario(d)
+    assert scenario.scenario_type == "violation"
+    assert "scenario_type" in scenario.malformed_reason
+    # The resulting MALFORMED short-circuit is exercised by
+    # test_runner_unknown_scenario_type_short_circuits_to_malformed.
+
+
+def test_runner_unknown_scenario_type_short_circuits_to_malformed(tmp_path):
+    _write_scenario(
+        tmp_path, "typo", query="widgets configuration",
+        content="Config uses foo bar here.",
+        metadata={"name": "typo", "scenario_type": "bening"},
+    )
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [result] = BenchmarkRunner(store).run_suite(tmp_path)
+    assert result.verdict == ScenarioVerdict.MALFORMED
+
+
+# ── runner ────────────────────────────────────────────────────────────────
+
+def _benign_metadata(exposed=None):
+    meta = {"name": "b", "category": "benign_control", "scenario_type": "benign"}
+    if exposed is not None:
+        meta["expected_exposed_decision_ids"] = exposed
+    return meta
+
+
+def test_runner_benign_pass_requires_satisfied_exposure(tmp_path):
+    [result] = _run(tmp_path, [
+        ("case", dict(
+            query="widgets configuration",
+            content="Config uses foo bar here.",
+            metadata=_benign_metadata(["rule-x"]),
+        )),
+    ])
+    assert result.verdict == ScenarioVerdict.PASS
+    assert result.exposed_decision_ids_hit == ["rule-x"]
+    assert result.enhanced_violation_count == 0
+
+
+def test_runner_benign_exposure_miss_is_weak_retrieval_not_pass(tmp_path):
+    [result] = _run(tmp_path, [
+        ("case", dict(
+            query="unrelated topic here",
+            content="Config uses foo bar here.",
+            metadata=_benign_metadata(["rule-x"]),
+        )),
+    ])
+    assert result.verdict == ScenarioVerdict.WEAK_RETRIEVAL
+    assert result.exposed_decision_ids_hit == []
+
+
+def test_runner_benign_without_exposure_contract_is_uncheckable(tmp_path):
+    """Charter invariant: a benign PASS requires proven enforcement scope.
+
+    A fixture that omits ``expected_exposed_decision_ids`` entirely must be
+    uncheckable (WEAK_RETRIEVAL), never a vacuous PASS.
+    """
+    [result] = _run(tmp_path, [
+        ("case", dict(
+            query="widgets configuration",
+            content="Config uses foo bar here.",
+            metadata=_benign_metadata(None),
+        )),
+    ])
+    assert result.verdict == ScenarioVerdict.WEAK_RETRIEVAL
+    assert "no exposure contract" in result.explanation
+
+
+def test_runner_violation_opt_in_emits_identity_and_exposure(tmp_path):
+    """Blocker #1 pin: explicitly declared scenario_type is an opt-in.
+
+    An explicit ``"scenario_type": "violation"`` guard must carry its
+    methodology identity through to the result instead of collapsing into
+    legacy output.
+    """
+    _write_scenario(
+        tmp_path, "guard",
+        query="widgets configuration flags",
+        content="placeholder",
+        metadata={
+            "name": "guard",
+            "scenario_type": "violation",
+            "expected_protected_decision_ids": ["rule-x"],
+            "expected_exposed_decision_ids": ["rule-x"],
+        },
+    )
+    # Overwrite sides: baseline violates the phrase, enhanced is clean.
+    d = tmp_path / "guard"
+    (d / "without_mneme.txt").write_text(
+        "The config enables foo_and_bar mode by default.", encoding="utf-8"
+    )
+    (d / "with_mneme.txt").write_text(
+        "Config keeps the two flags independent by default.", encoding="utf-8"
+    )
+
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [result] = BenchmarkRunner(store).run_suite(tmp_path)
+
+    assert result.verdict == ScenarioVerdict.PASS
+    assert result.scenario_type == "violation"
+    assert result.methodology_opt_in is True
+    assert result.expected_exposed_ids == ["rule-x"]
+    assert result.exposed_decision_ids_hit == ["rule-x"]
+
+
+def test_runner_violation_exposure_miss_downgrades_pass(tmp_path):
+    """Exposure contract on a violation scenario has identical semantics.
+
+    The single-term anti-pattern fires corpus-wide, so the baseline FAILs and
+    the enhanced side is clean even though the governing decision was never
+    retrieved. The unsatisfied exposure contract must downgrade this to
+    WEAK_RETRIEVAL -- a PASS would be coincidental.
+    """
+    d = tmp_path / "guard"
+    d.mkdir()
+    (d / "query.txt").write_text("widgets configuration", encoding="utf-8")
+    (d / "without_mneme.txt").write_text("We adopt zapdb now.", encoding="utf-8")
+    (d / "with_mneme.txt").write_text("We use something else entirely.", encoding="utf-8")
+    (d / "scenario.json").write_text(json.dumps({
+        "name": "guard",
+        "scenario_type": "violation",
+        "expected_protected_decision_ids": [],
+        "expected_exposed_decision_ids": ["rule-y"],
+    }), encoding="utf-8")
+
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [result] = BenchmarkRunner(store).run_suite(tmp_path)
+
+    assert result.baseline_violation_count >= 1
+    assert result.enhanced_violation_count == 0
+    assert result.exposed_decision_ids_hit == []
+    assert result.verdict == ScenarioVerdict.WEAK_RETRIEVAL
+
+
+def test_runner_violation_exposure_hit_allows_pass(tmp_path):
+    d = tmp_path / "guard"
+    d.mkdir()
+    (d / "query.txt").write_text("storage widgets", encoding="utf-8")
+    (d / "without_mneme.txt").write_text("We adopt zapdb now.", encoding="utf-8")
+    (d / "with_mneme.txt").write_text("We use something else entirely.", encoding="utf-8")
+    (d / "scenario.json").write_text(json.dumps({
+        "name": "guard",
+        "scenario_type": "violation",
+        "expected_exposed_decision_ids": ["rule-y"],
+    }), encoding="utf-8")
+
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [result] = BenchmarkRunner(store).run_suite(tmp_path)
+
+    assert result.verdict == ScenarioVerdict.PASS
+    assert result.exposed_decision_ids_hit == ["rule-y"]
+
+
+def test_runner_benign_block_is_false_positive(tmp_path):
+    [result] = _run(tmp_path, [
+        ("case", dict(
+            query="widgets configuration",
+            content="Config enables foo_and_bar mode.",
+            metadata=_benign_metadata(["rule-x"]),
+        )),
+    ])
+    assert result.verdict == ScenarioVerdict.FALSE_POSITIVE
+    assert result.enhanced_violation_count >= 1
+    assert result.enhanced_triggers
+
+
+def test_runner_violation_path_unchanged_without_scenario_type(tmp_path):
+    d = tmp_path / "guard"
+    d.mkdir()
+    (d / "query.txt").write_text("widgets configuration flags", encoding="utf-8")
+    (d / "without_mneme.txt").write_text(
+        "The config enables foo_and_bar mode by default.", encoding="utf-8"
+    )
+    (d / "with_mneme.txt").write_text(
+        "Config keeps the two flags independent by default.", encoding="utf-8"
+    )
+    (d / "scenario.json").write_text(json.dumps({
+        "name": "guard",
+        "expected_protected_decision_ids": ["rule-x"],
+    }), encoding="utf-8")
+
+    mem = tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    store = MemoryStore(mem)
+    store.load()
+    [result] = BenchmarkRunner(store).run_suite(tmp_path)
+    assert result.verdict == ScenarioVerdict.PASS
+    assert result.scenario_type == "violation"
+
+
+# ── summary / formatter partitioning ─────────────────────────────────────
+
+def _result(name, stype, verdict, declared=False):
+    return ScenarioResult(
+        name=name, category="c", verdict=verdict,
+        baseline_violation_count=0, enhanced_violation_count=0,
+        explanation="", scenario_type=stype,
+        methodology_opt_in=declared,
+    )
+
+
+MIXED = [
+    # Explicitly declared violation scenario: opt-in identity must survive.
+    _result("v_pass", "violation", ScenarioVerdict.PASS, declared=True),
+    _result("v_fail", "violation", ScenarioVerdict.FAIL, declared=True),
+    # Undeclared violation scenario: legacy output shape.
+    _result("v_legacy", "violation", ScenarioVerdict.WEAK),
+    _result("b_pass_1", "benign", ScenarioVerdict.PASS, declared=True),
+    _result("b_pass_2", "benign", ScenarioVerdict.PASS, declared=True),
+    _result("b_fp", "benign", ScenarioVerdict.FALSE_POSITIVE, declared=True),
+    _result("b_malformed", "benign", ScenarioVerdict.MALFORMED, declared=True),
+    _result("b_weak", "benign", ScenarioVerdict.WEAK_RETRIEVAL, declared=True),
+]
+
+
+def test_summary_partitions_violation_and_benign():
+    s = compute_summary(MIXED)
+    # Violation partition only.
+    assert s.passed == 1 and s.failed == 1 and s.weak == 1
+    assert s.pass_rate == 0.5
+    assert s.total == len(MIXED)
+    # Benign partition.
+    assert s.benign_total == 5
+    assert s.benign_passed == 2
+    assert s.benign_blocked == 1
+    assert s.benign_uncheckable == 2
+    assert s.false_positive_rate == round(1 / 3, 4)
+
+
+def test_terminal_legacy_only_output_has_no_benign_lines():
+    out = format_terminal([r for r in MIXED if r.scenario_type == "violation"])
+    assert "Benign controls" not in out
+
+
+def test_terminal_mixed_output_renders_partitioned_benign_line():
+    out = format_terminal(MIXED)
+    assert "Benign controls: false positives 1/3 checkable (FPR 33%)" in out
+    assert "uncheckable 2/5" in out
+
+
+def test_json_legacy_only_output_has_no_new_keys():
+    legacy = [r for r in MIXED if not r.methodology_opt_in]
+    payload = json.loads(format_json(legacy))
+    assert "enforcement_quality" not in payload["summary"]
+    assert all("scenario_type" not in r for r in payload["results"])
+    assert all("exposure" not in r for r in payload["results"])
+
+
+def test_json_mixed_output_emits_opt_in_keys_only_for_opt_in_rows():
+    payload = json.loads(format_json(MIXED))
+    eq = payload["summary"]["enforcement_quality"]
+    assert eq["violation_passed"] == 1
+    assert eq["violation_checkable"] == 2
+    assert eq["benign_total"] == 5
+    assert eq["benign_blocked"] == 1
+    assert eq["benign_checkable"] == 3
+    assert eq["false_positive_rate"] == round(1 / 3, 4)
+    assert eq["benign_uncheckable"] == 2
+
+    by_name = {r["name"]: r for r in payload["results"]}
+    # Explicit violation scenarios keep their opt-in identity (blocker #1).
+    assert by_name["v_pass"]["scenario_type"] == "violation"
+    assert by_name["v_pass"]["exposure"]["expected_ids"] == []
+    assert by_name["v_fail"]["scenario_type"] == "violation"
+    # Undeclared legacy rows keep the exact legacy shape.
+    assert "scenario_type" not in by_name["v_legacy"]
+    assert "exposure" not in by_name["v_legacy"]
+    # Benign rows carry identity; MALFORMED rows do not emit methodology keys.
+    assert by_name["b_fp"]["scenario_type"] == "benign"
+    assert by_name["b_pass_1"]["exposure"]["expected_ids"] == []
+    assert "scenario_type" not in by_name["b_malformed"]
+    assert "exposure" not in by_name["b_malformed"]
+
+
+def test_markdown_mixed_output_has_partitioned_summary():
+    out = format_markdown(MIXED)
+    assert "**Benign controls**" in out
+    assert "FPR 33%" in out
+
+
+# ── CLI exit semantics ────────────────────────────────────────────────────
+
+def _cli_exit_for(results_tmp_path, scenarios):
+    for name, kwargs in scenarios:
+        _write_scenario(results_tmp_path, name, **kwargs)
+    mem = results_tmp_path / "project_memory.json"
+    mem.write_text(json.dumps(MEMORY), encoding="utf-8")
+    return main([
+        "benchmark", str(results_tmp_path), "--memory", str(mem),
+    ])
+
+
+def test_cli_false_positive_exits_one(tmp_path):
+    scenarios = [
+        ("blocked", dict(
+            query="widgets configuration",
+            content="Config enables foo_and_bar mode.",
+            metadata=_benign_metadata(["rule-x"]),
+        )),
+    ]
+    assert _cli_exit_for(tmp_path, scenarios) == 1
+
+
+def test_cli_clean_benign_suite_exits_zero(tmp_path):
+    scenarios = [
+        ("clean", dict(
+            query="widgets configuration",
+            content="Config uses foo bar here.",
+            metadata=_benign_metadata(["rule-x"]),
+        )),
+    ]
+    assert _cli_exit_for(tmp_path, scenarios) == 0
+
+
+# ── shipped suite ─────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def shipped_results():
+    store = MemoryStore(SUITE / "project_memory.json")
+    store.load()
+    return BenchmarkRunner(store).run_suite(SUITE)
+
+
+def test_shipped_suite_verdicts(shipped_results):
+    by_name = {r.name: r for r in shipped_results}
+    assert set(by_name) == {
+        "guard_unreviewed_changes",
+        "guard_awin_identifier",
+        "guard_foo_and_bar_compound",
+        "benign_awin_programme",
+        "benign_slug_prose",
+        "benign_foo_bar_incomplete",
+        "benign_governance_docs",
+    }
+    guards = [r for r in shipped_results if r.name.startswith("guard_")]
+    benigns = [r for r in shipped_results if r.name.startswith("benign_")]
+    assert all(r.verdict == ScenarioVerdict.PASS for r in guards)
+    assert all(r.verdict == ScenarioVerdict.PASS for r in benigns)
+
+    s = compute_summary(shipped_results)
+    assert s.passed == 3 and s.failed == 0
+    assert s.benign_total == 4
+    assert s.benign_blocked == 0
+    assert s.false_positive_rate == 0.0
+    assert s.benign_uncheckable == 0
+    # Exposure contract: every benign control proved its governing rule was
+    # actually in enforcement scope; every guard declared one too and its
+    # opt-in identity survives into results (charter §2.4/§2.6).
+    for r in shipped_results:
+        assert r.methodology_opt_in is True
+        assert r.expected_exposed_ids
+        assert r.exposed_decision_ids_hit
+
+
+def test_shipped_suite_cli_exit_zero(tmp_path):
+    out = tmp_path / "report.json"
+    code = main([
+        "benchmark", str(SUITE),
+        "--memory", str(SUITE / "project_memory.json"),
+        "--json", str(out),
+    ])
+    assert code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    eq = payload["summary"]["enforcement_quality"]
+    assert eq["violation_checkable"] == 3
+    assert eq["false_positive_rate"] == 0.0


### PR DESCRIPTION
## Summary

Implements the enforcement-quality benchmark extension authorized by merged charter #318 and the `[layer1-freeze]` amendment (#319). Makes the #317 improvement quantitatively visible: enforcement false positives become a first-class, regression-gated metric.

Governance sequence satisfied: charter merge (#318) → freeze amendment (#319) → **this implementation**.

## What lands

**Runner (`mneme/benchmark.py`)**
- Sixth verdict `FALSE_POSITIVE` (benign scenarios only); `scenario_type: violation | benign` metadata — absent → violation internally, unknown → MALFORMED.
- Benign path evaluates the enhanced side through the enforcer; exposure contract (`expected_exposed_decision_ids`) must be in enforcement scope or the result is `WEAK_RETRIEVAL` / uncheckable — never a vacuous PASS.

**Report (`mneme/benchmark_report.py`)**
- Partitioned summary: violation catch rate vs FPR; benign results can never merge into the "violations caught" headline.
- Byte-identity preserved: new fields (`enforcement_quality`, per-result `scenario_type`/`exposure`) emit only for scenarios that declare `scenario_type`; canonical output is byte-for-byte unchanged.

**CLI (`mneme/cli.py`)**
- `FALSE_POSITIVE` exits 1. `MALFORMED` deliberately remains exit-0 per charter §5.

**Frozen suite (`examples/benchmarks-enforcement-quality/`)**
- Dedicated fixture memory + 7 incident-traceable scenarios: 3 violation guards (identifier form `assume_awin_awin_us_same_source`, compound `foo_and_bar`, `unreviewed enforcement changes`) + 4 benign controls (awin programme prose, live/category/slug prose, incomplete `foo bar`, governance docs).
- README documents invocation, provenance, metric definitions, TXT-fixture rationale (the enforcer is the code under test), and the scorecard template.

## Scorecard (first recorded measurement)

| Metric | Before #317 | Current | Target |
|---|---|---|---|
| Violation catch rate | 100% (7/7) | **100% (canonical) · 100% (3/3 guards)** | 100% |
| False-positive rate | >0% (unmeasured, dogfood FAILs) | **0% (0/4)** | ~0% |
| Retrieval Recall@3 | 1.00 | **1.00 (unchanged)** | 1.00 |
| Retrieval Precision@3 | 0.33 | **0.33 (unchanged, advisory)** | ↑ later |

## Freeze compliance

Canonical suite verified byte-identical post-change on all three surfaces (terminal, Markdown, JSON — hash-compared against pre-change goldens at `0725275c`). Canonical fixtures untouched. Layer 1 formulas/aggregation untouched (benign scenarios carry no expected IDs).

## Test plan

- New `tests/test_enforcement_quality_benchmark.py` (21 tests): loader defaults/typo-MALFORMED, exposure PASS/miss/block, violation-path invariance, partition math, formatter byte-compat both directions, CLI exits, shipped-suite assertions.
- Full suite: **808 passed, 5 skipped**. Canonical benchmark: **7/7, Layer 2 100%, exit 0**, outputs byte-identical.
- New suite run: catch 3/3, FPR 0/4, uncheckable 0/4, exit 0 (14 expected TXT-fallback warnings, rationale documented in suite README).

Closes the measurement gap identified after #317; charter reference: #318; freeze amendment: #319.
