### PR TITLE
feat: add Hermes Agent experimental integration

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -30,6 +30,7 @@ at what level, with what evidence. The website's
 | CLI-based CI gates | GitHub Actions, GitLab CI | `mneme check` reference patterns |
 | Experimental | OpenCode | plugin-hooks approach under evaluation; compaction experiment returned a NULL verdict |
 | Experimental | Kiro | bounded PreToolUse hook, contract-tested, [open PR #314](https://github.com/MnemeHQ/mneme/pull/314) |
+| Experimental | Hermes Agent | P1.5 POC passed (context injection + pre-tool blocking); no blocking Stop-equivalent, see [hermes.md](hermes.md) |
 | Planned | Deep Agents middleware POC | see [roadmap](../roadmap/2026-04-24-adoption-and-enhancement-roadmap.md) |
 
 ## Known limitations
@@ -46,6 +47,10 @@ at what level, with what evidence. The website's
   placeholder-`ANTHROPIC_API_KEY` caveat documented in [paperclip.md](paperclip.md).
 - **OpenCode**: no production plugin ships. The completed compaction
   experiment returned a NULL verdict and was closed evidence-only.
+- **Hermes Agent**: POC validated against hermes-agent 0.19.0 at the plugin
+  dispatch-runtime layer; `terminal` non-class-A forms, `execute_code`, and
+  `process` are bypass surfaces, and no blocking Stop-equivalent exists.
+  See [hermes.md](hermes.md).
 
 ## Distinction that matters
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,0 +1,122 @@
+# Hermes Agent — P1.5 proof of concept
+
+**Status: Experimental (POC complete, not a native integration).**
+
+Hermes Agent (Nous Research) exposes two plugin hooks that map onto existing
+Mneme surfaces without changing any frozen semantics:
+
+| Hermes hook | Mneme surface | Behavior |
+| --- | --- | --- |
+| `pre_llm_call` (per turn) | `MemoryStore` → `DecisionRetriever` → `format_decisions` | Retrieved decisions returned as `{"context": ...}`; Hermes appends them to the current turn's user message |
+| `pre_tool_call` (blocking) | ToolEvent translation → introduced-delta materialization → `mneme check` | Trusted strict-mode WARN/FAIL returns `{"action": "block", "message": <reason>}` |
+
+The adapter is a thin translation layer. It implements no retrieval,
+applicability, conflict, or enforcement semantics of its own: retrieval is
+the unchanged `DecisionRetriever` path shared with the Agent SDK adapter,
+enforcement is the unchanged `mneme check` CLI contract shared with the
+Claude Code hook, V4A patch parsing is the frozen Codex CLI transport
+parser, and shell preflight is the ADR-021 class-A reconstruction reused as-is.
+
+## What ships
+
+- `mneme/integrations/hermes/adapter.py` — pure translation + gate glue.
+- `mneme/integrations/hermes/plugin.py` — hook binding (`register(ctx)`).
+- `integrations/hermes-plugin/` — the standalone plugin directory users copy
+  to `<project>/.hermes/plugins/mneme/`.
+- `tests/integrations/hermes/` — context, gate, wiring, identity, and one
+  end-to-end test through the real `mneme check` subprocess.
+
+## Install (POC)
+
+1. Copy `integrations/hermes-plugin/` to `<project>/.hermes/plugins/mneme/`.
+2. Make the published `mneme` package importable from Hermes' Python
+   environment.
+3. Enable project plugins and opt in:
+
+   ```
+   HERMES_ENABLE_PROJECT_PLUGINS=true        # env var
+   # plus plugins.enabled: [mneme] in Hermes config — project plugins are
+   # opt-in even when the env var is set (verified against 0.19.0)
+   ```
+
+Enforcement mode follows the shared resolution (`MNEME_HOOK_MODE`, then
+"strict").
+
+## H0 capability probe findings (hermes-agent 0.19.0)
+
+Verified against the shipped package and exercised through Hermes' real
+plugin-manager dispatch (`invoke_hook` / `resolve_pre_tool_block`), not
+documentation alone:
+
+- **Payload shapes are deterministic.**
+  - `write_file`: `{path, content}` — full proposed content is present;
+    introduced-delta materialization applies unchanged (ADR-018).
+  - `patch` mode `replace`: `{path, old_string, new_string, replace_all?}` —
+    maps 1:1 onto the canonical Edit event.
+  - `patch` mode `patch`: raw V4A text — parsed by the frozen Codex CLI
+    parser (`parse_patch_operations`) with current-file snapshots supplied
+    per Update operation.
+  - `terminal`: `{command, workdir?, ...}` — the command arrives verbatim as
+    one string, so ADR-021 class-A heredoc reconstruction reuses without new
+    shell interpretation. No cwd is carried in any payload; the adapter uses
+    the project directory (project plugins load relative to CWD).
+- **Blocking primitive confirmed live**: forbidden `write_file` content and
+  a forbidden class-A heredoc both produced block directives through the
+  real dispatch path; compliant calls passed untouched. First valid
+  directive wins; a block requires a non-empty message.
+- **Context injection confirmed live**: a `{"context": text}` return was
+  collected through the real per-turn dispatch and joined into the user
+  message.
+- **Fail-open posture**: Hermes swallows hook exceptions and ignores invalid
+  directives, so the gate can only ever *prevent* what it deterministically
+  evaluated — it cannot silently turn failures into blocks.
+- **No blocking Stop-equivalent**: `on_session_end` is observer-only (its
+  return value is ignored). There is no session-delta backstop behind this
+  gate.
+- Live model-driven sessions were not available in the probe environment
+  (no provider credentials); all verification ran at the dispatch-runtime
+  layer, which owns the entire hook contract. Tool arguments themselves are
+  schema-constrained and handler-validated by Hermes.
+
+## H3 bypass coverage matrix
+
+| Mutation surface | Pre-execution outcome | Evidence |
+| --- | --- | --- |
+| `write_file` | **Caught** — full-content introduced-delta check | e2e test + dispatch probe |
+| `patch` mode `replace` | **Caught** — Edit-equivalent check | tests |
+| `patch` mode `patch`, Add/Update ops | **Caught** — frozen V4A parser + snapshots | tests |
+| `patch` mode `patch`, Delete op | Skip-by-design (introduces nothing; ADR-018) | parser contract |
+| Unparseable / snapshot-unavailable patch | Fail open, disclosed (never guessed) | tests |
+| `terminal`: single quoted-delimiter heredoc write | **Caught** — ADR-021 class-A reuse | tests + dispatch probe |
+| `terminal`: redirects, `tee`, `sed -i`, `mv`, `rm`, compound commands | **Bypassed pre-execution**, classified only | classification never blocks |
+| `execute_code` | **Bypassed** — arbitrary Python file I/O; unevaluated surface | characterized, not governed |
+| `process` tool | **Bypassed** — spawns arbitrary commands | discovered in H0 registry sweep |
+| Sub-agents (`delegate_task`) | Hook fires again per child dispatch (per dispatch contract); unverified live | unknown until credential-backed replay |
+| Completion time (session delta) | **Not covered** — no blocking Stop-equivalent | H0 finding |
+
+## What this integration is not
+
+- It does not claim Claude Code or Codex CLI enforcement parity. Those
+  integrations implement ADR-021's full prevent → catch → verify arc;
+  Hermes currently supports only the **prevent** tier.
+- It adds no HTTP/MCP surface, no fork of Hermes core, no generalized shell
+  parser, and no changes to `DecisionRetriever`, conflict detection,
+  enforcer semantics, typed-rule matching, path applicability, or benchmark
+  fixtures.
+
+## Validation status (H4 closeout)
+
+| Gate | Result |
+| --- | --- |
+| Context injection (H1) | PASS — existing retrieval path unchanged |
+| Direct mutation blocking (H2) | PASS — strict WARN/FAIL blocks via `{"action": "block"}` |
+| Bypass surfaces explicitly characterized (H3) | PASS — matrix above |
+| Zero frozen-core changes | PASS — adapter/tests/docs only |
+| Enforcement benchmark remains 7/7 | PASS — `mneme benchmark examples/benchmarks/` unchanged |
+
+**Recommendation: promote to "supported experimental integration".**
+All five POC exit criteria hold, so promotion out of roadmap-only status is
+justified — with the documented limitation that completion-time catch parity
+is absent and depends on Hermes exposing a blocking Stop-boundary primitive.
+Full production parity claims remain blocked on that gap and on a
+credential-backed live-session replay of the dispatch-level findings.

--- a/docs/roadmap/2026-04-24-adoption-and-enhancement-roadmap.md
+++ b/docs/roadmap/2026-04-24-adoption-and-enhancement-roadmap.md
@@ -193,6 +193,16 @@ Evaluate pre-mutation blocking, deterministic change reconstruction, opaque
 subagents. Roadmap-only until the POC passes; see
 [docs/integrations/README.md](../integrations/README.md) for current status.
 
+### Hermes Agent POC — P1.5 (POC passed)
+
+Completed 2026-08-25. Context injection via `pre_llm_call` and pre-tool
+blocking via `pre_tool_call` reuse the existing retrieval and `mneme check`
+paths unchanged; bypass surfaces (`terminal` non-class-A forms,
+`execute_code`, `process`) are characterized; the frozen 7/7 enforcement
+benchmark is unchanged. Promoted to Experimental — see
+[docs/integrations/hermes.md](../integrations/hermes.md). Production parity
+claims remain blocked on Hermes exposing a blocking Stop-equivalent.
+
 ---
 
 ## Checkpoint 6: Adoption test with external users

--- a/integrations/hermes-plugin/__init__.py
+++ b/integrations/hermes-plugin/__init__.py
@@ -1,0 +1,15 @@
+"""Mneme governance plugin for the Hermes Agent (POC).
+
+Requires the ``mneme`` package to be importable from Hermes' Python
+environment. All behavior lives in ``mneme.integrations.hermes.plugin``
+and ``mneme.integrations.hermes.adapter``; this file only forwards the
+plugin registration so the governed project can pin adapter behavior by
+pinning its mneme version.
+
+See docs/integrations/hermes.md in the Mneme repository for install,
+enforcement boundary, and the H3 bypass coverage matrix.
+"""
+
+from mneme.integrations.hermes.plugin import register
+
+__all__ = ["register"]

--- a/integrations/hermes-plugin/plugin.yaml
+++ b/integrations/hermes-plugin/plugin.yaml
@@ -1,0 +1,6 @@
+name: mneme
+version: 0.1.0
+description: Mneme architectural governance - decision context injection (pre_llm_call) and deterministic pre-tool mutation enforcement (pre_tool_call) via mneme check. POC.
+provides_hooks:
+  - pre_tool_call
+  - pre_llm_call

--- a/mneme/integrations/hermes/__init__.py
+++ b/mneme/integrations/hermes/__init__.py
@@ -1,0 +1,31 @@
+"""Mneme integration for the Hermes Agent (P1.5 POC)."""
+
+from mneme.integrations.hermes.adapter import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    ACTION_FAIL_OPEN,
+    ACTION_SKIP,
+    ACTION_WARN,
+    ContextInjection,
+    GateResult,
+    HERMES_MUTATING_TOOLS,
+    HERMES_SHELL_TOOLS,
+    HERMES_UNEVALUATED_TOOLS,
+    MnemeHermes,
+    directive_for,
+)
+
+__all__ = [
+    "MnemeHermes",
+    "ContextInjection",
+    "GateResult",
+    "directive_for",
+    "ACTION_ALLOW",
+    "ACTION_DENY",
+    "ACTION_WARN",
+    "ACTION_FAIL_OPEN",
+    "ACTION_SKIP",
+    "HERMES_MUTATING_TOOLS",
+    "HERMES_SHELL_TOOLS",
+    "HERMES_UNEVALUATED_TOOLS",
+]

--- a/mneme/integrations/hermes/adapter.py
+++ b/mneme/integrations/hermes/adapter.py
@@ -1,0 +1,536 @@
+"""Mneme integration for the Hermes Agent (P1.5 proof of concept).
+
+Two Hermes plugin hooks map onto existing Mneme surfaces:
+
+    pre_llm_call   -> MemoryStore + DecisionRetriever + format_decisions
+                      -> {"context": ...} injected into the current turn
+                      (the same retrieval path as the Agent SDK adapter)
+
+    pre_tool_call  -> Hermes args translation (write_file | patch | terminal)
+                      -> introduced-content materialization + `mneme check`
+                      (the same enforcement path as the Claude Code hook)
+                      -> {"action": "block"} + Mneme's reason, or no opinion
+
+No retrieval, applicability, conflict, or enforcement semantics are
+implemented here. The pure pieces are imported from
+``mneme.integrations.claude_code.hook``, ``mneme.decision_retriever``,
+and ``mneme.integrations.codex_cli.patch_parser``; this module only
+translates between Hermes' hook payloads and that existing behavior.
+
+Known boundary (characterized by the H0/H3 probes, see
+docs/integrations/hermes.md):
+
+- ``terminal`` commands are checked only when they match the ADR-021
+  class-A grammar (single quoted-delimiter heredoc write). Every other
+  shell form passes unevaluated: Hermes has no blocking Stop-equivalent,
+  so there is no session-delta backstop behind this gate.
+- ``execute_code`` and ``process`` are deliberately unevaluated bypass
+  surfaces. They are never claimed as governed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from mneme.context_builder import DEFAULT_MAX_DECISIONS, format_decisions
+from mneme.decision_retriever import DecisionRetriever
+from mneme.integrations.claude_code.hook import (
+    ToolEvent,
+    _CHECK_TIMEOUT_SECONDS,
+    _child_env,
+    find_memory,
+    format_applicability_reason,
+    format_reason,
+    introduced_between,
+    introduced_content,
+    MaterializeError,
+    parse_verdict,
+    resolve_mode,
+)
+from mneme.integrations.claude_code.shell_preflight import (
+    Classification,
+    classify_command,
+    reconstruct_heredoc_write,
+)
+from mneme.integrations.codex_cli.patch_parser import (
+    CodexPatchParseError,
+    parse_patch_operations,
+    patch_operation_specs,
+)
+from mneme.memory_store import MemoryStore
+
+# Actions returned by the mutation gate (same vocabulary as Agent SDK).
+ACTION_ALLOW = "allow"
+ACTION_DENY = "deny"
+ACTION_WARN = "warn"
+ACTION_FAIL_OPEN = "fail_open"
+ACTION_SKIP = "skip"
+
+HERMES_MUTATING_TOOLS = frozenset({"write_file", "patch"})
+HERMES_SHELL_TOOLS = frozenset({"terminal"})
+
+# Deliberately unevaluated mutation surfaces. Characterized, not governed:
+# see docs/integrations/hermes.md (H3 coverage matrix).
+HERMES_UNEVALUATED_TOOLS = frozenset({"execute_code", "process"})
+
+
+@dataclass(frozen=True)
+class ContextInjection:
+    """Decisions retrieved for one turn, before any material work."""
+
+    query: str
+    text: str
+    decision_ids: List[str]
+    memory_path: Optional[str]
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Structured outcome of one proposed mutation."""
+
+    action: str
+    tool_name: str
+    file_path: str
+    reason: str
+    verdict: Optional[str] = None
+    evaluation_complete: bool = True
+    payload: Optional[Dict[str, Any]] = None
+
+
+CheckRunner = Callable[..., subprocess.CompletedProcess]
+
+
+class MnemeHermes:
+    """Thin adapter binding Hermes plugin hooks to Mneme governance.
+
+    Args:
+        project_dir: Directory used to discover ``.mneme/project_memory.json``.
+            Defaults to the process working directory (Hermes loads project
+            plugins relative to CWD and its ``pre_tool_call`` payload carries
+            no cwd field).
+        memory: Explicit memory path override (wins over discovery).
+        mode: Explicit enforcement mode ("strict" or "warn"). Falls back to
+            the shared environment resolution (``MNEME_HOOK_MODE``, then
+            "strict").
+        check_runner: Test seam. Defaults to ``subprocess.run``.
+    """
+
+    def __init__(
+        self,
+        project_dir: str | Path = ".",
+        memory: str | Path | None = None,
+        mode: Optional[str] = None,
+        check_runner: Optional[CheckRunner] = None,
+    ) -> None:
+        self.project_dir = str(project_dir)
+        self._memory_override = str(memory) if memory else None
+        self._mode_override = mode
+        self._check_runner = check_runner or subprocess.run
+
+    # ── Context path (pre_llm_call) ──────────────────────────────────────────
+
+    def context_for_turn(self, query: str) -> ContextInjection:
+        """Retrieve relevant decisions via the existing retrieval path."""
+        memory = self._memory()
+        if memory is None:
+            return ContextInjection(query=query, text="", decision_ids=[], memory_path=None)
+
+        store = MemoryStore(memory)
+        store.load()
+        scored = DecisionRetriever(store.decisions()).retrieve(query)
+        text = format_decisions(scored, max_items=DEFAULT_MAX_DECISIONS)
+        ids: List[str] = []
+        seen: set[str] = set()
+        for s in scored:
+            if s.score <= 0.0 or s.decision.id in seen:
+                continue
+            seen.add(s.decision.id)
+            ids.append(s.decision.id)
+            if len(ids) >= DEFAULT_MAX_DECISIONS:
+                break
+
+        return ContextInjection(
+            query=query, text=text, decision_ids=ids, memory_path=str(memory)
+        )
+
+    # ── Enforcement path (pre_tool_call) ─────────────────────────────────────
+
+    def evaluate_tool_call(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        cwd: str = "",
+    ) -> GateResult:
+        """Evaluate one proposed Hermes tool call through the existing path."""
+        args = args if isinstance(args, dict) else {}
+
+        if tool_name == "write_file":
+            return self._gate_event(self._write_file_event(args, cwd))
+
+        if tool_name == "patch":
+            patch_mode = args.get("mode", "replace")
+            if patch_mode == "replace":
+                return self._gate_event(self._patch_replace_event(args, cwd))
+            if patch_mode == "patch":
+                return self._gate_v4a_patch(args.get("patch", ""), cwd)
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                tool_name,
+                "",
+                f"mneme-hermes: unknown patch mode {patch_mode!r}, failing open",
+            )
+
+        if tool_name == "terminal":
+            return self._gate_terminal(args.get("command", ""), args.get("workdir", ""), cwd)
+
+        if tool_name in HERMES_UNEVALUATED_TOOLS:
+            return self._gate(
+                ACTION_SKIP,
+                tool_name,
+                "",
+                "unevaluated mutation surface (see Hermes POC coverage matrix)",
+            )
+
+        return self._gate(ACTION_SKIP, tool_name, "", "not a checked mutating tool")
+
+    # ── Directive translation ────────────────────────────────────────────────
+
+    def pre_tool_call(self, tool_name: str = "", args: Optional[Dict] = None, **_: Any):
+        """Hermes ``pre_tool_call`` callback: returns a block directive or None.
+
+        Policy mirrors the documented integrations: only a trusted strict-mode
+        WARN/FAIL verdict blocks; warn mode and every fail-open outcome pass
+        with the reason logged by the caller (never silently).
+        """
+        result = self.evaluate_tool_call(tool_name, args or {}, cwd=self.project_dir)
+        return directive_for(result)
+
+    def pre_llm_call(self, user_message: str = "", **_: Any):
+        """Hermes ``pre_llm_call`` callback: returns {"context": ...} or None."""
+        injection = self.context_for_turn(user_message)
+        if not injection.text:
+            return None
+        return {"context": injection.text}
+
+    # ── Translation helpers (pure payload mapping) ───────────────────────────
+
+    @staticmethod
+    def _write_file_event(args: Dict[str, Any], cwd: str) -> ToolEvent:
+        file_path = str(args.get("path", ""))
+        return ToolEvent(
+            tool_name="Write",
+            file_path=file_path,
+            cwd=cwd,
+            tool_input={"file_path": file_path, "content": args.get("content", "")},
+        )
+
+    @staticmethod
+    def _patch_replace_event(args: Dict[str, Any], cwd: str) -> ToolEvent:
+        file_path = str(args.get("path", ""))
+        tool_input: Dict[str, Any] = {
+            "file_path": file_path,
+            "old_string": args.get("old_string", ""),
+            "new_string": args.get("new_string", ""),
+        }
+        if args.get("replace_all"):
+            tool_input["replace_all"] = True
+        return ToolEvent(
+            tool_name="Edit",
+            file_path=file_path,
+            cwd=cwd,
+            tool_input=tool_input,
+        )
+
+    # ── Shared gate internals ────────────────────────────────────────────────
+
+    def _memory(self):
+        if self._memory_override:
+            p = Path(self._memory_override)
+            return p if p.is_file() else None
+        return find_memory(Path(self.project_dir))
+
+    def _mode(self) -> str:
+        if self._mode_override in ("strict", "warn"):
+            return self._mode_override
+        return resolve_mode()
+
+    def _gate(
+        self,
+        action: str,
+        tool_name: str,
+        file_path: str,
+        reason: str,
+        verdict: Optional[str] = None,
+        evaluation_complete: bool = True,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> GateResult:
+        return GateResult(
+            action=action,
+            tool_name=tool_name,
+            file_path=file_path,
+            reason=reason,
+            verdict=verdict,
+            evaluation_complete=evaluation_complete,
+            payload=payload,
+        )
+
+    def _gate_event(self, event: ToolEvent) -> GateResult:
+        """Materialize + check one canonical Write/Edit event."""
+        memory = self._memory()
+        if memory is None:
+            # Same policy as every other integration: outside any governed
+            # project, the gate has no opinion.
+            return self._gate(ACTION_SKIP, event.tool_name, event.file_path, "no project memory")
+
+        try:
+            checked_content = introduced_content(event)
+        except MaterializeError as e:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                event.tool_name,
+                event.file_path,
+                f"mneme-hermes: cannot materialize content, failing open: {e}",
+            )
+
+        return self._check_introduced(
+            event.tool_name, event.file_path, checked_content, memory
+        )
+
+    def _check_introduced(
+        self,
+        tool_label: str,
+        file_path: str,
+        checked_content: str,
+        memory: Path,
+    ) -> GateResult:
+        if not checked_content.strip():
+            return self._gate(
+                ACTION_SKIP, tool_label, file_path, "no non-blank introduced lines"
+            )
+
+        mode = self._mode()
+        proc = self._run_check(file_path, checked_content, memory, mode)
+
+        if proc is None:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                tool_label,
+                file_path,
+                "mneme-hermes: could not run mneme check. Failing open.",
+            )
+
+        payload = parse_verdict(proc.stdout)
+        if payload is None:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                tool_label,
+                file_path,
+                "mneme-hermes: no parseable verdict from mneme check "
+                f"(exit {proc.returncode}). Failing open.",
+            )
+
+        verdict = payload["verdict"]
+        if payload.get("evaluation_complete") is False:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                tool_label,
+                file_path,
+                format_applicability_reason(payload),
+                verdict=verdict,
+                evaluation_complete=False,
+                payload=payload,
+            )
+
+        if verdict == "PASS":
+            return self._gate(
+                ACTION_ALLOW, tool_label, file_path, "", verdict=verdict, payload=payload
+            )
+
+        reason = format_reason(payload)
+        if mode == "warn":
+            return self._gate(
+                ACTION_WARN, tool_label, file_path, reason, verdict=verdict, payload=payload
+            )
+        return self._gate(
+            ACTION_DENY, tool_label, file_path, reason, verdict=verdict, payload=payload
+        )
+
+    def _run_check(self, file_path: str, content: str, memory: Path, mode: str):
+        """Run `mneme check` exactly as the existing integrations do."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as tf:
+            tf.write(content)
+            input_path = tf.name
+
+        rel = file_path or "(unknown)"
+        target_path = file_path
+        if target_path and not Path(target_path).is_absolute():
+            target_path = str(Path(self.project_dir) / target_path)
+
+        command = [
+            sys.executable, "-m", "mneme", "check",
+            "--memory", str(memory),
+            "--input", input_path,
+            "--query", f"edit to {rel}",
+            "--mode", mode,
+            "--json",
+        ]
+        if target_path:
+            command.extend(["--target-path", target_path])
+
+        try:
+            return self._check_runner(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_CHECK_TIMEOUT_SECONDS,
+                env=_child_env(),
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        finally:
+            try:
+                os.unlink(input_path)
+            except OSError:
+                pass
+
+    # ── V4A multi-file patches (patch tool, mode="patch") ────────────────────
+
+    def _gate_v4a_patch(self, patch_text: str, cwd: str) -> GateResult:
+        """Evaluate a V4A patch via the frozen Codex CLI transport parser."""
+        memory = self._memory()
+        if memory is None:
+            return self._gate(ACTION_SKIP, "patch", "", "no project memory")
+
+        base = Path(cwd or self.project_dir)
+
+        def resolve(raw: str) -> Path:
+            p = Path(raw)
+            return p if p.is_absolute() else base / raw
+
+        try:
+            specs = patch_operation_specs(patch_text)
+        except CodexPatchParseError as e:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                "patch",
+                "",
+                f"mneme-hermes: unparseable V4A patch, failing open: {e}",
+            )
+
+        snapshots: Dict[str, Optional[str]] = {}
+        for kind, raw_path in specs:
+            if kind != "update":
+                continue
+            target = resolve(raw_path)
+            try:
+                snapshots[raw_path] = target.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                # Snapshot explicitly unavailable: the operation is reported
+                # as unevaluated rather than guessed at.
+                snapshots[raw_path] = None
+
+        try:
+            operations = parse_patch_operations(patch_text, snapshots)
+        except CodexPatchParseError as e:
+            return self._gate(
+                ACTION_FAIL_OPEN,
+                "patch",
+                "",
+                f"mneme-hermes: V4A patch could not be validated against "
+                f"current files, failing open: {e}",
+            )
+
+        worst: Optional[GateResult] = None
+        for op in operations:
+            if op.kind == "delete":
+                continue  # pure deletion introduces nothing new (ADR-018)
+            target_abs = str(resolve(op.target_path))
+            if op.introduced_content is None:
+                # Snapshot explicitly unavailable: disclosed as unevaluated,
+                # never guessed at.
+                result = self._gate(
+                    ACTION_FAIL_OPEN,
+                    "patch",
+                    target_abs,
+                    "mneme-hermes: update snapshot unavailable; operation unevaluated",
+                )
+            else:
+                result = self._check_introduced(
+                    "patch", target_abs, op.introduced_content, memory
+                )
+            if result.action == ACTION_DENY:
+                return result
+            if result.action in (ACTION_WARN, ACTION_FAIL_OPEN):
+                worst = result
+        return worst or self._gate(ACTION_ALLOW, "patch", "", "", verdict="PASS")
+
+    # ── Terminal preflight (ADR-021 class A only) ────────────────────────────
+
+    def _gate_terminal(self, command: str, workdir: str, cwd: str) -> GateResult:
+        rec = reconstruct_heredoc_write(command)
+        if rec is None:
+            cls = classify_command(command)
+            value = cls.value if isinstance(cls, Classification) else str(cls)
+            return self._gate(
+                ACTION_SKIP,
+                "terminal",
+                "",
+                f"classified {value}: no deterministic pre-execution check "
+                "(no session-delta backstop exists in Hermes)",
+            )
+
+        memory = self._memory()
+        if memory is None:
+            return self._gate(ACTION_SKIP, "terminal", rec.target_path, "no project memory")
+
+        base = workdir or cwd or self.project_dir
+        target_abs = rec.target_path
+        if not Path(target_abs).is_absolute():
+            target_abs = str(Path(base) / target_abs)
+
+        try:
+            current = Path(target_abs).read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            current = ""
+        proposed = current + rec.proposed_content if rec.append else rec.proposed_content
+        checked = introduced_between(current, proposed)
+        return self._check_introduced("terminal", target_abs, checked, memory)
+
+
+def directive_for(result: GateResult) -> Optional[Dict[str, str]]:
+    """Translate a gate outcome into a Hermes ``pre_tool_call`` directive.
+
+    Only DENY produces a directive — an explicit ``{"action": "approve"}``
+    would escalate to human approval and weaken Hermes' own permission flow,
+    so PASS/skip/warn/fail-open stay silent (None) exactly like Antigravity's
+    deny-only policy. Hermes requires a non-empty message on block.
+    """
+    if result.action == ACTION_DENY:
+        message = result.reason or f"blocked by mneme ({result.tool_name})"
+        return {"action": "block", "message": message}
+    return None
+
+
+__all__ = [
+    "MnemeHermes",
+    "ContextInjection",
+    "GateResult",
+    "directive_for",
+    "ACTION_ALLOW",
+    "ACTION_DENY",
+    "ACTION_WARN",
+    "ACTION_FAIL_OPEN",
+    "ACTION_SKIP",
+    "HERMES_MUTATING_TOOLS",
+    "HERMES_SHELL_TOOLS",
+    "HERMES_UNEVALUATED_TOOLS",
+]

--- a/mneme/integrations/hermes/plugin.py
+++ b/mneme/integrations/hermes/plugin.py
@@ -1,0 +1,93 @@
+"""Hermes plugin wiring for the Mneme integration.
+
+This module contains no governance logic: it only binds
+:class:`mneme.integrations.hermes.adapter.MnemeHermes` to Hermes' plugin
+hook contract and translates gate outcomes to directives.
+
+Install (POC): copy ``integrations/hermes-plugin/`` from this repository
+to ``<project>/.hermes/plugins/mneme/``, enable project plugins
+(``HERMES_ENABLE_PROJECT_PLUGINS=true``) and the plugin itself
+(``plugins.enabled: [mneme]`` in Hermes config), and make the ``mneme``
+package importable from Hermes' Python environment.
+
+The plugin is fail-open by construction: Hermes swallows hook exceptions,
+and :func:`mneme.integrations.hermes.adapter.directive_for` emits a block
+directive only for a trusted strict-mode WARN/FAIL verdict.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from mneme.integrations.hermes.adapter import (
+    ACTION_FAIL_OPEN,
+    ACTION_WARN,
+    GateResult,
+    MnemeHermes,
+    directive_for,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _log_unevaluated(result: GateResult) -> None:
+    """Fail-open outcomes must be visible, never silent."""
+    if not result.reason:
+        return
+    if result.action == ACTION_WARN:
+        logger.warning(
+            "[mneme] WARN - architectural decision flagged (warn mode; "
+            "not blocked):\n%s",
+            result.reason,
+        )
+    elif result.action == ACTION_FAIL_OPEN:
+        logger.warning(
+            "[mneme] UNEVALUATED - failing open, this mutation was NOT "
+            "checked:\n%s",
+            result.reason,
+        )
+
+
+def make_gate(project_dir: Optional[str] = None, **kwargs: Any) -> MnemeHermes:
+    return MnemeHermes(project_dir=project_dir or os.getcwd(), **kwargs)
+
+
+def on_pre_tool_call(gate: MnemeHermes, tool_name: str = "", args: Optional[Dict] = None, **_: Any):
+    """``pre_tool_call`` hook: block directive for trusted violations."""
+    try:
+        result = gate.evaluate_tool_call(tool_name, args or {}, cwd=gate.project_dir)
+    except Exception as exc:  # pragma: no cover - defensive mirror of policy
+        logger.warning("mneme-hermes: gate error, failing open: %s", exc)
+        return None
+    _log_unevaluated(result)
+    return directive_for(result)
+
+
+def on_pre_llm_call(gate: MnemeHermes, user_message: str = "", **_: Any):
+    """``pre_llm_call`` hook: inject retrieved decisions as context."""
+    try:
+        return gate.pre_llm_call(user_message=user_message)
+    except Exception as exc:
+        logger.warning("mneme-hermes: context retrieval failed: %s", exc)
+        return None
+
+
+def register(ctx, gate: Optional[MnemeHermes] = None) -> None:
+    """Hermes plugin entry point.
+
+    ``gate`` is a test seam; production callers get the default constructor
+    bound to the process working directory.
+    """
+    gate = gate or make_gate()
+    ctx.register_hook("pre_tool_call", lambda **kw: on_pre_tool_call(gate, **kw))
+    ctx.register_hook("pre_llm_call", lambda **kw: on_pre_llm_call(gate, **kw))
+
+
+__all__ = [
+    "register",
+    "make_gate",
+    "on_pre_tool_call",
+    "on_pre_llm_call",
+]

--- a/tests/integrations/hermes/test_adapter_context.py
+++ b/tests/integrations/hermes/test_adapter_context.py
@@ -1,0 +1,62 @@
+"""H1 context-injection tests: pre_llm_call through the existing retrieval path."""
+
+import json
+
+import pytest
+
+from mneme.integrations.hermes.adapter import MnemeHermes
+
+
+@pytest.fixture()
+def governed(tmp_path):
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(
+        json.dumps(
+            {
+                "meta": {
+                    "name": "fixture",
+                    "description": "test project memory",
+                },
+                "version": 1,
+                "decisions": [
+                    {
+                        "id": "D-DB-1",
+                        "decision": "PostgreSQL via psycopg2 is the only approved storage layer",
+                        "rationale": "one canonical persistence path",
+                        "scope": ["database", "storage"],
+                        "rules": [{"type": "FORBID_LITERAL", "value": "import redis"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return mem
+
+
+class TestContextForTurn:
+    def test_injects_retrieved_decisions(self, tmp_path, governed):
+        gate = MnemeHermes(project_dir=tmp_path)
+        injection = gate.context_for_turn("which storage backend for the session cache?")
+        assert "[Mneme decisions applied]" in injection.text
+        assert injection.decision_ids == ["D-DB-1"]
+        assert injection.memory_path.endswith("project_memory.json")
+
+    def test_pre_llm_call_returns_hermes_context_shape(self, tmp_path, governed):
+        gate = MnemeHermes(project_dir=tmp_path)
+        payload = gate.pre_llm_call(user_message="database layer question")
+        assert isinstance(payload, dict)
+        assert set(payload) == {"context"}
+        assert "[Mneme decisions applied]" in payload["context"]
+
+    def test_irrelevant_query_injects_nothing(self, tmp_path):
+        gate = MnemeHermes(project_dir=tmp_path)
+        # Lexical retrieval scores zero; format_decisions returns "".
+        payload = gate.pre_llm_call(user_message="zzz qqq xxx")
+        assert payload is None
+
+    def test_no_project_memory_injects_nothing(self, tmp_path):
+        gate = MnemeHermes(project_dir=tmp_path / "empty")
+        payload = gate.pre_llm_call(user_message="anything")
+        assert payload is None

--- a/tests/integrations/hermes/test_adapter_gate.py
+++ b/tests/integrations/hermes/test_adapter_gate.py
@@ -1,0 +1,340 @@
+"""H2 enforcement tests: Hermes payloads through the shared Mneme check path."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mneme.integrations.hermes import adapter
+from mneme.integrations.hermes.adapter import ACTION_DENY, ACTION_SKIP, MnemeHermes, directive_for
+
+
+def _verdict(verdict="FAIL", evaluation_complete=True):
+    stdout = json.dumps(
+        {
+            "schema": "mneme.check/v1",
+            "verdict": verdict,
+            "mode": "strict",
+            "evaluation_complete": evaluation_complete,
+            "violations": (
+                [
+                    {
+                        "decision_id": "D1",
+                        "decision_text": "never do the bad thing",
+                        "severity": "FAIL",
+                        "rule": "no forbidden token",
+                        "trigger": "FORBIDDEN_TOKEN",
+                        "kind": "literal",
+                        "rule_type": "FORBID_LITERAL",
+                        "input_path": "",
+                        "selector": "",
+                    }
+                ]
+                if verdict != "PASS"
+                else []
+            ),
+            "applicability": [],
+            "freshness": [],
+        }
+    )
+    if not evaluation_complete:
+        stdout = json.dumps(
+            {
+                "schema": "mneme.check/v1",
+                "verdict": "WARN",
+                "mode": "strict",
+                "evaluation_complete": False,
+                "violations": [],
+                "applicability": [
+                    {
+                        "decision_id": "D2",
+                        "rule_type": "FORBID_LITERAL",
+                        "rule_value": "X",
+                        "outcome": "UNKNOWN",
+                        "reason": "path applicability unknown",
+                    }
+                ],
+                "freshness": [],
+            }
+        )
+    return SimpleNamespace(returncode=2 if verdict != "PASS" else 0, stdout=stdout, stderr="")
+
+
+@pytest.fixture()
+def gate(tmp_path, monkeypatch):
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "decisions": [
+                    {
+                        "id": "D1",
+                        "decision": "never do the bad thing",
+                        "rules": [{"type": "FORBID_LITERAL", "value": "FORBIDDEN_TOKEN"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(adapter, "find_memory", lambda start: mem)
+    return MnemeHermes(project_dir=str(tmp_path))
+
+
+def _runner(result=None, error=None):
+    def run(*args, **kwargs):
+        if error is not None:
+            raise error
+        return result
+
+    return run
+
+
+class TestWriteFileGate:
+    def test_violating_write_denies_with_block_directive(self, tmp_path, gate):
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call(
+            "write_file",
+            {"path": str(tmp_path / "new.py"), "content": "x = FORBIDDEN_TOKEN\n"},
+            cwd=str(tmp_path),
+        )
+        assert result.action == ACTION_DENY
+        assert "FORBIDDEN_TOKEN" in result.reason
+        assert directive_for(result) == {"action": "block", "message": result.reason}
+
+    def test_compliant_write_passes_without_directive(self, tmp_path, gate):
+        gate._check_runner = _runner(_verdict("PASS"))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "new.py"), "content": "ok = True\n"},
+            cwd=str(tmp_path),
+        )
+        assert result.action == adapter.ACTION_ALLOW
+        assert directive_for(result) is None
+
+    def test_pre_tool_call_hook_emits_block(self, tmp_path, gate):
+        gate._check_runner = _runner(_verdict("FAIL"))
+        payload = gate.pre_tool_call(
+            tool_name="write_file",
+            args={"path": str(tmp_path / "new.py"), "content": "FORBIDDEN_TOKEN\n"},
+        )
+        assert payload["action"] == "block"
+        assert payload["message"]
+
+
+class TestPatchReplaceGate:
+    def test_replacement_introducing_violation_is_caught(self, tmp_path, gate):
+        target = tmp_path / "svc.py"
+        target.write_text("def f():\n    return 1\n", encoding="utf-8")
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "return 1",
+                "new_string": "return FORBIDDEN_TOKEN",
+            },
+            cwd=str(tmp_path),
+        )
+        assert result.action == ACTION_DENY
+
+    def test_unmatched_old_string_fails_open(self, tmp_path, gate):
+        target = tmp_path / "svc.py"
+        target.write_text("a = 1\n", encoding="utf-8")
+        seen = {}
+
+        def runner(command, **kwargs):
+            seen["called"] = True
+            return _verdict("PASS")
+
+        gate._check_runner = runner
+        result = gate.evaluate_tool_call(
+            "patch",
+            {"mode": "replace", "path": str(target), "old_string": "NOPE", "new_string": "x"},
+            cwd=str(tmp_path),
+        )
+        assert result.action == adapter.ACTION_FAIL_OPEN
+        assert "called" not in seen
+
+
+class TestV4APatchGate:
+    def test_add_file_operation_is_checked(self, tmp_path, gate):
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Add File: probe_target.py\n"
+            "+x = FORBIDDEN_TOKEN\n"
+            "*** End Patch"
+        )
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call("patch", {"mode": "patch", "patch": patch_text},
+                                        cwd=str(tmp_path))
+        assert result.action == ACTION_DENY
+        assert result.file_path.endswith("probe_target.py")
+
+    def test_update_file_uses_current_snapshot(self, tmp_path, gate):
+        target = tmp_path / "svc.py"
+        target.write_text("def existing():\n    return 1\n", encoding="utf-8")
+        patch_text = (
+            "*** Begin Patch\n"
+            f"*** Update File: {target}\n"
+            "@@\n"
+            " def existing():\n"
+            "-    return 1\n"
+            "+    return FORBIDDEN_TOKEN\n"
+            "*** End Patch"
+        )
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call("patch", {"mode": "patch", "patch": patch_text},
+                                        cwd=str(tmp_path))
+        assert result.action == ACTION_DENY
+
+    def test_delete_only_patch_introduces_nothing(self, tmp_path, gate):
+        patch_text = "*** Begin Patch\n*** Delete File: gone.py\n*** End Patch"
+
+        def runner(command, **kwargs):
+            raise AssertionError("check must not run for a pure deletion")
+
+        gate._check_runner = runner
+        result = gate.evaluate_tool_call("patch", {"mode": "patch", "patch": patch_text},
+                                        cwd=str(tmp_path))
+        assert result.action == adapter.ACTION_ALLOW
+
+    def test_unparseable_patch_fails_open(self, gate):
+        result = gate.evaluate_tool_call(
+            "patch", {"mode": "patch", "patch": "*** Begin Patch\n*** Nonsense\n"}, cwd="."
+        )
+        assert result.action == adapter.ACTION_FAIL_OPEN
+        assert "unparseable" in result.reason
+
+    def test_missing_update_snapshot_is_disclosed_not_guessed(self, tmp_path, gate):
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Update File: does_not_exist.py\n"
+            "@@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch"
+        )
+
+        def runner(command, **kwargs):
+            # The unevaluated operation must fail open before any check runs.
+            raise AssertionError("no check should run on an unavailable snapshot")
+
+        gate._check_runner = runner
+        result = gate.evaluate_tool_call("patch", {"mode": "patch", "patch": patch_text},
+                                        cwd=str(tmp_path))
+        assert result.action == adapter.ACTION_FAIL_OPEN
+        assert "unevaluated" in result.reason
+
+
+class TestTerminalPreflight:
+    def test_class_a_heredoc_write_is_checked(self, tmp_path, gate):
+        command = f"cat > {tmp_path / 'out.txt'} << 'EOF'\nFORBIDDEN_TOKEN\nEOF"
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call("terminal", {"command": command}, cwd=str(tmp_path))
+        assert result.action == ACTION_DENY
+
+    def test_non_heredoc_command_passes_unevaluated(self, tmp_path, gate):
+        def runner(command, **kwargs):
+            raise AssertionError("class B/C commands must not be checked pre-execution")
+
+        gate._check_runner = runner
+        result = gate.evaluate_tool_call(
+            "terminal", {"command": "echo FORBIDDEN_TOKEN > leak.txt"}, cwd=str(tmp_path)
+        )
+        assert result.action == ACTION_SKIP
+        assert "classified" in result.reason
+
+    def test_workdir_used_for_relative_targets(self, tmp_path, gate):
+        workdir = tmp_path / "sub"
+        workdir.mkdir()
+        command = "cat > out.txt << 'EOF'\nFORBIDDEN_TOKEN\nEOF"
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call(
+            "terminal", {"command": command, "workdir": str(workdir)}, cwd=str(tmp_path)
+        )
+        assert result.action == ACTION_DENY
+        assert result.file_path == str(workdir / "out.txt")
+
+
+class TestUnevaluatedSurfaces:
+    @pytest.mark.parametrize("tool,args", [
+        ("execute_code", {"code": "open('x.py','w').write('FORBIDDEN_TOKEN')"}),
+        ("process", {"command": "python gen.py", "action": "start"}),
+        ("read_file", {"path": "x"}),
+    ])
+    def test_never_claims_governance_over_bypass_surfaces(self, gate, tool, args):
+        result = gate.evaluate_tool_call(tool, args, cwd=".")
+        assert result.action == ACTION_SKIP
+
+
+class TestFailureSemantics:
+    def test_check_launch_failure_fails_open(self, tmp_path, gate):
+        gate._check_runner = _runner(error=OSError("no interpreter"))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "n.py"), "content": "x\n"}, cwd=str(tmp_path)
+        )
+        assert result.action == adapter.ACTION_FAIL_OPEN
+
+    def test_unparseable_verdict_fails_open(self, tmp_path, gate):
+        gate._check_runner = _runner(SimpleNamespace(returncode=1, stdout="boom", stderr=""))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "n.py"), "content": "x\n"}, cwd=str(tmp_path)
+        )
+        assert result.action == adapter.ACTION_FAIL_OPEN
+
+    def test_incomplete_evaluation_fails_open(self, tmp_path, gate):
+        gate._check_runner = _runner(_verdict(evaluation_complete=False))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "n.py"), "content": "x\n"}, cwd=str(tmp_path)
+        )
+        assert result.action == adapter.ACTION_FAIL_OPEN
+        assert result.evaluation_complete is False
+
+    def test_no_project_memory_has_no_opinion(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(adapter, "find_memory", lambda start: None)
+        gate = MnemeHermes(project_dir=str(tmp_path))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": "x.py", "content": "FORBIDDEN_TOKEN\n"}, cwd=str(tmp_path)
+        )
+        assert result.action == ACTION_SKIP
+
+
+class TestModeSemantics:
+    def test_warn_mode_flags_but_does_not_block(self, tmp_path, gate, monkeypatch):
+        monkeypatch.setenv("MNEME_HOOK_MODE", "warn")
+        gate._check_runner = _runner(_verdict("FAIL"))
+        result = gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "n.py"), "content": "x\n"}, cwd=str(tmp_path)
+        )
+        assert result.action == adapter.ACTION_WARN
+        assert directive_for(result) is None
+
+    def test_strict_is_default(self, tmp_path, gate, monkeypatch):
+        monkeypatch.delenv("MNEME_HOOK_MODE", raising=False)
+        seen = {}
+        gate._check_runner = lambda command, **kw: seen.update(
+            mode=command[command.index("--mode") + 1]
+        ) or _verdict("PASS")
+        gate.evaluate_tool_call(
+            "write_file", {"path": str(tmp_path / "n.py"), "content": "x\n"}, cwd=str(tmp_path)
+        )
+        assert seen["mode"] == "strict"
+
+
+class TestCheckInvocation:
+    def test_invokes_shared_cli_contract(self, tmp_path, gate):
+        seen = {}
+        gate._check_runner = lambda command, **kwargs: seen.update(
+            command=command, **kwargs
+        ) or _verdict("PASS")
+        path = str(tmp_path / "n.py")
+        gate.evaluate_tool_call("write_file", {"path": path, "content": "x\n"}, cwd=str(tmp_path))
+        cmd = seen["command"]
+        assert cmd[1:3] == ["-m", "mneme"]
+        assert "--json" in cmd
+        assert "--target-path" in cmd
+        assert path in cmd
+        assert seen["timeout"] == adapter._CHECK_TIMEOUT_SECONDS

--- a/tests/integrations/hermes/test_hook_e2e.py
+++ b/tests/integrations/hermes/test_hook_e2e.py
@@ -1,0 +1,55 @@
+"""End-to-end: Hermes payload -> adapter -> real `mneme check` subprocess.
+
+No fakes: exercises the identical CLI contract the Claude Code hook uses.
+"""
+
+import json
+
+import pytest
+
+from mneme.integrations.hermes.adapter import ACTION_ALLOW, ACTION_DENY, MnemeHermes
+
+
+@pytest.fixture()
+def governed(tmp_path):
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(
+        json.dumps(
+            {
+                "meta": {"name": "fixture", "description": "test project memory"},
+                "version": 1,
+                "decisions": [
+                    {
+                        "id": "D1",
+                        "decision": "never do the bad thing",
+                        "scope": ["storage"],
+                        "rules": [{"type": "FORBID_LITERAL", "value": "FORBIDDEN_TOKEN"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_forbidden_write_blocks_end_to_end(governed):
+    gate = MnemeHermes(project_dir=str(governed))
+    result = gate.evaluate_tool_call(
+        "write_file",
+        {"path": str(governed / "new.py"), "content": "x = FORBIDDEN_TOKEN\n"},
+        cwd=str(governed),
+    )
+    assert result.action == ACTION_DENY
+    assert "D1" in result.reason
+
+
+def test_compliant_write_passes_end_to_end(governed):
+    gate = MnemeHermes(project_dir=str(governed))
+    result = gate.evaluate_tool_call(
+        "write_file",
+        {"path": str(governed / "new.py"), "content": "clean = True\n"},
+        cwd=str(governed),
+    )
+    assert result.action == ACTION_ALLOW

--- a/tests/integrations/hermes/test_integration_identity.py
+++ b/tests/integrations/hermes/test_integration_identity.py
@@ -1,0 +1,75 @@
+"""Integration-identity tests: the Hermes adapter must reuse, not copy, Mneme.
+
+Mirrors tests/integrations/agent_sdk/test_integration_identity.py: pins that
+the adapter imports the shared semantics and implements no retrieval,
+matching, or scoring logic of its own.
+"""
+
+import ast
+from pathlib import Path
+
+ADAPTER = (
+    Path(__file__).resolve().parents[3] / "mneme" / "integrations" / "hermes" / "adapter.py"
+)
+
+# Symbols that ARE the existing semantics. The adapter must import them,
+# never redefine them.
+REQUIRED_IMPORTS = [
+    "introduced_content",
+    "introduced_between",
+    "find_memory",
+    "resolve_mode",
+    "parse_verdict",
+    "format_reason",
+    "format_applicability_reason",
+    "DecisionRetriever",
+    "format_decisions",
+    "MemoryStore",
+    "reconstruct_heredoc_write",
+    "classify_command",
+    "parse_patch_operations",
+]
+
+
+def test_adapter_imports_existing_semantics():
+    source = ADAPTER.read_text(encoding="utf-8")
+    for name in REQUIRED_IMPORTS:
+        assert name in source, f"adapter must reuse {name} from core"
+
+
+def test_adapter_defines_no_matching_or_scoring_logic():
+    """No tokenization/scoring/matching reimplementation may appear."""
+    tree = ast.parse(ADAPTER.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            names.add(f"re.{node.func.attr}")
+    for token in ("SequenceMatcher", "get_opcodes"):
+        assert token not in names, f"duplicated diff/matching logic: {token}"
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "import re" not in src, "adapter must not do regex rule matching"
+    for bad in ("weight", "stopword"):
+        assert bad not in src, f"duplicated retrieval scoring: {bad}"
+
+
+def test_claude_code_hook_module_untouched_surface():
+    """The Claude Code hook keeps its own entry points and constants."""
+    from mneme.integrations.claude_code import hook
+
+    for attr in (
+        "main",
+        "cli_main",
+        "parse_event",
+        "should_check",
+        "materialize_proposed_content",
+        "introduced_content",
+        "find_memory",
+        "resolve_mode",
+        "parse_verdict",
+        "format_reason",
+    ):
+        assert hasattr(hook, attr), f"hook surface changed: {attr}"

--- a/tests/integrations/hermes/test_plugin_wiring.py
+++ b/tests/integrations/hermes/test_plugin_wiring.py
@@ -1,0 +1,80 @@
+"""Hermes plugin wiring tests: hooks bind to the gate and translate directives."""
+
+from mneme.integrations.hermes import plugin
+from mneme.integrations.hermes.adapter import GateResult, MnemeHermes
+
+
+class _FakeCtx:
+    def __init__(self):
+        self.hooks = {}
+
+    def register_hook(self, name, callback):
+        self.hooks.setdefault(name, []).append(callback)
+
+
+def _denied_result():
+    return GateResult(
+        action="deny", tool_name="write_file", file_path="x.py", reason="violation report"
+    )
+
+
+def test_register_binds_both_hooks(tmp_path):
+    ctx = _FakeCtx()
+    gate = MnemeHermes(project_dir=str(tmp_path))
+    plugin.register(ctx, gate=gate)
+    assert set(ctx.hooks) == {"pre_tool_call", "pre_llm_call"}
+    assert len(ctx.hooks["pre_tool_call"]) == 1
+    assert len(ctx.hooks["pre_llm_call"]) == 1
+
+
+def test_pre_tool_hook_returns_block_for_denied_mutation(tmp_path):
+    ctx = _FakeCtx()
+    gate = MnemeHermes(project_dir=str(tmp_path))
+    plugin.register(ctx, gate=gate)
+
+    calls = {}
+
+    def fake_evaluate(tool_name, args, cwd=""):
+        calls["tool"] = tool_name
+        return _denied_result()
+
+    gate.evaluate_tool_call = fake_evaluate
+    directive = ctx.hooks["pre_tool_call"][0](
+        tool_name="write_file", args={"path": "x.py", "content": "y"}
+    )
+    assert calls["tool"] == "write_file"
+    assert directive == {"action": "block", "message": "violation report"}
+
+
+def test_pre_tool_hook_fails_open_on_gate_crash():
+    gate = MnemeHermes(project_dir=".")
+
+    def boom(*a, **kw):
+        raise RuntimeError("exploded")
+
+    gate.evaluate_tool_call = boom
+    directive = plugin.on_pre_tool_call(gate, tool_name="write_file", args={})
+    assert directive is None
+
+
+def test_warn_and_fail_open_never_emit_directives(caplog):
+    warn = GateResult(action="warn", tool_name="write_file", file_path="", reason="flagged")
+    unevaluated = GateResult(
+        action="fail_open", tool_name="write_file", file_path="", reason="not checked"
+    )
+    assert plugin.directive_for(warn) is None
+    with caplog.at_level("WARNING", logger="mneme.integrations.hermes.plugin"):
+        assert plugin._log_unevaluated(warn) is None
+        assert plugin._log_unevaluated(unevaluated) is None
+    assert "warn mode" in caplog.text
+    assert "NOT" in caplog.text
+
+
+def test_directive_for_requires_block_message_semantics():
+    from mneme.integrations.hermes.adapter import directive_for
+
+    result = GateResult(action="deny", tool_name="terminal", file_path="", reason="")
+    payload = directive_for(result)
+    # Hermes ignores a block without a message; adapter must always supply one.
+    assert payload["action"] == "block"
+    assert payload["message"]


### PR DESCRIPTION
## Summary

Adds the Hermes Agent (Nous Research) as an **experimental** integration, per the H0-H4 POC workstream. Transport translation only - no retrieval, applicability, conflict, or enforcement semantics change.

- **H1 context injection**: `pre_llm_call` -> existing `MemoryStore -> DecisionRetriever -> format_decisions` -> `{context: ...}` returned to Hermes.
- **H2 pre-tool enforcement**: `pre_tool_call` for `write_file` / `patch` (replace + V4A via the frozen Codex parser) and `terminal` class-A heredoc writes, funneled through the unchanged `mneme check` path; strict WARN/FAIL emits Hermes `{action: block}`.
- **H3 coverage matrix** (docs/integrations/hermes.md): explicitly documents bypass surfaces (`terminal` non-class-A forms, `execute_code`, `process`) and the **absent catch tier** - Hermes has no blocking Stop-equivalent, so ADR-021 prevent->catch->verify parity is NOT claimed.
- **H4 validation**: 37 new tests (+ identity test pinning reuse-not-copy), full suite 981 passed / 5 skipped, frozen enforcement benchmark unchanged at **7/7**, zero frozen-core changes.

H0 evidence was captured against hermes-agent 0.19.0 through Hermes' real plugin-manager dispatch (`invoke_hook` / `resolve_pre_tool_block`), not documentation assumptions. Provider-backed live-session replay is a promotion/parity gate, deliberately not a prerequisite for this experimental adapter.

Scope guard: no changes to `DecisionRetriever`, conflict detection, enforcer semantics, typed rules, path applicability, benchmark fixtures, or any ADR.

Docs: `docs/integrations/hermes.md`, support-matrix row in `docs/integrations/README.md`, roadmap note.