### PR TITLE
build: update agentic AI SDLC package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Mneme HQ
 
-**Architectural drift prevention for the agentic AI SDLC.**
+**Architectural drift prevention for the AI SDLC.**
 
 Mneme turns architectural decisions and ADRs into deterministic guardrails across AI coding agents, generated rules and CI gates.
 
-Architectural governance is the mechanism: Mneme makes decisions enforceable before incompatible changes reach review.
+Mneme HQ is the architectural governance layer for AI-assisted development.
 
 <a href="https://www.youtube.com/watch?v=LaJqeJrKkgg" target="_blank">
   <img 
@@ -38,7 +38,7 @@ Architectural governance is the mechanism: Mneme makes decisions enforceable bef
 
 ## What Mneme Is
 
-At its current Layer 1 scope, Mneme prevents architectural drift in local-repo, single-developer agentic AI development workflows. It does this through project-scoped architectural governance:
+Local-repo, single-developer, project-scoped architectural governance for AI-assisted code generation. Specifically:
 
 - A way to **encode architectural decisions** as structured records in `project_memory.json`.
 - A **deterministic retriever** that selects relevant decisions for any given prompt or task.
@@ -68,7 +68,7 @@ The freeze is governed by three load-bearing principles. Every feature is judged
 - **Auditable > autonomous.** Every block records which decision matched, which rule triggered, which term in the input fired it. A human can reconstruct any verdict from the artifacts.
 - **Prevention before review.** Mneme runs *before* the LLM generates output, not after. The intervention point is the prompt boundary.
 
-Mneme is built to prevent architectural drift across the agentic AI SDLC. Architectural governance is the mechanism. See the [concepts hub](https://mnemehq.com/concepts/) for definitions including governance before generation, verification contracts, architectural drift, and governance infrastructure.
+Mneme is built around a broader architectural governance model for AI-assisted development. See the [concepts hub](https://mnemehq.com/concepts/) for definitions including governance before generation, verification contracts, architectural drift, and governance infrastructure.
 
 ## Benchmark Philosophy
 
@@ -111,9 +111,7 @@ Mneme HQ turns those decisions into structured, retrievable constraints that can
 
 ## What Mneme HQ is
 
-**Mneme HQ** is open-source architectural drift prevention for the agentic AI SDLC.
-
-It uses architectural governance and deterministic enforcement to keep AI-generated changes aligned with repository architecture and prior decisions.
+**Mneme HQ** is the architectural governance layer for AI-assisted development.
 
 This repository demonstrates the first core capability: injecting structured architectural decisions into LLM calls so outputs stay consistent with prior engineering decisions.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Mneme HQ
 
-**Architectural drift prevention for the AI SDLC.**
+**Architectural drift prevention for the agentic AI SDLC.**
 
 Mneme turns architectural decisions and ADRs into deterministic guardrails across AI coding agents, generated rules and CI gates.
 
-Mneme HQ is the architectural governance layer for AI-assisted development.
+Architectural governance is the mechanism: Mneme makes decisions enforceable before incompatible changes reach review.
 
 <a href="https://www.youtube.com/watch?v=LaJqeJrKkgg" target="_blank">
   <img 
@@ -38,7 +38,7 @@ Mneme HQ is the architectural governance layer for AI-assisted development.
 
 ## What Mneme Is
 
-Local-repo, single-developer, project-scoped architectural governance for AI-assisted code generation. Specifically:
+At its current Layer 1 scope, Mneme prevents architectural drift in local-repo, single-developer agentic AI development workflows. It does this through project-scoped architectural governance:
 
 - A way to **encode architectural decisions** as structured records in `project_memory.json`.
 - A **deterministic retriever** that selects relevant decisions for any given prompt or task.
@@ -68,7 +68,7 @@ The freeze is governed by three load-bearing principles. Every feature is judged
 - **Auditable > autonomous.** Every block records which decision matched, which rule triggered, which term in the input fired it. A human can reconstruct any verdict from the artifacts.
 - **Prevention before review.** Mneme runs *before* the LLM generates output, not after. The intervention point is the prompt boundary.
 
-Mneme is built around a broader architectural governance model for AI-assisted development. See the [concepts hub](https://mnemehq.com/concepts/) for definitions including governance before generation, verification contracts, architectural drift, and governance infrastructure.
+Mneme is built to prevent architectural drift across the agentic AI SDLC. Architectural governance is the mechanism. See the [concepts hub](https://mnemehq.com/concepts/) for definitions including governance before generation, verification contracts, architectural drift, and governance infrastructure.
 
 ## Benchmark Philosophy
 
@@ -111,7 +111,9 @@ Mneme HQ turns those decisions into structured, retrievable constraints that can
 
 ## What Mneme HQ is
 
-**Mneme HQ** is the architectural governance layer for AI-assisted development.
+**Mneme HQ** is open-source architectural drift prevention for the agentic AI SDLC.
+
+It uses architectural governance and deterministic enforcement to keep AI-generated changes aligned with repository architecture and prior decisions.
 
 This repository demonstrates the first core capability: injecting structured architectural decisions into LLM calls so outputs stay consistent with prior engineering decisions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mneme-hq"
 version = "0.5.2"
-description = "Architectural drift prevention for the AI SDLC. Deterministic ADR guardrails across coding agents and CI."
-keywords = ["architectural-drift-prevention", "ai-coding-agents", "adr", "governance", "ci", "codex", "claude-code"]
+description = "Architectural drift prevention for the agentic AI SDLC. Deterministic ADR guardrails across coding agents and CI."
+keywords = ["architectural-drift-prevention", "architectural-drift", "agentic-ai-sdlc", "agentic-ai", "ai-coding-agents", "adr", "architectural-governance", "ci", "codex", "claude-code"]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -27,6 +27,13 @@ dev = [
 [project.scripts]
 mneme = "mneme.cli:main"
 mneme-hook = "mneme.integrations.claude_code.hook:cli_main"
+
+[project.urls]
+Homepage = "https://mnemehq.com"
+Documentation = "https://mnemehq.com/docs/"
+Repository = "https://github.com/MnemeHQ/mneme"
+Issues = "https://github.com/MnemeHQ/mneme/issues"
+Changelog = "https://mnemehq.com/changelog/"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Homepage = "https://mnemehq.com"
 Documentation = "https://mnemehq.com/docs/"
 Repository = "https://github.com/MnemeHQ/mneme"
 Issues = "https://github.com/MnemeHQ/mneme/issues"
-Changelog = "https://mnemehq.com/changelog/"
+Changelog = "https://github.com/MnemeHQ/mneme/releases"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- update the PyPI/package summary for **architectural drift prevention for the agentic AI SDLC**
- add agentic, drift-prevention, and architectural-governance discovery keywords
- add canonical Homepage, Documentation, Repository, Issues, and Changelog URLs

## Relationship to #325
PR #325 owns the root README rebuild and category lead. This PR is deliberately narrowed to `pyproject.toml` so it complements #325 without overlapping or conflicting.

## Verification
- parsed `pyproject.toml` with Python `tomllib`
- `git diff --check`