### PR TITLE
feat: add authoritative governability assessment API

### DIFF
--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -378,7 +378,10 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
     from mneme.schemas import Decision
 
     # Check typed FORBID_LITERAL rules (always enforced, FAIL severity)
-    has_literal_rules = bool(decision.rules)
+    has_literal_rules = any(
+        rule.type == "FORBID_LITERAL"
+        for rule in decision.rules
+    )
 
     # Check anti-patterns - determine which are single-term (always enforced)
     single_term_aps = []

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -319,3 +319,125 @@ def check_prompt(
         violations=violations,
         applicability=applicability,
     )
+
+
+# ── Governability Assessment ────────────────────────────────────────────────────────
+
+from dataclasses import dataclass
+from typing import Literal
+
+GovernabilityTier = Literal["enforceable", "partial", "guidance"]
+
+
+@dataclass(frozen=True)
+class GovernabilityAssessment:
+    """
+    Mneme's authoritative assessment of a Decision's governability.
+
+    This is the single source of truth for whether a Decision can be
+    deterministically enforced. Consumers (audit workspace, CLI, etc.)
+    MUST use this function rather than reimplementing Mneme's semantics.
+
+    Enforcement tiers (matching Mneme's check_prompt behavior):
+
+    - enforceable: Decision has at least one mechanically enforceable rule
+      (typed FORBID_LITERAL rule, or single-term anti_pattern).
+      These are always checked regardless of retrieval score.
+
+    - partial: Decision has only multi-term anti_patterns or "no X" constraints.
+      Multi-term anti_patterns are only enforced for top-N retrieved decisions.
+      "no X" constraints produce WARN severity.
+
+    - guidance: Decision has no mechanically enforceable rules at all.
+      It exists for retrieval/context only.
+    """
+    decision_id: str
+    tier: GovernabilityTier
+    has_literal_rules: bool
+    has_single_term_anti_patterns: bool
+    has_multi_term_anti_patterns: bool
+    has_no_constraints: bool
+    applicable_paths: tuple[str, ...]  # paths where typed rules apply
+    confidence: float  # 1.0 = fully enforceable, 0.7 = partial, 0.0 = guidance only
+
+
+def assess_governability(decision: "Decision") -> GovernabilityAssessment:
+    """
+    Assess whether a Decision can be deterministically governed by Mneme.
+
+    This is the authoritative implementation of Mneme's governability semantics.
+    All external consumers (audit workspace, CLI, etc.) MUST call this function
+    rather than reimplementing the logic.
+
+    Args:
+        decision: A Mneme Decision object (from schemas.py)
+
+    Returns:
+        GovernabilityAssessment with Mneme's authoritative verdict.
+    """
+    from mneme.schemas import Decision
+
+    # Check typed FORBID_LITERAL rules (always enforced, FAIL severity)
+    has_literal_rules = bool(decision.rules)
+
+    # Check anti-patterns - determine which are single-term (always enforced)
+    single_term_aps = []
+    multi_term_aps = []
+    for ap in decision.anti_patterns:
+        if _is_literal_rule(ap):
+            single_term_aps.append(ap)
+        else:
+            multi_term_aps.append(ap)
+
+    has_single_term_anti_patterns = bool(single_term_aps)
+    has_multi_term_anti_patterns = bool(multi_term_aps)
+
+    # Check "no X" constraints (produce WARN severity)
+    has_no_constraints = any(
+        _rule_terms(c, min_len=3) for c in decision.constraints
+        if re.match(r"^no\s+(.+)$", c.strip(), re.IGNORECASE)
+    )
+
+    # Collect paths from typed rules
+    applicable_paths = set()
+    for rule in decision.rules:
+        if rule.include_paths:
+            applicable_paths.update(rule.include_paths)
+
+    # Determine tier and confidence based on Mneme's enforcement behavior
+    if has_literal_rules or has_single_term_anti_patterns:
+        # These are ALWAYS enforced regardless of retrieval score
+        tier: GovernabilityTier = "enforceable"
+        confidence = 1.0
+    elif has_multi_term_anti_patterns or has_no_constraints:
+        # Multi-term anti-patterns only enforced for top-N retrieved decisions
+        # "no X" constraints produce WARN (not FAIL)
+        tier = "partial"
+        confidence = 0.7
+    else:
+        # No mechanically enforceable rules - retrieval/context only
+        tier = "guidance"
+        confidence = 0.0
+
+    return GovernabilityAssessment(
+        decision_id=decision.id,
+        tier=tier,
+        has_literal_rules=has_literal_rules,
+        has_single_term_anti_patterns=has_single_term_anti_patterns,
+        has_multi_term_anti_patterns=has_multi_term_anti_patterns,
+        has_no_constraints=has_no_constraints,
+        applicable_paths=tuple(sorted(applicable_paths)),
+        confidence=confidence,
+    )
+
+
+# Export for external consumers
+__all__ = [
+    "Severity",
+    "Violation",
+    "EnforcementResult",
+    "check_prompt",
+    "GovernabilityAssessment",
+    "GovernabilityTier",
+    "assess_governability",
+]

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -682,3 +682,138 @@ def test_scoped_typed_rule_missing_path_reports_unknown():
     assert result.verdict == Severity.PASS
     assert not result.evaluation_complete
     assert result.applicability[0].outcome.value == "UNKNOWN"
+
+
+# ── assess_governability tests ──────────────────────────────────────────────────
+
+from mneme.enforcer import assess_governability, GovernabilityAssessment, GovernabilityTier
+
+
+def test_assess_governability_enforceable_via_literal_rule():
+    """A decision with a FORBID_LITERAL rule is enforceable."""
+    d = Decision(
+        id="ADR-001",
+        decision="Use PostgreSQL",
+        rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+    )
+    assessment = assess_governability(d)
+    assert isinstance(assessment, GovernabilityAssessment)
+    assert assessment.tier == "enforceable"
+    assert assessment.confidence == 1.0
+    assert assessment.has_literal_rules is True
+    assert assessment.decision_id == "ADR-001"
+
+
+def test_assess_governability_enforceable_via_single_term_anti_pattern():
+    """A single-term anti_pattern is enforceable (always enforced)."""
+    d = Decision(
+        id="ADR-002",
+        decision="No ORM",
+        anti_patterns=["orm"],
+    )
+    assessment = assess_governability(d)
+    assert assessment.tier == "enforceable"
+    assert assessment.confidence == 1.0
+    assert assessment.has_single_term_anti_patterns is True
+    assert assessment.has_multi_term_anti_patterns is False
+
+
+def test_assess_governability_partial_via_multi_term_anti_pattern():
+    """Multi-term anti_pattern is only partial (enforced for top-N only)."""
+    d = Decision(
+        id="ADR-003",
+        decision="No complex dependencies",
+        anti_patterns=["introduce ORM framework"],
+    )
+    assessment = assess_governability(d)
+    assert assessment.tier == "partial"
+    assert assessment.confidence == 0.7
+    assert assessment.has_single_term_anti_patterns is False
+    assert assessment.has_multi_term_anti_patterns is True
+
+
+def test_assess_governability_partial_via_no_constraint():
+    """A 'no X' constraint yields partial (WARN severity only)."""
+    d = Decision(
+        id="ADR-004",
+        decision="No external DB",
+        constraints=["no postgres"],
+    )
+    assessment = assess_governability(d)
+    assert assessment.tier == "partial"
+    assert assessment.confidence == 0.7
+    assert assessment.has_no_constraints is True
+
+
+def test_assess_governability_guidance_only():
+    """A decision with no mechanical rules is guidance only."""
+    d = Decision(
+        id="ADR-005",
+        decision="Services must not import each other",
+        rationale="Service boundaries",
+    )
+    assessment = assess_governability(d)
+    assert assessment.tier == "guidance"
+    assert assessment.confidence == 0.0
+    assert assessment.has_literal_rules is False
+    assert assessment.has_single_term_anti_patterns is False
+    assert assessment.has_multi_term_anti_patterns is False
+    assert assessment.has_no_constraints is False
+
+
+def test_assess_governability_applicable_paths():
+    """Applicable paths are extracted from typed rules."""
+    d = Decision(
+        id="ADR-006",
+        decision="Use PostgreSQL for storage",
+        scope=["storage"],
+        rules=[
+            Rule(type="FORBID_LITERAL", value="sqlite", include_paths=("src/**", "tests/**")),
+            Rule(type="FORBID_LITERAL", value="mysql"),
+        ],
+    )
+    assessment = assess_governability(d)
+    assert assessment.applicable_paths == ("src/**", "tests/**")
+    assert assessment.tier == "enforceable"
+
+
+def test_assess_governability_decision_id_preserved():
+    """The decision ID is preserved in the assessment."""
+    d = Decision(
+        id="ADR-999",
+        decision="Test decision",
+        rules=[Rule(type="FORBID_LITERAL", value="test")],
+    )
+    assessment = assess_governability(d)
+    assert assessment.decision_id == "ADR-999"
+
+
+def test_assess_governability_combined_rules():
+    """A decision with both literal rules and constraints is enforceable."""
+    d = Decision(
+        id="ADR-007",
+        decision="Use PostgreSQL, no ORM",
+        rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+        constraints=["no ORM"],
+    )
+    assessment = assess_governability(d)
+    assert assessment.tier == "enforceable"
+    assert assessment.confidence == 1.0
+    assert assessment.has_literal_rules is True
+    assert assessment.has_no_constraints is True
+
+
+def test_assess_governability_mixed_enforceable_and_partial():
+    """A decision with multi-term anti-pattern and literal rule is enforceable."""
+    d = Decision(
+        id="ADR-008",
+        decision="Complex decision",
+        rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+        anti_patterns=["introduce ORM framework"],
+    )
+    assessment = assess_governability(d)
+    # Literal rule makes it enforceable (highest tier wins)
+    assert assessment.tier == "enforceable"
+    assert assessment.confidence == 1.0
+    assert assessment.has_literal_rules is True
+    assert assessment.has_multi_term_anti_patterns is True


### PR DESCRIPTION
## Summary

- add public `GovernabilityTier` and frozen `GovernabilityAssessment` types
- add `assess_governability(decision)` as the authoritative core API for classifying architectural decisions as `enforceable`, `partial`, or `guidance`
- derive classification from existing Mneme enforcement primitives and behavior rather than duplicating policy semantics in consumers
- expose applicable paths from typed rule `include_paths`
- explicitly treat only typed `FORBID_LITERAL` rules as literal-rule enforcement
- add focused regression coverage for literal rules, anti-patterns, `no X` constraints, guidance-only decisions, path applicability, and mixed cases

## Why

The Architecture Audit Workspace needs a stable Mneme-core answer to one question: whether architectural intent can be deterministically governed. This keeps that decision in the Python core so UI/API consumers do not reimplement enforcement semantics.

## Scope

- `mneme/enforcer.py`
- `tests/test_enforcer.py`
- no retrieval, ranking, ConflictDetector, integration-adapter, benchmark, or memory-format changes

## Validation

- 9 focused `assess_governability` tests added
- full core suite reported green: 1099 passed
- Architecture Audit vertical slice reports 1 enforceable / 1 partial / 3 guidance

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: not-exposed
- Agent session: not-exposed
- Task origin: chatgpt
- Human owner: @TheoV823
