### PR TITLE
docs: record ADR lifecycle reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
   degraded states fail open with visible UNEVALUATED diagnostics. Validated
   10/10 against Codex CLI 0.149.1 (Windows, `codex exec`, pinned binary);
   evidence under `validation/codex-cli/`.
+- Read-only ADR lifecycle reconciliation in `mneme check --adr-dir` (#333).
+  Reports `DANGLING_SUPERSEDES`, `ORPHAN_SUPERSEDED`, `ACTIVE_CONTRADICTION`,
+  `SILENT_PRECEDENCE_ELIMINATION`, and `LEDGER_STATUS_MISMATCH`. Findings are
+  warn-only and do not alter retrieval, conflict detection, ranking, or
+  enforcement. Graph supersession now matches compiler semantics: only an
+  accepted ADR can retire another accepted ADR.
 
 ---
 
@@ -331,5 +337,5 @@ No engine changes. Shells out to existing `mneme check` v0.3.x.
 ### Tests
 
 - 21 new integration tests under `tests/integrations/claude_code/`.
-- 2 end-to-end tests (skipped when `mneme` not on `$PATH`).
+- 2 end-to-end tests (skipped when `mneme` is not on `$PATH`).
 - Full suite: 170 passed, 2 skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,5 +337,5 @@ No engine changes. Shells out to existing `mneme check` v0.3.x.
 ### Tests
 
 - 21 new integration tests under `tests/integrations/claude_code/`.
-- 2 end-to-end tests (skipped when `mneme` is not on `$PATH`).
+- 2 end-to-end tests (skipped when `mneme` not on `$PATH`).
 - Full suite: 170 passed, 2 skipped.

--- a/docs/architecture/current-phase.md
+++ b/docs/architecture/current-phase.md
@@ -31,7 +31,7 @@ These are shipped but not under freeze; they may evolve without a charter amendm
 - Google Antigravity pre-tool adapter.
 - Codex CLI enforcement integration (PreToolUse gate + Stop audit).
 - Paperclip — validated compatibility through both transports, no adapter required.
-- ADR parser/compiler/validator pipeline.
+- ADR parser/compiler/validator and read-only lifecycle reconciliation pipeline.
 - Site-level benchmark presentation copy.
 
 The active Layer 1 product surface is the `mneme` Python package, the `mneme` CLI, the enforcement interfaces (`mneme check`, the `mneme-hook` Claude Code hook, Cursor rules export) and the supported integrations. A historical `POST /complete` HTTP wrapper once shipped alongside the legacy benchmark application; it was extracted from core with that application and is no longer part of the product surface. The extraction was structural only — it did not change retrieval, enforcement or benchmark methodology. The `mneme-hq[api]` optional dependency remains declared for compatibility, but it no longer installs an active HTTP layer. Reviving an HTTP surface would require a separate architectural decision.


### PR DESCRIPTION
## Summary
- add the merged ADR lifecycle reconciliation capability to `CHANGELOG.md` under Unreleased
- clarify `docs/architecture/current-phase.md` so the experimental ADR pipeline includes read-only lifecycle reconciliation
- keep ADR lineage/versioning explicitly deferred

## Boundaries
- docs only
- no README changes
- no retrieval, ConflictDetector, enforcement, ranking, benchmark, or memory changes
- no PyPI/release claims