### PR TITLE
docs: add current five-minute quickstart

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,38 @@ jobs:
       - name: Run test suite
         run: python -m pytest
 
+      # Temporary branch-only validation for PR #327. Remove after the
+      # documented quickstart has been exercised end-to-end.
+      - name: Exercise five-minute quickstart
+        shell: bash
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+
+          mneme init
+          mneme add_decision \
+            --memory .mneme/project_memory.json \
+            --id config-format \
+            --decision "Use JSON for configuration files" \
+            --scope config \
+            --constraint "Use JSON only" \
+            --anti-pattern "Do not use YAML"
+
+          python -c "import pathlib; pathlib.Path('prompt_clean.txt').write_text('Add a new JSON config file', encoding='utf-8')"
+          clean_output="$(mneme check --memory .mneme/project_memory.json --input prompt_clean.txt --query configuration)"
+          printf '%s\n' "$clean_output"
+          grep -q "Result: PASS" <<<"$clean_output"
+
+          python -c "import pathlib; pathlib.Path('prompt_violation.txt').write_text('Set up a new YAML config file for this module', encoding='utf-8')"
+          set +e
+          violation_output="$(mneme check --memory .mneme/project_memory.json --input prompt_violation.txt --query configuration 2>&1)"
+          violation_rc=$?
+          set -e
+          printf '%s\n' "$violation_output"
+          test "$violation_rc" -eq 2
+          grep -q "Result: FAIL" <<<"$violation_output"
+
   # The LangChain integration's live governed-loop tests require the
   # optional extra; the canonical job above intentionally runs without it.
   pytest-langchain:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,38 +37,6 @@ jobs:
       - name: Run test suite
         run: python -m pytest
 
-      # Temporary branch-only validation for PR #327. Remove after the
-      # documented quickstart has been exercised end-to-end.
-      - name: Exercise five-minute quickstart
-        shell: bash
-        run: |
-          set -euo pipefail
-          workdir="$(mktemp -d)"
-          cd "$workdir"
-
-          mneme init
-          mneme add_decision \
-            --memory .mneme/project_memory.json \
-            --id config-format \
-            --decision "Use JSON for configuration files" \
-            --scope config \
-            --constraint "Use JSON only" \
-            --anti-pattern "Do not use YAML"
-
-          python -c "import pathlib; pathlib.Path('prompt_clean.txt').write_text('Add a new JSON config file', encoding='utf-8')"
-          clean_output="$(mneme check --memory .mneme/project_memory.json --input prompt_clean.txt --query configuration)"
-          printf '%s\n' "$clean_output"
-          grep -q "Result: PASS" <<<"$clean_output"
-
-          python -c "import pathlib; pathlib.Path('prompt_violation.txt').write_text('Set up a new YAML config file for this module', encoding='utf-8')"
-          set +e
-          violation_output="$(mneme check --memory .mneme/project_memory.json --input prompt_violation.txt --query configuration 2>&1)"
-          violation_rc=$?
-          set -e
-          printf '%s\n' "$violation_output"
-          test "$violation_rc" -eq 2
-          grep -q "Result: FAIL" <<<"$violation_output"
-
   # The LangChain integration's live governed-loop tests require the
   # optional extra; the canonical job above intentionally runs without it.
   pytest-langchain:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,107 @@
+# 5-Minute Quickstart
+
+This guide shows the smallest working Mneme loop: install the package, create project memory, record one architectural decision, and verify both compliant and prohibited inputs. No API key is required.
+
+Mneme provides architectural drift prevention for the agentic AI SDLC by turning recorded decisions into deterministic guardrails. This quickstart exercises the CLI enforcement surface directly.
+
+## 1. Install
+
+Requires Python 3.11+.
+
+```bash
+pip install mneme-hq
+```
+
+Verify the CLI:
+
+```bash
+mneme --help
+```
+
+## 2. Initialize project memory
+
+Create an empty project-local decision corpus:
+
+```bash
+mneme init
+```
+
+This creates `.mneme/project_memory.json`.
+
+## 3. Add a decision
+
+Record a simple architectural decision: use JSON for configuration files and do not use YAML.
+
+```bash
+mneme add_decision \
+  --memory .mneme/project_memory.json \
+  --id config-format \
+  --decision "Use JSON for configuration files" \
+  --scope config \
+  --constraint "Use JSON only" \
+  --anti-pattern "Do not use YAML"
+```
+
+## 4. Check a compliant input
+
+Create an input file explicitly as UTF-8:
+
+```bash
+python -c "import pathlib; pathlib.Path('prompt_clean.txt').write_text('Add a new JSON config file', encoding='utf-8')"
+```
+
+Run the check:
+
+```bash
+mneme check \
+  --memory .mneme/project_memory.json \
+  --input prompt_clean.txt \
+  --query configuration
+```
+
+Expected result:
+
+```text
+Result: PASS
+```
+
+The command exits `0`.
+
+## 5. Check a prohibited input
+
+Create an input that contradicts the recorded decision:
+
+```bash
+python -c "import pathlib; pathlib.Path('prompt_violation.txt').write_text('Set up a new YAML config file for this module', encoding='utf-8')"
+```
+
+Run the same deterministic check:
+
+```bash
+mneme check \
+  --memory .mneme/project_memory.json \
+  --input prompt_violation.txt \
+  --query configuration
+```
+
+Expected result:
+
+```text
+Result: FAIL
+```
+
+`mneme check` uses strict mode by default, so this FAIL exits `2`.
+
+## What just happened
+
+The same decision corpus was used for both inputs. Retrieval identified relevant architectural guidance; enforcement evaluated the applicable recorded rule and returned a deterministic verdict.
+
+The CLI is also the common policy surface used by CI patterns and several agent integrations. Each integration documents which mutations it can block before execution and which paths require later audit.
+
+## Next steps
+
+- [Integration support matrix](integrations/README.md)
+- [Claude Code integration](integrations/claude-code.md)
+- [ADR import](integrations/adr-import.md)
+- [Current architecture phase](architecture/current-phase.md)
+- [Root README](../README.md)


### PR DESCRIPTION
## Summary

Re-land the five-minute quickstart on current `main` as a docs-only change.

The guide shows the smallest working CLI loop:

1. install Mneme;
2. initialize project memory;
3. record one JSON-vs-YAML architectural decision;
4. verify a compliant input returns PASS / exit 0;
5. verify a prohibited input returns FAIL / exit 2 in default strict mode.

## Architecture alignment

- exercises the existing CLI enforcement surface only;
- does not change retrieval, enforcement, applicability, conflict handling, benchmark semantics, memory format, or integrations;
- keeps integration-specific blocking boundaries out of the quickstart and links to their canonical docs instead;
- uses the accepted `agentic AI SDLC` category wording already reconciled by #326.

## Current-main validation

The old branch was rebuilt directly on current `main` after its dependency landed.

The documented flow was then executed end-to-end in a clean temporary directory on GitHub CI using the current package:

- `mneme init` -> created `.mneme/project_memory.json`
- `mneme add_decision ...` -> added `config-format`
- compliant JSON input -> `Result: PASS`, exit 0
- prohibited YAML input -> `Result: FAIL`, exit 2
- canonical test suite on the validation run -> **1117 passed, 8 skipped**
- LangChain-extra CI -> **PASS**

The temporary branch-only workflow step used to exercise the exact documentation was removed after validation. Final PR diff is exactly one file:

- `docs/quickstart.md`

## Scope

No code, ADR, memory, benchmark fixture, integration, workflow, or release changes.

## Credit

Maintainer takeover of the earlier contributor quickstart work, rebuilt from current `main` rather than carrying forward the stale branch lineage.

## Execution provenance

- Change author: mixed
- Agent: chatgpt-work
- Agent model: GPT-5.6 Sol
- Agent session: not-exposed
- Task origin: chatgpt
- Human owner: @TheoV823