### PR TITLE
docs: add architecture-aware GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a reproducible problem in Mneme core
+title: ''
+labels: bug
+assignees: ''
+---
+
+> **Repository boundary:** This repository is for the Mneme core package. Website issues belong in [MnemeHQ/mnemehq-site](https://github.com/MnemeHQ/mnemehq-site).
+
+## Describe the bug
+
+What happened, and what did you expect instead?
+
+## Reproduction
+
+Please provide the smallest reproducible case you can, including the command, input, and relevant memory/ADR shape when applicable.
+
+1. Run command: `...`
+2. Input or target: `...`
+3. Observe: `...`
+
+## Output and errors
+
+Paste the relevant CLI output, JSON verdict, traceback, or error message.
+
+```text
+...
+```
+
+## Environment
+
+- Mneme package version:
+- Python version:
+- OS:
+- Integration/harness and version, if applicable:
+
+## Additional context
+
+Include anything else needed to reproduce or classify the issue. Do not include secrets or private repository content.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Propose a change to Mneme core
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+> **Repository boundary:** This repository is for the Mneme core package. Website issues belong in [MnemeHQ/mnemehq-site](https://github.com/MnemeHQ/mnemehq-site).
+
+## Problem
+
+What concrete problem should Mneme solve?
+
+## Proposed change
+
+Describe the behavior or interface you would like to add or change.
+
+## Alternatives considered
+
+What other approaches did you consider?
+
+## Architecture classification
+
+Please identify, if known:
+
+- Affected core surface (for example: CLI, retrieval, enforcement, applicability, conflict detection, benchmark, integration):
+- Relevant ADR or architecture document:
+- Could this change frozen retrieval, enforcement, or benchmark semantics? [ ] Yes [ ] No [ ] Unsure
+- Could this require a charter amendment? [ ] Yes [ ] No [ ] Unsure
+
+Do not infer a new architecture rule from an existing integration or adjacent component; link the governing source if one exists.
+
+## Additional context
+
+Add examples, expected behavior, or other evidence that helps evaluate the proposal.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## What changed and why
+
+<!-- Describe the change and the problem it solves. Keep the PR narrowly scoped. -->
+
+## Core behavior classification
+
+<!-- Retrieval, enforcement, applicability/conflict handling, and benchmark semantics are distinct surfaces. -->
+<!-- Behavioural changes to frozen retrieval, enforcement, or benchmark semantics may require the charter-amendment procedure. -->
+
+Affected surface(s):
+
+- [ ] No core behavioral change (docs/tooling/integration-only)
+- [ ] Retrieval / decision ranking or context selection
+- [ ] Enforcement / verdict semantics
+- [ ] Rule applicability or conflict handling
+- [ ] Benchmark harness or benchmark semantics
+- [ ] Other core behavior (explain below)
+
+Relevant ADR / architecture document(s):
+
+<!-- Link the governing source. Do not infer architecture from adjacent integrations. -->
+
+Charter amendment required?
+
+- [ ] Yes
+- [ ] No
+- [ ] Unsure / needs maintainer classification
+
+## Tests
+
+<!-- Describe the tests run for this change. -->
+
+- [ ] `pytest tests/ -v` passes locally
+
+## Benchmark verification
+
+<!-- Run the benchmark when core enforcement behavior changes; follow the freeze procedure for benchmark-semantic or fixture changes. -->
+
+- [ ] Run; results unchanged or explained below
+- [ ] N/A
+
+## Documentation
+
+- [ ] Relevant documentation updated
+- [ ] N/A
+
+## Project memory
+
+<!-- Changes to `.mneme/project_memory.json` require `[memory]` in the PR title. An ADR amendment may reconcile the matching memory decision in the same reviewed PR under the repository's memory rule. -->
+
+- [ ] This PR modifies `.mneme/project_memory.json` and the title includes `[memory]`
+- [ ] This PR does not modify `.mneme/project_memory.json`


### PR DESCRIPTION
## Summary

Maintainer takeover of Prashant's three GitHub templates from #241, rebuilt from current `main`.

## Preserved from #241

- bug template for core package reports
- feature-request architecture classification
- PR test/benchmark/documentation checklist
- website issues routed to `MnemeHQ/mnemehq-site`
- `[memory]` title requirement for `.mneme/project_memory.json` changes

## Architecture alignment

The current repo explicitly separates retrieval, enforcement, rule applicability/conflict handling, and benchmark semantics. The old template grouped retrieval scoring under "enforcement behaviour"; this takeover removes that conflation.

The PR template now classifies affected core surfaces separately and asks for the governing ADR/architecture source plus charter-amendment status. The feature template follows the same model.

Validated against current `CONTRIBUTING.md`, `docs/architecture/current-phase.md`, and the accepted ADR-017/019/020 separation.

## Scope

Exactly three new GitHub template files:

- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

No code, ADR, memory, benchmark fixture, workflow, integration, or release changes.

## Credit

Supersedes #241 as a maintainer takeover. The original contribution remains credited to Prashant.