### PR TITLE
feat: read-only ADR lifecycle reconciliation analyzer

### DIFF
--- a/mneme/adr_import.py
+++ b/mneme/adr_import.py
@@ -66,23 +66,24 @@ def project_decision_graph(adrs: list[ADR]) -> list[DecisionNode]:
     """Project a parsed ADR corpus into the minimal graph.
 
     Status mapping:
-      ADR.status == "accepted" AND not in any other ADR's supersedes -> "active"
-      ADR.status == "accepted" AND IS in some other ADR's supersedes -> "superseded"
+      ADR.status == "accepted" AND not in any accepted ADR's supersedes -> "active"
+      ADR.status == "accepted" AND IS in some accepted ADR's supersedes -> "superseded"
       ADR.status == "superseded" (explicit in frontmatter)            -> "superseded"
       ADR.status == "deprecated"                                       -> "deprecated"
       ADR.status == "proposed"                                         -> "inactive"
 
-    ``superseded_by`` is the id of the ADR that explicitly supersedes
-    this one, or None. If multiple ADRs claim to supersede the same
+    ``superseded_by`` is the id of the accepted ADR that explicitly supersedes
+    this one, or None. If multiple accepted ADRs claim to supersede the same
     target, the lexicographically lowest id wins (deterministic; rare
     in practice and validate_corpus catches the cycle case).
     """
     superseded_by_map: dict[str, str] = {}
     for a in adrs:
-        for ref in a.supersedes:
-            existing = superseded_by_map.get(ref)
-            if existing is None or a.id < existing:
-                superseded_by_map[ref] = a.id
+        if a.status == "accepted":
+            for ref in a.supersedes:
+                existing = superseded_by_map.get(ref)
+                if existing is None or a.id < existing:
+                    superseded_by_map[ref] = a.id
 
     out: list[DecisionNode] = []
     for a in adrs:

--- a/mneme/adr_lifecycle.py
+++ b/mneme/adr_lifecycle.py
@@ -9,23 +9,17 @@ introducing a new abstraction. New codes are module-level constants below.
 """
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-import re
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-from mneme.adr_freshness import FreshnessIssue, check_freshness
+from mneme.adr_compiler import PRIORITY_RANK, ADRPrecedenceError, _pick_within_scope
+from mneme.adr_freshness import FreshnessIssue
 from mneme.adr_import import project_decision_graph
-from mneme.adr_parser import parse_adr_file, parse_adr_directory
-from mneme.adr_compiler import resolve_precedence, ADRPrecedenceError, PRIORITY_RANK
-from mneme.adr_schema import ADRParseError
+from mneme.adr_parser import parse_adr_file
+from mneme.adr_schema import ADR, ADRParseError
 
 # ── Finding codes (extend FreshnessIssue.code vocabulary) ─────────────────────
 
-UNEXPLAINED_NUMBERING_GAP = "UNEXPLAINED_NUMBERING_GAP"
 DANGLING_SUPERSEDES = "DANGLING_SUPERSEDES"
 ORPHAN_SUPERSEDED = "ORPHAN_SUPERSEDED"
 ACTIVE_CONTRADICTION = "ACTIVE_CONTRADICTION"
@@ -34,7 +28,6 @@ LEDGER_STATUS_MISMATCH = "LEDGER_STATUS_MISMATCH"
 
 # Deterministic output order
 _CODE_ORDER = [
-    UNEXPLAINED_NUMBERING_GAP,
     DANGLING_SUPERSEDES,
     ORPHAN_SUPERSEDED,
     ACTIVE_CONTRADICTION,
@@ -42,9 +35,6 @@ _CODE_ORDER = [
     LEDGER_STATUS_MISMATCH,
 ]
 
-# ── Internal helpers ──────────────────────────────────────────────────────────
-
-_ADR_ID_PATTERN = re.compile(r"^ADR-(\d+)$")
 _SOURCE_TYPE_ADR = "adr"
 
 
@@ -60,17 +50,13 @@ def _load_raw_decisions(memory_path: Path) -> list[dict]:
     return [d for d in raw if isinstance(d, dict)]
 
 
-def _compute_source_hash(adr_path: Path) -> str:
-    return hashlib.sha256(adr_path.read_bytes()).hexdigest()
-
-
-def _scan_adr_directory_tolerant(adr_dir: Path):
+def _scan_adr_directory_tolerant(adr_dir: Path) -> tuple[list[ADR], list[tuple[Path, str]]]:
     """Parse every ADR-*.md, separating successes from failures.
 
     Returns (parsed_list, parse_errors) where parse_errors is a list of
     (path, message) tuples for files matching the glob that failed to parse.
     """
-    parsed: list = []
+    parsed: list[ADR] = []
     parse_errors: list[tuple[Path, str]] = []
     for path in sorted(adr_dir.glob("ADR-*.md")):
         try:
@@ -80,28 +66,6 @@ def _scan_adr_directory_tolerant(adr_dir: Path):
         except Exception as exc:
             parse_errors.append((path, f"unexpected parse error: {exc}"))
     return parsed, parse_errors
-
-
-def _extract_numbering_gaps(parsed: list) -> list[int]:
-    """Return sorted list of missing integer IDs between min and max present."""
-    nums: list[int] = []
-    for a in parsed:
-        m = _ADR_ID_PATTERN.match(a.id)
-        if m:
-            nums.append(int(m.group(1)))
-    if not nums:
-        return []
-    present = set(nums)
-    full = set(range(min(nums), max(nums) + 1))
-    return sorted(full - present)
-
-
-def _has_ledger_tombstone_for_gap(gap_id: str, raw_decisions: list[dict]) -> bool:
-    """Return True if ledger has a decision for the missing ADR (tombstone)."""
-    for dec in raw_decisions:
-        if dec.get("id") == gap_id:
-            return True
-    return False
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -115,9 +79,8 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
         memory_path: Path to project_memory.json.
 
     Returns:
-        List of FreshnessIssue records. May include freshness issues if
-        check_freshness is called first; here we return only lifecycle-specific
-        codes. Order is deterministic by _CODE_ORDER then by adr_id.
+        List of FreshnessIssue records.
+        Order is deterministic by _CODE_ORDER then by adr_id.
     """
     corpus_dir = Path(corpus_dir)
     memory_path = Path(memory_path)
@@ -141,11 +104,6 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
             path=str(path),
             message=message,
         ))
-
-    # UNEXPLAINED_NUMBERING_GAP: ordinary missing numbers in sequence are common
-    # and not treated as defects. Only suppressed when ledger has a record, and
-    # ordinary gaps without a ledger produce no warning.
-    # (Preserved in code vocabulary for callers that inspect index continuity).
 
     # DANGLING_SUPERSEDES (forward refs to unknown ids)
     for a in parsed:
@@ -178,29 +136,45 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
                 ),
             ))
 
-    # ACTIVE_CONTRADICTION + SILENT_PRECEDENCE_ELIMINATION
-    # resolve_precedence raises ADRPrecedenceError on the first ambiguous scope.
-    # Iterate to catch multiple scopes: on each raise, record the tie,
-    # remove the tied ids, and retry.
-    # Filter to valid accepted ADRs with known priority before calling.
+    # Independent per-scope resolution over graph-derived active ADRs:
+    # 1. Build the active set from project_decision_graph.
+    # 2. Group active ADRs by scope.
+    # 3. Resolve each scope separately.
+    # 4. Emit ACTIVE_CONTRADICTION for a tied group.
+    # 5. Emit SILENT_PRECEDENCE_ELIMINATION only when that same group has a real winner and active losers.
+    active_ids = {n.id for n in nodes if n.status == "active"}
     valid_priorities = set(PRIORITY_RANK.keys())
-    remaining = [
+    active_adrs = [
         a for a in parsed
-        if a.status == "accepted"
+        if a.id in active_ids
         and a.priority in valid_priorities
-        and a.id
         and a.date
         and a.scope != "None"
     ]
-    tied_ids: set[str] = set()
-    while True:
+
+    by_scope: dict[str, list[ADR]] = {}
+    for a in active_adrs:
+        by_scope.setdefault(a.scope, []).append(a)
+
+    for scope, group in sorted(by_scope.items()):
+        if len(group) < 2:
+            continue
         try:
-            winners = resolve_precedence(remaining)
-            break
+            winner = _pick_within_scope(scope, group)
+            for loser in sorted(group, key=lambda a: a.id):
+                if loser.id != winner.id:
+                    findings.append(FreshnessIssue(
+                        code=SILENT_PRECEDENCE_ELIMINATION,
+                        adr_id=loser.id,
+                        path=str(loser.source_path),
+                        message=(
+                            f"{loser.id} was silently eliminated by precedence in scope "
+                            f"{scope!r} (winner: {winner.id}). Both claim active status with "
+                            f"no explicit supersedes link. Add an explicit supersedes link or "
+                            f"retire one decision."
+                        ),
+                    ))
         except ADRPrecedenceError as exc:
-            for tid in exc.ids:
-                tied_ids.add(tid)
-            # Record contradiction finding
             findings.append(FreshnessIssue(
                 code=ACTIVE_CONTRADICTION,
                 adr_id=",".join(sorted(exc.ids)),
@@ -213,38 +187,6 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
                     f"explicit supersedes link."
                 ),
             ))
-            # Remove tied ids from consideration for silent-elimination scan
-            remaining = [a for a in remaining if a.id not in tied_ids]
-
-    winner_ids = {w.id for w in winners}
-
-    # SILENT_PRECEDENCE_ELIMINATION: narrow — report ONLY when:
-    # 1. both decisions claim an active status (accepted + unreferenced);
-    # 2. they overlap in scope (same scope);
-    # 3. no explicit supersession relationship exists; and
-    # 4. one disappears solely because precedence selects the other.
-    accepted_unreferenced = {
-        n.id for n in nodes
-        if n.status == "active" and n.superseded_by is None
-    }
-    silent_losers = accepted_unreferenced - winner_ids - tied_ids
-    for loser_id in sorted(silent_losers):
-        adr = next((a for a in parsed if a.id == loser_id), None)
-        src = str(adr.source_path) if adr else "unknown"
-        scope = adr.scope if adr else "unknown"
-        winner = next((w for w in winners if w.scope == scope), None)
-        winner_id = winner.id if winner else "unknown"
-        findings.append(FreshnessIssue(
-            code=SILENT_PRECEDENCE_ELIMINATION,
-            adr_id=loser_id,
-            path=src,
-            message=(
-                f"{loser_id} was silently eliminated by precedence in scope "
-                f"{scope!r} (winner: {winner_id}). Both claim active status with "
-                f"no explicit supersedes link. Add an explicit supersedes link or "
-                f"retire one decision."
-            ),
-        ))
 
     # LEDGER_STATUS_MISMATCH: ledger entries whose source ADR is non-active
     raw_decisions = _load_raw_decisions(memory_path)
@@ -291,7 +233,6 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
 
 __all__ = [
     "analyze_lifecycle",
-    "UNEXPLAINED_NUMBERING_GAP",
     "DANGLING_SUPERSEDES",
     "ORPHAN_SUPERSEDED",
     "ACTIVE_CONTRADICTION",

--- a/mneme/adr_lifecycle.py
+++ b/mneme/adr_lifecycle.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 
 from mneme.adr_compiler import PRIORITY_RANK, ADRPrecedenceError, _pick_within_scope
-from mneme.adr_freshness import FreshnessIssue
+from mneme.adr_freshness import FreshnessIssue, _id_from_filename
 from mneme.adr_import import project_decision_graph
 from mneme.adr_parser import parse_adr_file
 from mneme.adr_schema import ADR, ADRParseError
@@ -100,7 +100,7 @@ def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[F
     for path, message in parse_errors:
         findings.append(FreshnessIssue(
             code="ADR_UNPARSEABLE",
-            adr_id=path.stem,
+            adr_id=_id_from_filename(path),
             path=str(path),
             message=message,
         ))

--- a/mneme/adr_lifecycle.py
+++ b/mneme/adr_lifecycle.py
@@ -1,0 +1,300 @@
+"""
+adr_lifecycle.py — Read-only lifecycle reconciliation analyzer.
+
+Compares the on-disk ADR corpus against the imported ledger and the
+precedence-resolved active set, surfacing mismatches as warn-only findings.
+
+All findings use the existing FreshnessIssue type from adr_freshness to avoid
+introducing a new abstraction. New codes are module-level constants below.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mneme.adr_freshness import FreshnessIssue, check_freshness
+from mneme.adr_import import project_decision_graph
+from mneme.adr_parser import parse_adr_file, parse_adr_directory
+from mneme.adr_compiler import resolve_precedence, ADRPrecedenceError, PRIORITY_RANK
+from mneme.adr_schema import ADRParseError
+
+# ── Finding codes (extend FreshnessIssue.code vocabulary) ─────────────────────
+
+UNEXPLAINED_NUMBERING_GAP = "UNEXPLAINED_NUMBERING_GAP"
+DANGLING_SUPERSEDES = "DANGLING_SUPERSEDES"
+ORPHAN_SUPERSEDED = "ORPHAN_SUPERSEDED"
+ACTIVE_CONTRADICTION = "ACTIVE_CONTRADICTION"
+SILENT_PRECEDENCE_ELIMINATION = "SILENT_PRECEDENCE_ELIMINATION"
+LEDGER_STATUS_MISMATCH = "LEDGER_STATUS_MISMATCH"
+
+# Deterministic output order
+_CODE_ORDER = [
+    UNEXPLAINED_NUMBERING_GAP,
+    DANGLING_SUPERSEDES,
+    ORPHAN_SUPERSEDED,
+    ACTIVE_CONTRADICTION,
+    SILENT_PRECEDENCE_ELIMINATION,
+    LEDGER_STATUS_MISMATCH,
+]
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+_ADR_ID_PATTERN = re.compile(r"^ADR-(\d+)$")
+_SOURCE_TYPE_ADR = "adr"
+
+
+def _load_raw_decisions(memory_path: Path) -> list[dict]:
+    """Read decisions[] from memory file as raw dicts (tolerant, warn-only)."""
+    try:
+        data = json.loads(memory_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    raw = data.get("decisions") if isinstance(data, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [d for d in raw if isinstance(d, dict)]
+
+
+def _compute_source_hash(adr_path: Path) -> str:
+    return hashlib.sha256(adr_path.read_bytes()).hexdigest()
+
+
+def _scan_adr_directory_tolerant(adr_dir: Path):
+    """Parse every ADR-*.md, separating successes from failures.
+
+    Returns (parsed_list, parse_errors) where parse_errors is a list of
+    (path, message) tuples for files matching the glob that failed to parse.
+    """
+    parsed: list = []
+    parse_errors: list[tuple[Path, str]] = []
+    for path in sorted(adr_dir.glob("ADR-*.md")):
+        try:
+            parsed.append(parse_adr_file(path))
+        except ADRParseError as exc:
+            parse_errors.append((path, str(exc)))
+        except Exception as exc:
+            parse_errors.append((path, f"unexpected parse error: {exc}"))
+    return parsed, parse_errors
+
+
+def _extract_numbering_gaps(parsed: list) -> list[int]:
+    """Return sorted list of missing integer IDs between min and max present."""
+    nums: list[int] = []
+    for a in parsed:
+        m = _ADR_ID_PATTERN.match(a.id)
+        if m:
+            nums.append(int(m.group(1)))
+    if not nums:
+        return []
+    present = set(nums)
+    full = set(range(min(nums), max(nums) + 1))
+    return sorted(full - present)
+
+
+def _has_ledger_tombstone_for_gap(gap_id: str, raw_decisions: list[dict]) -> bool:
+    """Return True if ledger has a decision for the missing ADR (tombstone)."""
+    for dec in raw_decisions:
+        if dec.get("id") == gap_id:
+            return True
+    return False
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def analyze_lifecycle(corpus_dir: str | Path, memory_path: str | Path) -> list[FreshnessIssue]:
+    """
+    Read-only lifecycle reconciliation.
+
+    Args:
+        corpus_dir: Directory containing ADR-*.md files.
+        memory_path: Path to project_memory.json.
+
+    Returns:
+        List of FreshnessIssue records. May include freshness issues if
+        check_freshness is called first; here we return only lifecycle-specific
+        codes. Order is deterministic by _CODE_ORDER then by adr_id.
+    """
+    corpus_dir = Path(corpus_dir)
+    memory_path = Path(memory_path)
+
+    if not corpus_dir.is_dir():
+        return []
+    if not memory_path.is_file():
+        return []
+
+    parsed, parse_errors = _scan_adr_directory_tolerant(corpus_dir)
+    nodes = project_decision_graph(parsed)
+    parsed_ids = {a.id for a in parsed}
+
+    findings: list[FreshnessIssue] = []
+
+    # Parse errors as unparseable
+    for path, message in parse_errors:
+        findings.append(FreshnessIssue(
+            code="ADR_UNPARSEABLE",
+            adr_id=path.stem,
+            path=str(path),
+            message=message,
+        ))
+
+    # UNEXPLAINED_NUMBERING_GAP: ordinary missing numbers in sequence are common
+    # and not treated as defects. Only suppressed when ledger has a record, and
+    # ordinary gaps without a ledger produce no warning.
+    # (Preserved in code vocabulary for callers that inspect index continuity).
+
+    # DANGLING_SUPERSEDES (forward refs to unknown ids)
+    for a in parsed:
+        for ref in a.supersedes:
+            if ref not in parsed_ids:
+                findings.append(FreshnessIssue(
+                    code=DANGLING_SUPERSEDES,
+                    adr_id=a.id,
+                    path=str(a.source_path),
+                    message=(
+                        f"{a.id} supersedes unknown ADR {ref!r} — the target does "
+                        f"not exist in the corpus. Fix the reference or add the "
+                        f"missing ADR."
+                    ),
+                ))
+
+    # ORPHAN_SUPERSEDED (declared/derived superseded with no successor pointer)
+    for n in nodes:
+        if n.status == "superseded" and n.superseded_by is None:
+            adr = next((a for a in parsed if a.id == n.id), None)
+            src = str(adr.source_path) if adr else "unknown"
+            findings.append(FreshnessIssue(
+                code=ORPHAN_SUPERSEDED,
+                adr_id=n.id,
+                path=src,
+                message=(
+                    f"{n.id} is marked superseded (declared or via link) but has "
+                    f"no recorded successor (superseded_by is None). Add a "
+                    f"supersedes link from the replacing ADR or update status."
+                ),
+            ))
+
+    # ACTIVE_CONTRADICTION + SILENT_PRECEDENCE_ELIMINATION
+    # resolve_precedence raises ADRPrecedenceError on the first ambiguous scope.
+    # Iterate to catch multiple scopes: on each raise, record the tie,
+    # remove the tied ids, and retry.
+    # Filter to valid accepted ADRs with known priority before calling.
+    valid_priorities = set(PRIORITY_RANK.keys())
+    remaining = [
+        a for a in parsed
+        if a.status == "accepted"
+        and a.priority in valid_priorities
+        and a.id
+        and a.date
+        and a.scope != "None"
+    ]
+    tied_ids: set[str] = set()
+    while True:
+        try:
+            winners = resolve_precedence(remaining)
+            break
+        except ADRPrecedenceError as exc:
+            for tid in exc.ids:
+                tied_ids.add(tid)
+            # Record contradiction finding
+            findings.append(FreshnessIssue(
+                code=ACTIVE_CONTRADICTION,
+                adr_id=",".join(sorted(exc.ids)),
+                path="",
+                message=(
+                    f"Active-active contradiction at scope {exc.scope!r} between: "
+                    f"{', '.join(sorted(exc.ids))}. These accepted ADRs share the "
+                    f"same scope, priority, and date — precedence cannot break the "
+                    f"tie. Resolve by editing status/priority/date or adding an "
+                    f"explicit supersedes link."
+                ),
+            ))
+            # Remove tied ids from consideration for silent-elimination scan
+            remaining = [a for a in remaining if a.id not in tied_ids]
+
+    winner_ids = {w.id for w in winners}
+
+    # SILENT_PRECEDENCE_ELIMINATION: narrow — report ONLY when:
+    # 1. both decisions claim an active status (accepted + unreferenced);
+    # 2. they overlap in scope (same scope);
+    # 3. no explicit supersession relationship exists; and
+    # 4. one disappears solely because precedence selects the other.
+    accepted_unreferenced = {
+        n.id for n in nodes
+        if n.status == "active" and n.superseded_by is None
+    }
+    silent_losers = accepted_unreferenced - winner_ids - tied_ids
+    for loser_id in sorted(silent_losers):
+        adr = next((a for a in parsed if a.id == loser_id), None)
+        src = str(adr.source_path) if adr else "unknown"
+        scope = adr.scope if adr else "unknown"
+        winner = next((w for w in winners if w.scope == scope), None)
+        winner_id = winner.id if winner else "unknown"
+        findings.append(FreshnessIssue(
+            code=SILENT_PRECEDENCE_ELIMINATION,
+            adr_id=loser_id,
+            path=src,
+            message=(
+                f"{loser_id} was silently eliminated by precedence in scope "
+                f"{scope!r} (winner: {winner_id}). Both claim active status with "
+                f"no explicit supersedes link. Add an explicit supersedes link or "
+                f"retire one decision."
+            ),
+        ))
+
+    # LEDGER_STATUS_MISMATCH: ledger entries whose source ADR is non-active
+    raw_decisions = _load_raw_decisions(memory_path)
+    for dec in raw_decisions:
+        source = dec.get("source")
+        if not isinstance(source, dict) or source.get("type") != _SOURCE_TYPE_ADR:
+            continue
+        rel = source.get("path")
+        if not rel:
+            continue
+        adr_id = dec.get("id")
+        if not adr_id:
+            continue
+        # Resolve the source path relative to memory file parent
+        resolved = (memory_path.parent / rel).resolve()
+        if not resolved.is_file():
+            # Missing file handled by freshness.ADR_MISSING; skip to avoid dup
+            continue
+        # Find the node in our graph
+        node = next((n for n in nodes if n.id == adr_id), None)
+        if node is None:
+            # ADR not in current corpus (deleted or renamed); freshness owns this
+            continue
+        if node.status != "active":
+            # The ledger still holds this as a current decision but the ADR is
+            # no longer active. This decision remains retrievable.
+            findings.append(FreshnessIssue(
+                code=LEDGER_STATUS_MISMATCH,
+                adr_id=adr_id,
+                path=str(rel),
+                message=(
+                    f"Ledger decision {adr_id} references an ADR whose current "
+                    f"derived status is {node.status!r}, not active. The ledger "
+                    f"entry remains retrievable and enforceable. Re-import after "
+                    f"updating the ADR or retire the decision explicitly."
+                ),
+            ))
+
+    # Deterministic ordering
+    order_map = {code: i for i, code in enumerate(_CODE_ORDER)}
+    findings.sort(key=lambda f: (order_map.get(f.code, 99), f.adr_id))
+    return findings
+
+
+__all__ = [
+    "analyze_lifecycle",
+    "UNEXPLAINED_NUMBERING_GAP",
+    "DANGLING_SUPERSEDES",
+    "ORPHAN_SUPERSEDED",
+    "ACTIVE_CONTRADICTION",
+    "SILENT_PRECEDENCE_ELIMINATION",
+    "LEDGER_STATUS_MISMATCH",
+]

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -34,6 +34,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from mneme.adr_freshness import FreshnessIssue, check_freshness
+from mneme.adr_lifecycle import analyze_lifecycle
 from mneme.adr_import import (
     apply_import,
     compile_for_import,
@@ -264,6 +265,23 @@ def _check_payload(
     }
 
 
+def _collect_adr_diagnostics(
+    memory_path: str | Path,
+    adr_dir: str | Path,
+) -> list[FreshnessIssue]:
+    """Collect ADR freshness issues and lifecycle findings (warn-only)."""
+    freshness = check_freshness(memory_path=memory_path, adr_dir=adr_dir)
+    lifecycle = analyze_lifecycle(corpus_dir=adr_dir, memory_path=memory_path)
+    seen: set[tuple[str, str, str]] = set()
+    combined: list[FreshnessIssue] = []
+    for issue in freshness + lifecycle:
+        key = (issue.code, issue.adr_id, issue.path)
+        if key not in seen:
+            seen.add(key)
+            combined.append(issue)
+    return combined
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
     input_path = Path(args.input)
     if not input_path.exists():
@@ -289,8 +307,8 @@ def _cmd_check(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         # Machine-readable mode: the payload must be the only thing on stdout,
         # so the human-readable violation and freshness blocks are suppressed.
-        freshness = check_freshness(memory_path=args.memory, adr_dir=args.adr_dir)
-        print(json.dumps(_check_payload(result, freshness, args.mode)))
+        diagnostics = _collect_adr_diagnostics(memory_path=args.memory, adr_dir=args.adr_dir)
+        print(json.dumps(_check_payload(result, diagnostics, args.mode)))
         if not result.evaluation_complete:
             return 2
         return _EXIT_CODES_BY_MODE[args.mode][result.verdict]
@@ -325,13 +343,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
             )
         print()
 
-    # ADR freshness diagnostics are warn-only: they print to stdout but
-    # never influence the exit code. Skipped silently when adr_dir is
-    # absent so existing CLI output is unchanged for projects that do
-    # not use ADRs.
-    freshness = check_freshness(memory_path=args.memory, adr_dir=args.adr_dir)
-    if freshness:
-        for issue in freshness:
+    # ADR freshness and lifecycle diagnostics are warn-only: they print to
+    # stdout but never influence the exit code. Skipped silently when adr_dir
+    # is absent so existing CLI output is unchanged for projects that do not
+    # use ADRs.
+    diagnostics = _collect_adr_diagnostics(memory_path=args.memory, adr_dir=args.adr_dir)
+    if diagnostics:
+        for issue in diagnostics:
             _print_freshness_issue(issue)
         print()
 
@@ -555,8 +573,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--adr-dir", dest="adr_dir", default="docs/adr",
         help=(
             "Directory containing ADR markdown files to check for freshness "
-            "drift (warn-only; never affects exit code). "
-            "Defaults to docs/adr; freshness is skipped silently if absent."
+            "drift and lifecycle consistency (warn-only; never affects exit code). "
+            "Defaults to docs/adr; diagnostics are skipped silently if absent."
         ),
     )
     p_check.set_defaults(func=_cmd_check)

--- a/tests/test_adr_lifecycle.py
+++ b/tests/test_adr_lifecycle.py
@@ -259,6 +259,42 @@ class TestLifecycleAnalyzer:
         # ADR-001 must not re-enter to falsely eliminate ADR-004 or be reported as eliminated
         assert eliminations == [], f"Unexpected eliminations: {eliminations}"
 
+    def test_proposed_adr_does_not_retire_accepted_adr_for_contradiction_detection(self, tmp_path: Path):
+        """
+        Regression: a proposed (non-accepted) ADR declaring supersedes=[ADR-001]
+        must NOT retire accepted ADR-001.
+
+        Setup:
+          ADR-001: accepted, normal, 2026-01-01, scope 'storage'
+          ADR-002: proposed, normal, 2026-01-01, scope 'compute', supersedes: [ADR-001]
+          ADR-003: accepted, normal, 2026-01-01, scope 'storage' (ties with ADR-001)
+
+        Expected:
+          ADR-001 remains active (proposed ADR-002 cannot retire it).
+          Scope 'storage' has ADR-001 + ADR-003 tying -> ACTIVE_CONTRADICTION emitted.
+          Ledger decision for ADR-001 is still active -> NO LEDGER_STATUS_MISMATCH.
+        """
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage", date="2026-01-01")
+        _write_adr(tmp_path, "ADR-002", "proposed", "compute", date="2026-01-01", supersedes=["ADR-001"])
+        _write_adr(tmp_path, "ADR-003", "accepted", "storage", date="2026-01-01")
+        _write_ledger(tmp_path, [{
+            "id": "ADR-001",
+            "decision": "Storage choice",
+            "scope": ["storage"],
+            "constraints": [],
+            "anti_patterns": [],
+            "rules": [],
+            "source": {"type": "adr", "path": "ADR-001-test.md", "sha256": "abc"},
+        }])
+
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        contradictions = [f for f in findings if f.code == ACTIVE_CONTRADICTION]
+        mismatches = [f for f in findings if f.code == LEDGER_STATUS_MISMATCH]
+
+        assert len(contradictions) == 1
+        assert "ADR-001" in contradictions[0].adr_id and "ADR-003" in contradictions[0].adr_id
+        assert mismatches == []
+
 
 class TestFullFixture:
     """Run a multi-ADR fixture against the analyzer for smoke coverage."""

--- a/tests/test_adr_lifecycle.py
+++ b/tests/test_adr_lifecycle.py
@@ -2,27 +2,24 @@
 test_adr_lifecycle.py — Lifecycle analyzer tests.
 
 Validates finding codes, deterministic ordering, tolerant parsing,
-read-only semantics, and the stale-retrievability regression.
+read-only semantics, the stale-retrievability regression, and per-scope isolation.
 """
 from __future__ import annotations
 
 import hashlib
 import json
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from mneme.adr_lifecycle import (
     analyze_lifecycle,
-    UNEXPLAINED_NUMBERING_GAP,
     DANGLING_SUPERSEDES,
     ORPHAN_SUPERSEDED,
     ACTIVE_CONTRADICTION,
     SILENT_PRECEDENCE_ELIMINATION,
     LEDGER_STATUS_MISMATCH,
 )
-from mneme.adr_freshness import FreshnessIssue
 from mneme.decision_retriever import DecisionRetriever
 from mneme.schemas import Decision
 
@@ -103,14 +100,6 @@ def _make_3_5_stale_entry() -> dict:
 
 
 class TestLifecycleAnalyzer:
-    def test_ordinary_numbering_gap_no_warning(self, tmp_path: Path):
-        """Ordinary numbering gaps (e.g. ADR-002 never created) produce no warning."""
-        _write_adr(tmp_path, "ADR-001", "accepted", "")
-        _write_adr(tmp_path, "ADR-003", "accepted", "")
-        _write_ledger(tmp_path, [])
-        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
-        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
-
     def test_dangling_supersedes(self, tmp_path: Path):
         _write_adr(tmp_path, "ADR-001", "accepted", "", supersedes=["ADR-999"])
         _write_ledger(tmp_path, [])
@@ -176,10 +165,10 @@ class TestLifecycleAnalyzer:
         # Order respects _CODE_ORDER
         codes = [f.code for f in findings1]
         assert codes == sorted(codes, key=lambda c: [
-            UNEXPLAINED_NUMBERING_GAP, DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
+            DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
             ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION, LEDGER_STATUS_MISMATCH
         ].index(c) if c in [
-            UNEXPLAINED_NUMBERING_GAP, DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
+            DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
             ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION, LEDGER_STATUS_MISMATCH
         ] else 99)
 
@@ -191,8 +180,6 @@ class TestLifecycleAnalyzer:
         findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
         # Should still process the valid file and report parse error for the bad one
         assert any(f.code == "ADR_UNPARSEABLE" and "ADR-002" in f.adr_id for f in findings)
-        # NUMBERING_GAP only checks successfully parsed ADRs; ADR-001 has no gap
-        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
 
     def test_read_only_no_mutations(self, tmp_path: Path):
         _write_adr(tmp_path, "ADR-001", "accepted", "")
@@ -239,18 +226,48 @@ class TestLifecycleAnalyzer:
         # And the entry is still retrievable (no enforcement change)
         assert target.decision.id == "ADR-004"
 
+    def test_tied_adr_superseding_other_scope_does_not_resurrect_superseded_adr(self, tmp_path: Path):
+        """
+        Regression: when a tied ADR supersedes an ADR in another scope, the superseded
+        ADR must not re-enter consideration or cause false elimination findings.
+
+        Setup:
+          Scope 'compute':
+            ADR-002: accepted, normal, 2026-01-01, supersedes: [ADR-001]
+            ADR-003: accepted, normal, 2026-01-01 (ties with ADR-002)
+          Scope 'storage':
+            ADR-001: accepted, normal, 2026-01-01 (superseded by ADR-002)
+            ADR-004: accepted, normal, 2026-01-01
+
+        Expected findings:
+          ACTIVE_CONTRADICTION for ADR-002,ADR-003 in scope 'compute'.
+          NO SILENT_PRECEDENCE_ELIMINATION in scope 'storage' (ADR-001 is superseded,
+          so ADR-004 is the sole active decision in 'storage').
+        """
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage", date="2026-01-01")
+        _write_adr(tmp_path, "ADR-002", "accepted", "compute", date="2026-01-01", supersedes=["ADR-001"])
+        _write_adr(tmp_path, "ADR-003", "accepted", "compute", date="2026-01-01")
+        _write_adr(tmp_path, "ADR-004", "accepted", "storage", date="2026-01-01")
+        _write_ledger(tmp_path, [])
+
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        contradictions = [f for f in findings if f.code == ACTIVE_CONTRADICTION]
+        eliminations = [f for f in findings if f.code == SILENT_PRECEDENCE_ELIMINATION]
+
+        assert len(contradictions) == 1
+        assert "ADR-002" in contradictions[0].adr_id and "ADR-003" in contradictions[0].adr_id
+        # ADR-001 must not re-enter to falsely eliminate ADR-004 or be reported as eliminated
+        assert eliminations == [], f"Unexpected eliminations: {eliminations}"
+
 
 class TestFullFixture:
-    """Run the full M0 31-ADR fixture against the analyzer for smoke coverage."""
+    """Run a multi-ADR fixture against the analyzer for smoke coverage."""
     def test_full_fixture(self, tmp_path: Path):
-        # Reuse the M0 fixture generator logic inline (lightweight subset)
-        # Just ensure analyzer runs without exception on a realistic corpus
         corpus = tmp_path / "corpus"
         corpus.mkdir()
         ledger_dir = tmp_path / "ledger"
         ledger_dir.mkdir()
 
-        # Minimal representative set covering all finding types
         adrs = [
             ("ADR-001", "accepted", "", [], "foundational"),
             ("ADR-002", "accepted", "ci", [], "normal"),
@@ -293,7 +310,6 @@ class TestFullFixture:
 
         findings = analyze_lifecycle(corpus, ledger_dir / "project_memory.json")
         codes = {f.code for f in findings}
-        # Fixture has continuous 001-010, no numbering gap expected
         expected = {DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
                     ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION,
                     LEDGER_STATUS_MISMATCH}
@@ -325,7 +341,7 @@ class TestNegativeCases:
         _write_adr(tmp_path, "ADR-003", "accepted", "compute")
         _write_ledger(tmp_path, [])
         findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
-        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
+        assert not findings, f"Expected no warnings, got: {[(f.code, f.adr_id) for f in findings]}"
 
     def test_explicit_supersession_produces_no_silent_elimination_warning(self, tmp_path: Path):
         """Two accepted ADRs in same scope, but ADR-002 explicitly supersedes ADR-001."""

--- a/tests/test_adr_lifecycle.py
+++ b/tests/test_adr_lifecycle.py
@@ -1,0 +1,345 @@
+"""
+test_adr_lifecycle.py — Lifecycle analyzer tests.
+
+Validates finding codes, deterministic ordering, tolerant parsing,
+read-only semantics, and the stale-retrievability regression.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mneme.adr_lifecycle import (
+    analyze_lifecycle,
+    UNEXPLAINED_NUMBERING_GAP,
+    DANGLING_SUPERSEDES,
+    ORPHAN_SUPERSEDED,
+    ACTIVE_CONTRADICTION,
+    SILENT_PRECEDENCE_ELIMINATION,
+    LEDGER_STATUS_MISMATCH,
+)
+from mneme.adr_freshness import FreshnessIssue
+from mneme.decision_retriever import DecisionRetriever
+from mneme.schemas import Decision
+
+
+def _write_adr(dir: Path, adr_id: str, status: str, scope: str, supersedes=None,
+               title="Test", date="2026-01-01", priority="normal", constraints=None):
+    supersedes = supersedes or []
+    if supersedes:
+        supersedes_yaml = "\n" + "".join(f"  - {s}\n" for s in supersedes)
+    else:
+        supersedes_yaml = " []"
+    constraints_yaml = ""
+    if constraints:
+        constraints_yaml = "\n## Constraints\n" + "".join(f"- {c}\n" for c in constraints)
+    # Quote empty scope to avoid YAML null
+    scope_yaml = f'"{scope}"' if scope == "" else scope
+    text = f"""---
+id: {adr_id}
+title: {title}
+status: {status}
+priority: {priority}
+date: {date}
+scope: {scope_yaml}
+supersedes:{supersedes_yaml}
+---
+
+# {title}
+
+Body text for {adr_id}.{constraints_yaml}
+"""
+    (dir / f"{adr_id}-test.md").write_text(text, encoding="utf-8", newline="\n")
+
+
+def _write_ledger(dir: Path, entries: list[dict]) -> Path:
+    """Write a minimal project_memory.json with given decisions."""
+    mem = {
+        "meta": {"name": "test", "description": "", "version": "0.1.0", "owner": "", "created": "2026-01-01"},
+        "items": [],
+        "examples": [],
+        "decisions": entries,
+    }
+    p = dir / "project_memory.json"
+    p.write_text(json.dumps(mem, indent=2) + "\n", encoding="utf-8", newline="\n")
+    return p
+
+
+def _hashes(dir: Path) -> dict[str, str]:
+    """Return {relative_path: sha256} for all files in dir."""
+    out = {}
+    for p in dir.rglob("*"):
+        if p.is_file():
+            rel = p.relative_to(dir).as_posix()
+            out[rel] = hashlib.sha256(p.read_bytes()).hexdigest()
+    return out
+
+
+def _make_3_5_stale_entry() -> dict:
+    """Construct a ledger decision that scores exactly 3.5 for the regression query.
+
+    Query tokens (len>=4, stopwords excluded):
+      "embedding vector storage postgres" -> {"embedding", "vector", "storage", "postgres"}
+    Target score 3.5 = rationale matches (3) * 0.5 + scope "storage" * 2.0
+    """
+    return {
+        "id": "ADR-999",
+        "decision": "Use SQLite for local persistence",
+        "rationale": (
+            "Local persistence uses SQLite via the stdlib sqlite3 module. "
+            "Embedding vector stored in postgres database for now."
+        ),
+        "scope": ["storage"],
+        "constraints": ["no postgres"],
+        "anti_patterns": [],
+        "rules": [{"type": "FORBID_LITERAL", "value": "postgres"}],
+        "created_at": "2026-01-01",
+        "updated_at": "2026-01-01",
+    }
+
+
+class TestLifecycleAnalyzer:
+    def test_ordinary_numbering_gap_no_warning(self, tmp_path: Path):
+        """Ordinary numbering gaps (e.g. ADR-002 never created) produce no warning."""
+        _write_adr(tmp_path, "ADR-001", "accepted", "")
+        _write_adr(tmp_path, "ADR-003", "accepted", "")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
+
+    def test_dangling_supersedes(self, tmp_path: Path):
+        _write_adr(tmp_path, "ADR-001", "accepted", "", supersedes=["ADR-999"])
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert any(f.code == DANGLING_SUPERSEDES and f.adr_id == "ADR-001" for f in findings)
+
+    def test_orphan_superseded(self, tmp_path: Path):
+        _write_adr(tmp_path, "ADR-001", "superseded", "")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert any(f.code == ORPHAN_SUPERSEDED and f.adr_id == "ADR-001" for f in findings)
+
+    def test_active_contradiction(self, tmp_path: Path):
+        _write_adr(tmp_path, "ADR-010", "accepted", "scope.x", date="2026-01-01",
+                   constraints=["FORBID_LITERAL foo"])
+        _write_adr(tmp_path, "ADR-011", "accepted", "scope.x", date="2026-01-01",
+                   constraints=["FORBID_LITERAL bar"])
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert any(f.code == ACTIVE_CONTRADICTION and "ADR-010" in f.adr_id and "ADR-011" in f.adr_id
+                   for f in findings)
+
+    def test_silent_precedence_elimination(self, tmp_path: Path):
+        # ADR-001 and ADR-002 both accepted in scope 'ci' without supersedes link.
+        # ADR-001 is newer (2026-02-01 vs 2026-01-01), so precedence selects ADR-001.
+        # ADR-002 is silently eliminated solely by precedence.
+        _write_adr(tmp_path, "ADR-001", "accepted", "ci", priority="normal", date="2026-02-01")
+        _write_adr(tmp_path, "ADR-002", "accepted", "ci", priority="normal", date="2026-01-01")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert any(f.code == SILENT_PRECEDENCE_ELIMINATION and f.adr_id == "ADR-002"
+                   for f in findings)
+
+    def test_ledger_status_mismatch_stale_retrievable(self, tmp_path: Path):
+        # Corpus: ADR-004 deprecated on disk
+        _write_adr(tmp_path, "ADR-004", "deprecated", "storage")
+        # Ledger: decision ADR-004 still present with source pointing at the file
+        entry = _make_3_5_stale_entry()
+        entry["id"] = "ADR-004"
+        entry["source"] = {"type": "adr", "path": "ADR-004-test.md", "sha256": "deadbeef"}
+        _write_ledger(tmp_path, [entry])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert any(f.code == LEDGER_STATUS_MISMATCH and f.adr_id == "ADR-004"
+                   for f in findings)
+
+    def test_deterministic_ordering(self, tmp_path: Path):
+        # Create multiple finding types in one run
+        _write_adr(tmp_path, "ADR-001", "accepted", "", supersedes=["ADR-999"])
+        _write_adr(tmp_path, "ADR-002", "superseded", "")
+        _write_adr(tmp_path, "ADR-010", "accepted", "scope.x", date="2026-01-01")
+        _write_adr(tmp_path, "ADR-011", "accepted", "scope.x", date="2026-01-01")
+        _write_adr(tmp_path, "ADR-003", "accepted", "ci", priority="foundational")
+        _write_adr(tmp_path, "ADR-004", "accepted", "ci", priority="normal")
+        _write_adr(tmp_path, "ADR-005", "deprecated", "storage")
+        entry = _make_3_5_stale_entry()
+        entry["id"] = "ADR-005"
+        entry["source"] = {"type": "adr", "path": "ADR-005-test.md", "sha256": "deadbeef"}
+        _write_ledger(tmp_path, [entry])
+        findings1 = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        findings2 = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        # Exact same output twice
+        assert [(f.code, f.adr_id) for f in findings1] == [(f.code, f.adr_id) for f in findings2]
+        # Order respects _CODE_ORDER
+        codes = [f.code for f in findings1]
+        assert codes == sorted(codes, key=lambda c: [
+            UNEXPLAINED_NUMBERING_GAP, DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
+            ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION, LEDGER_STATUS_MISMATCH
+        ].index(c) if c in [
+            UNEXPLAINED_NUMBERING_GAP, DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
+            ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION, LEDGER_STATUS_MISMATCH
+        ] else 99)
+
+    def test_tolerant_parse_error(self, tmp_path: Path):
+        # Write one valid ADR and one malformed ADR
+        _write_adr(tmp_path, "ADR-001", "accepted", "")
+        (tmp_path / "ADR-002-test.md").write_text("not yaml frontmatter", encoding="utf-8")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        # Should still process the valid file and report parse error for the bad one
+        assert any(f.code == "ADR_UNPARSEABLE" and "ADR-002" in f.adr_id for f in findings)
+        # NUMBERING_GAP only checks successfully parsed ADRs; ADR-001 has no gap
+        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
+
+    def test_read_only_no_mutations(self, tmp_path: Path):
+        _write_adr(tmp_path, "ADR-001", "accepted", "")
+        _write_adr(tmp_path, "ADR-002", "deprecated", "")
+        ledger = _write_ledger(tmp_path, [])
+        corpus_hashes = _hashes(tmp_path)
+        _ = analyze_lifecycle(tmp_path, ledger)
+        # Hashes unchanged
+        assert _hashes(tmp_path) == corpus_hashes
+
+    def test_regression_stale_decision_flagged_and_score_unchanged(self, tmp_path: Path):
+        """
+        Reproduce the M0 3.5-scoring stale decision and prove the analyzer flags it.
+
+        The ledger entry ADR-999 is designed to score 3.5 for the query
+        "embedding vector storage postgres" (rationale matches 3 tokens @0.5
+        + scope 'storage' @2.0). The corpus ADR is deprecated.
+        """
+        _write_adr(tmp_path, "ADR-004", "deprecated", "storage")
+        entry = _make_3_5_stale_entry()
+        entry["id"] = "ADR-004"
+        entry["source"] = {"type": "adr", "path": "ADR-004-test.md", "sha256": "deadbeef"}
+        ledger = _write_ledger(tmp_path, [entry])
+
+        # Analyzer runs
+        findings = analyze_lifecycle(tmp_path, ledger)
+        flagged = any(f.code == LEDGER_STATUS_MISMATCH and f.adr_id == "ADR-004"
+                      for f in findings)
+        assert flagged, "Analyzer should flag the stale ledger entry"
+
+        # Retrieval score unchanged (regression guard)
+        raw = json.loads(ledger.read_text(encoding="utf-8"))
+        decisions = [
+            Decision(id=d["id"], decision=d["decision"], scope=d.get("scope", []),
+                     constraints=d.get("constraints", []),
+                     anti_patterns=d.get("anti_patterns", []),
+                     created_at=d.get("created_at", ""), updated_at=d.get("updated_at", ""))
+            for d in raw["decisions"]
+        ]
+        scored = DecisionRetriever(decisions).retrieve("embedding vector storage postgres")
+        target = next(s for s in scored if s.decision.id == "ADR-004")
+        # Exact score match from M0 evidence
+        assert target.score == pytest.approx(3.5)
+        # And the entry is still retrievable (no enforcement change)
+        assert target.decision.id == "ADR-004"
+
+
+class TestFullFixture:
+    """Run the full M0 31-ADR fixture against the analyzer for smoke coverage."""
+    def test_full_fixture(self, tmp_path: Path):
+        # Reuse the M0 fixture generator logic inline (lightweight subset)
+        # Just ensure analyzer runs without exception on a realistic corpus
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        ledger_dir = tmp_path / "ledger"
+        ledger_dir.mkdir()
+
+        # Minimal representative set covering all finding types
+        adrs = [
+            ("ADR-001", "accepted", "", [], "foundational"),
+            ("ADR-002", "accepted", "ci", [], "normal"),
+            ("ADR-003", "accepted", "ci", [], "foundational"),
+            ("ADR-004", "deprecated", "storage", [], "normal"),
+            ("ADR-005", "accepted", "retrieval", [], "normal"),
+            ("ADR-006", "accepted", "retrieval", ["ADR-005"], "normal"),
+            ("ADR-007", "superseded", "obs", [], "normal"),
+            ("ADR-008", "accepted", "scope.x", [], "normal"),
+            ("ADR-009", "accepted", "scope.x", [], "normal"),
+            ("ADR-010", "accepted", "", ["ADR-999"], "normal"),
+        ]
+        for adr_id, status, scope, supersedes, prio in adrs:
+            _write_adr(corpus, adr_id, status, scope, supersedes, priority=prio)
+
+        # Ledger entries for actives + stale ADR-004
+        ledger_entries = []
+        for adr_id, status, scope, supersedes, prio in adrs:
+            if status == "accepted" and adr_id not in {"ADR-008", "ADR-009"}:
+                entry = {
+                    "id": adr_id,
+                    "decision": "Test decision",
+                    "rationale": "Rationale text with embedding vector storage postgres",
+                    "scope": [scope],
+                    "constraints": [],
+                    "anti_patterns": [],
+                    "rules": [],
+                    "created_at": "2026-01-01",
+                    "updated_at": "2026-01-01",
+                    "source": {"type": "adr", "path": f"../corpus/{adr_id}-test.md", "sha256": "x"},
+                }
+                ledger_entries.append(entry)
+        # Stale deprecated
+        entry = _make_3_5_stale_entry()
+        entry["id"] = "ADR-004"
+        entry["source"] = {"type": "adr", "path": "../corpus/ADR-004-test.md", "sha256": "x"}
+        ledger_entries.append(entry)
+
+        _write_ledger(ledger_dir, ledger_entries)
+
+        findings = analyze_lifecycle(corpus, ledger_dir / "project_memory.json")
+        codes = {f.code for f in findings}
+        # Fixture has continuous 001-010, no numbering gap expected
+        expected = {DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED,
+                    ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION,
+                    LEDGER_STATUS_MISMATCH}
+        assert expected.issubset(codes), f"missing: {expected - codes}"
+
+
+class TestNegativeCases:
+    """Negative tests: cases that MUST NOT produce warnings."""
+
+    def test_intentional_tombstones_produce_no_warning(self, tmp_path: Path):
+        """A deprecated/superseded ADR file on disk (tombstone) without a stale ledger entry."""
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage")
+        _write_adr(tmp_path, "ADR-002", "deprecated", "storage")
+        _write_ledger(tmp_path, [{
+            "id": "ADR-001",
+            "decision": "Current decision",
+            "scope": ["storage"],
+            "constraints": [],
+            "anti_patterns": [],
+            "rules": [],
+            "source": {"type": "adr", "path": "ADR-001-test.md", "sha256": "abc"},
+        }])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert not findings, f"Expected no warnings, got: {[(f.code, f.adr_id) for f in findings]}"
+
+    def test_ordinary_numbering_gaps_produce_no_warning(self, tmp_path: Path):
+        """ADR-001 and ADR-003 exist, ADR-002 was never created. No warning."""
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage")
+        _write_adr(tmp_path, "ADR-003", "accepted", "compute")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert not any(f.code == UNEXPLAINED_NUMBERING_GAP for f in findings)
+
+    def test_explicit_supersession_produces_no_silent_elimination_warning(self, tmp_path: Path):
+        """Two accepted ADRs in same scope, but ADR-002 explicitly supersedes ADR-001."""
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage", supersedes=[])
+        _write_adr(tmp_path, "ADR-002", "accepted", "storage", supersedes=["ADR-001"])
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert not any(f.code == SILENT_PRECEDENCE_ELIMINATION for f in findings)
+
+    def test_valid_precedence_non_conflicting_produces_no_warning(self, tmp_path: Path):
+        """Decisions in different or hierarchical scopes produce no elimination warning."""
+        _write_adr(tmp_path, "ADR-001", "accepted", "storage")
+        _write_adr(tmp_path, "ADR-002", "accepted", "storage.embeddings")
+        _write_adr(tmp_path, "ADR-003", "accepted", "compute")
+        _write_ledger(tmp_path, [])
+        findings = analyze_lifecycle(tmp_path, tmp_path / "project_memory.json")
+        assert not any(f.code == SILENT_PRECEDENCE_ELIMINATION for f in findings)

--- a/tests/test_cli_check_freshness.py
+++ b/tests/test_cli_check_freshness.py
@@ -319,3 +319,48 @@ def test_check_json_exposes_stable_lifecycle_codes(tmp_path, capsys):
     mismatch = next(i for i in payload["freshness"] if i["code"] == "LEDGER_STATUS_MISMATCH")
     assert mismatch["adr_id"] == "ADR-004"
     assert "deprecated" in mismatch["message"]
+
+
+def test_check_deduplicates_unparseable_diagnostic_between_freshness_and_lifecycle(tmp_path, capsys):
+    """
+    Regression: when an ADR is unparseable (e.g. ADR-002-bad.md), check_freshness and
+    analyze_lifecycle must both identify it with the canonical id ('ADR-002'), and
+    _collect_adr_diagnostics must deduplicate so it is reported exactly once in stdout and JSON.
+    """
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "ADR-002-bad.md").write_text("invalid yaml without header\n", encoding="utf-8")
+
+    mem = _memory(tmp_path)
+    inp = _input(tmp_path, "Clean input")
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    assert code == 0
+    # Must appear exactly once in stdout
+    assert out.count("ADR_UNPARSEABLE") == 1
+    assert "ADR-002" in out
+
+    # Must appear exactly once in JSON
+    main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--json",
+        "--adr-dir", str(adr_dir),
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    unparseable_items = [i for i in payload["freshness"] if i["code"] == "ADR_UNPARSEABLE"]
+    assert len(unparseable_items) == 1
+    assert unparseable_items[0]["adr_id"] == "ADR-002"
+

--- a/tests/test_cli_check_freshness.py
+++ b/tests/test_cli_check_freshness.py
@@ -211,3 +211,111 @@ def test_check_ignores_non_adr_markdown_in_adr_dir(tmp_path, capsys):
     out = capsys.readouterr().out
     for code in ("ADR_UNIMPORTED", "ADR_CHANGED", "ADR_MISSING", "ADR_UNPARSEABLE"):
         assert code not in out
+
+
+def test_check_emits_lifecycle_diagnostics(tmp_path, capsys):
+    """Lifecycle findings (like LEDGER_STATUS_MISMATCH) surface under mneme check --adr-dir."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    # Write a deprecated ADR
+    (adr_dir / "ADR-004-sqlite.md").write_text(
+        "---\nid: ADR-004\ntitle: SQLite\nstatus: deprecated\npriority: normal\n"
+        "date: 2026-01-01\nscope: \"storage\"\nsupersedes: []\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [],
+        "decisions": [
+            {
+                "id": "ADR-004",
+                "decision": "Use SQLite",
+                "scope": ["storage"],
+                "constraints": ["no postgres"],
+                "anti_patterns": [],
+                "rules": [],
+                "source": {
+                    "type": "adr",
+                    "path": "../docs/adr/ADR-004-sqlite.md",
+                    "sha256": "abc",
+                },
+            },
+        ],
+    }), encoding="utf-8")
+    inp = _input(tmp_path, "Clean input")
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "warn",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    out = capsys.readouterr().out
+    assert "LEDGER_STATUS_MISMATCH" in out
+    assert "ADR-004" in out
+    # Warn-only exit code
+    assert code == 0
+
+
+def test_check_json_exposes_stable_lifecycle_codes(tmp_path, capsys):
+    """`mneme check --json` includes lifecycle findings with stable codes in the payload."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "ADR-004-sqlite.md").write_text(
+        "---\nid: ADR-004\ntitle: SQLite\nstatus: deprecated\npriority: normal\n"
+        "date: 2026-01-01\nscope: \"storage\"\nsupersedes: []\n---\nBody.\n",
+        encoding="utf-8",
+    )
+    (adr_dir / "ADR-010-dangling.md").write_text(
+        "---\nid: ADR-010\ntitle: Dangling\nstatus: accepted\npriority: normal\n"
+        "date: 2026-01-01\nscope: \"dangling\"\nsupersedes:\n  - ADR-999\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+    mem = tmp_path / ".mneme" / "project_memory.json"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text(json.dumps({
+        "meta": {"name": "t", "description": "t"},
+        "items": [], "examples": [],
+        "decisions": [
+            {
+                "id": "ADR-004",
+                "decision": "Use SQLite",
+                "scope": ["storage"],
+                "constraints": ["no postgres"],
+                "anti_patterns": [],
+                "rules": [],
+                "source": {
+                    "type": "adr",
+                    "path": "../docs/adr/ADR-004-sqlite.md",
+                    "sha256": "abc",
+                },
+            },
+        ],
+    }), encoding="utf-8")
+    inp = _input(tmp_path, "Clean input")
+
+    code = main([
+        "check",
+        "--memory", str(mem),
+        "--input", str(inp),
+        "--query", "storage",
+        "--mode", "strict",
+        "--json",
+        "--adr-dir", str(adr_dir),
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0  # Warn-only diagnostics do not fail strict mode
+    codes = {i["code"] for i in payload["freshness"]}
+    assert "LEDGER_STATUS_MISMATCH" in codes
+    assert "DANGLING_SUPERSEDES" in codes
+    mismatch = next(i for i in payload["freshness"] if i["code"] == "LEDGER_STATUS_MISMATCH")
+    assert mismatch["adr_id"] == "ADR-004"
+    assert "deprecated" in mismatch["message"]


### PR DESCRIPTION
## Summary
Implements read-only ADR lifecycle reconciliation analyzer (M1/M2) beside adr_freshness.

## Capabilities
- **Analyzer (mneme/adr_lifecycle.py):** Pure, read-only analyze_lifecycle(corpus_dir, memory_path) -> list[FreshnessIssue]
- **CLI aggregation (mneme/cli.py):** mneme check --adr-dir aggregates both freshness and lifecycle diagnostics
- **Stable --json codes:** LEDGER_STATUS_MISMATCH, DANGLING_SUPERSEDES, ORPHAN_SUPERSEDED, ACTIVE_CONTRADICTION, SILENT_PRECEDENCE_ELIMINATION
- **Warn-only semantics:** Diagnostics do not affect exit codes or policy verdicts on compliant prompts (exit 0 / PASS in both warn and strict modes)
- **Per-scope isolation:** Each scope is resolved independently over graph-derived active ADRs; supersessions are never artificially resurrected across scopes
- **Boundary preservation:** No changes to DecisionRetriever, ConflictDetector, compiler, or ranking (reproduces stale ADR-004 score 3.5 while flagging it)

## Testing
- 16 focused tests in tests/test_adr_lifecycle.py including negative cases (intentional tombstones, ordinary numbering gaps, explicit supersession, non-conflicting precedence, per-scope isolation regression, proposed ADR supersession isolation)
- 3 CLI integration tests in tests/test_cli_check_freshness.py (stdout + --json payload + unparseable deduplication)
- 1020 total test suite tests passing (6 skipped)