### PR TITLE
ci: record agent execution provenance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What changed and why? Keep the scope narrow. -->
+
+## Validation
+
+<!-- List the checks actually run. -->
+
+## Execution provenance
+
+- Change author: <!-- human | agent | mixed -->
+- Agent: <!-- none | codex | claude-code | kiro | chatgpt-work | other concrete agent -->
+- Agent model: <!-- n/a for human-only; otherwise model id or not-exposed -->
+- Agent session: <!-- n/a for human-only; otherwise stable session id / share URL / not-exposed -->
+- Task origin: <!-- manual | chatgpt | claude | local | other -->
+- Human owner: <!-- @github-username -->

--- a/.github/workflows/provenance-check.yml
+++ b/.github/workflows/provenance-check.yml
@@ -1,0 +1,23 @@
+name: agent provenance check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  provenance:
+    name: Validate PR execution provenance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate provenance block
+        run: python scripts/check_pr_provenance.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+Notes for AI agents working in this repository.
+
+Repository workflow, worktree lifecycle, merge policy, and architecture constraints are defined in `CLAUDE.md`; those rules apply regardless of which agent is executing the task.
+
+## Agent execution provenance
+
+Every pull request must record who actually produced the change. Git author identity is not sufficient because agent work is commonly committed under the human owner's Git identity.
+
+Use the PR template's `Execution provenance` block. Required fields:
+
+- `Change author`: `human`, `agent`, or `mixed`.
+- `Agent`: the concrete agent surface (`codex`, `claude-code`, `kiro`, `chatgpt-work`, etc.), or `none` for human-only work.
+- `Agent model`: model identifier when exposed; `not-exposed` is acceptable when the tool does not expose it; `n/a` only for human-only work.
+- `Agent session`: stable session ID or share/work URL when available; `not-exposed` is acceptable when unavailable; `n/a` only for human-only work.
+- `Task origin`: where the task was scoped (`chatgpt`, `claude`, `local`, `manual`, etc.).
+- `Human owner`: GitHub username responsible for review/promotion.
+
+When an agent creates commits directly, also append commit trailers where practical:
+
+```text
+Agent: codex
+Agent-Model: gpt-5.6-sol
+Agent-Session: cx_...
+Task-Origin: chatgpt
+Human-Owner: TheoV823
+```
+
+The PR body is the durable source of truth because squash merges may collapse or discard individual commit trailers.
+
+Authorship, human promotion, release/deployment, and worktree cleanup are separate lifecycle facts. Never infer one from another. If usage/session limits interrupt the task, report the remaining lifecycle step explicitly.

--- a/scripts/check_pr_provenance.py
+++ b/scripts/check_pr_provenance.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate the pull request Execution provenance block."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+FIELDS = {
+    "change author": "Change author",
+    "agent": "Agent",
+    "agent model": "Agent model",
+    "agent session": "Agent session",
+    "task origin": "Task origin",
+    "human owner": "Human owner",
+}
+
+
+def _event_body() -> str:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise RuntimeError("GITHUB_EVENT_PATH is not set")
+    payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    return str((payload.get("pull_request") or {}).get("body") or "")
+
+
+def _extract(body: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    in_block = False
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if re.match(r"^##\s+Execution provenance\s*$", line, flags=re.I):
+            in_block = True
+            continue
+        if in_block and line.startswith("## "):
+            break
+        if not in_block:
+            continue
+        match = re.match(r"^-\s*([^:]+):\s*(.*)$", line)
+        if match:
+            key = match.group(1).strip().lower()
+            if key in FIELDS:
+                values[key] = match.group(2).strip()
+    return values
+
+
+def _usable(value: str) -> bool:
+    return bool(value.strip()) and "<!--" not in value and "-->" not in value
+
+
+def validate(body: str) -> list[str]:
+    if not re.search(r"^##\s+Execution provenance\s*$", body, flags=re.I | re.M):
+        return ["missing '## Execution provenance' block"]
+
+    values = _extract(body)
+    errors: list[str] = []
+    for key, label in FIELDS.items():
+        if key not in values or not _usable(values[key]):
+            errors.append(f"missing or unresolved field: {label}")
+    if errors:
+        return errors
+
+    author = values["change author"].lower()
+    if author not in {"human", "agent", "mixed"}:
+        errors.append("Change author must be one of: human, agent, mixed")
+
+    agent = values["agent"].lower()
+    model = values["agent model"].lower()
+    session = values["agent session"].lower()
+
+    if author == "human":
+        if agent != "none":
+            errors.append("human-only work must use 'Agent: none'")
+        if model != "n/a":
+            errors.append("human-only work must use 'Agent model: n/a'")
+        if session != "n/a":
+            errors.append("human-only work must use 'Agent session: n/a'")
+    elif author in {"agent", "mixed"}:
+        if agent in {"none", "n/a", "unknown"}:
+            errors.append("agent/mixed work must name the concrete agent")
+        if model in {"", "n/a", "unknown"}:
+            errors.append("agent/mixed work must provide a model id or 'not-exposed'")
+        if session in {"", "n/a", "unknown"}:
+            errors.append("agent/mixed work must provide a session reference or 'not-exposed'")
+
+    owner = values["human owner"]
+    if not owner.startswith("@") or len(owner) < 2:
+        errors.append("Human owner must be a GitHub username beginning with @")
+
+    return errors
+
+
+def main() -> int:
+    try:
+        body = _event_body()
+    except Exception as exc:
+        print(f"provenance-check: ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    errors = validate(body)
+    if errors:
+        print("provenance-check: FAIL")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("provenance-check: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a repo-level agent provenance contract that applies regardless of agent surface
- add a durable Execution provenance block to the PR template
- add a metadata-only PR provenance validator/workflow
- keep authorship, human promotion, release/deployment, and worktree cleanup as separate lifecycle facts
- no runtime, enforcement, retrieval, ConflictDetector, benchmark, or ADR semantics changed

## Validation

- scope is limited to `AGENTS.md`, PR template, provenance validator, and CI workflow
- validator accepts explicit `not-exposed` when an agent tool does not expose model/session identity
- human-only PRs must explicitly use `Agent: none`, `Agent model: n/a`, `Agent session: n/a`

## Execution provenance

- Change author: agent
- Agent: chatgpt
- Agent model: GPT-5.6 Sol
- Agent session: not-exposed
- Task origin: chatgpt
- Human owner: @TheoV823
