### PR TITLE
docs: refresh current roadmap and Claude Skill boundaries

### DIFF
--- a/docs/architecture/current-phase.md
+++ b/docs/architecture/current-phase.md
@@ -1,74 +1,96 @@
 # Mneme — Current Phase
 
-> One-page orientation: where Mneme is right now, what is frozen, what is experimental, what is deferred.
+> One-page orientation: where Mneme is right now, what is frozen, what is shipped, what is experimental, and what remains to validate.
 > If you are a contributor, design partner, or new reader, start here.
 
 ## Phase
 
-**Layer 1 — validation phase.**
+**Layer 1 — external validation and adoption phase.**
 
-Layer 1 is local-repo, single-developer, project-scoped architectural governance for AI-assisted code generation. The mechanism is frozen; what remains is real-world validation.
+Layer 1 is local-repo, project-scoped architectural governance for AI-assisted software development. The core mechanism is established; the current priority is proving that it prevents architectural drift on real repositories, with external developers and design partners, across the agent surfaces teams already use.
+
+This is no longer primarily a capability-building phase. New integrations and experiments are justified when they strengthen external validation, interoperability evidence, or the architectural-control thesis.
 
 ## What is frozen
 
-Pinned at commit [`e73ff7d`](https://github.com/TheoV823/mneme/commit/e73ff7d) and documented in [layer1-freeze-e73ff7d.md](./layer1-freeze-e73ff7d.md):
+Pinned at commit [`e73ff7d`](https://github.com/MnemeHQ/mneme/commit/e73ff7d) and documented in [layer1-freeze-e73ff7d.md](./layer1-freeze-e73ff7d.md):
 
 - **Retrieval mechanics** — deterministic bag-of-tokens scoring with fixed weights, stopword floor, insertion-order tiebreak.
-- **Enforcement semantics** — `anti_patterns` → FAIL, `"no X"` constraints → WARN, word-boundary matching. Frozen at `e73ff7d` as top-K-only (enforcement bounded by the retrieval top-N); [ADR-017](../adr/ADR-017-enforcement-scope-vs-retrieval-scope.md) subsequently separated enforcement scope from retrieval scope, so enforcement now evaluates the full decision corpus (literal rules corpus-wide, multi-term rules still retrieval-gated), with typed-rule semantics under [ADR-019](../adr/ADR-019-typed-literal-rule-contract.md)/[ADR-020](../adr/ADR-020-explicit-path-applicability-for-typed-rules.md).
+- **Enforcement semantics** — `anti_patterns` → FAIL, `"no X"` constraints → WARN, word-boundary matching. Frozen at `e73ff7d` as top-K-only (enforcement bounded by the retrieval top-N); [ADR-017](../adr/ADR-017-enforcement-scope-vs-retrieval-scope.md) subsequently separated enforcement scope from retrieval scope, so typed literal rules are evaluated independently of retrieval ranking, with typed-rule semantics under [ADR-019](../adr/ADR-019-typed-literal-rule-contract.md) and path applicability under [ADR-020](../adr/ADR-020-explicit-path-applicability-for-typed-rules.md).
 - **Benchmark methodology** — two-layer scoring (retrieval vs. enforcement), structured-fixture path with TXT fallback, five-verdict semantics, K=3 canonical.
 - **Charter principles** — deterministic > clever, auditable > autonomous, prevention before review, no passive ingestion, no auto-learning, no hidden vector magic.
-- **Scope wedge** — local-repo, single-developer, project-scoped. Multi-repo / team / org sync is Layer 2.
+- **Scope wedge** — project-scoped architectural governance. Team, org and cross-repo governance remain later-layer territory.
 
 No behavioral change to retrieval or enforcement is in scope without an explicit charter amendment.
 
-## What is experimental
+## What is shipped
 
-These are shipped but not under freeze; they may evolve without a charter amendment:
+The canonical support taxonomy lives in [docs/integrations/README.md](../integrations/README.md). As of the v0.6.0 line, shipped product surfaces include:
 
-- Cursor rules export.
-- Claude Code hook integration.
-- Claude Agent SDK adapter.
-- Google Antigravity pre-tool adapter.
-- Codex CLI enforcement integration (PreToolUse gate + Stop audit).
-- Paperclip — validated compatibility through both transports, no adapter required.
-- ADR parser/compiler/validator and read-only lifecycle reconciliation pipeline.
-- Site-level benchmark presentation copy.
+- `mneme` Python package and CLI, including `mneme check`, typed `FORBID_LITERAL` rules and explicit path applicability.
+- Authoritative governability assessment via `assess_governability()`, classifying decisions as `enforceable`, `partial`, or `guidance`.
+- ADR parser/compiler/validator plus read-only ADR lifecycle reconciliation.
+- **Native integrations:** Claude Code, Claude Agent SDK, Google Antigravity, Codex CLI, LangChain agents on LangGraph, and Kiro CLI 3.0 / v3.
+- **Validated compatibility:** Paperclip through its CLI and ACP transports.
+- **Rules export:** Cursor.
+- **CLI-based CI gates:** reference patterns for CI systems such as GitHub Actions and GitLab CI.
 
-The active Layer 1 product surface is the `mneme` Python package, the `mneme` CLI, the enforcement interfaces (`mneme check`, the `mneme-hook` Claude Code hook, Cursor rules export) and the supported integrations. A historical `POST /complete` HTTP wrapper once shipped alongside the legacy benchmark application; it was extracted from core with that application and is no longer part of the product surface. The extraction was structural only — it did not change retrieval, enforcement or benchmark methodology. The `mneme-hq[api]` optional dependency remains declared for compatibility, but it no longer installs an active HTTP layer. Reviving an HTTP surface would require a separate architectural decision.
+The Claude Code plugin also ships a `mneme` Skill and the `/mneme:context`, `/mneme:check`, `/mneme:record`, and `/mneme:review` commands. The Skill is an executable workflow over Mneme capabilities; deterministic enforcement remains owned by the hook and `mneme check`, not by the Skill itself.
+
+## What is experimental or evidence-only
+
+These surfaces have useful evidence but are not promoted to full support:
+
+- **Hermes Agent** — Experimental. Context injection and supported pre-tool blocking are proven; no blocking Stop-equivalent exists.
+- **OpenCode** — Experimental. Plugin-hook work remains incomplete; the completed compaction experiment returned a NULL verdict.
+- **Claude Managed Agents** — evidence-only **PARTIAL** result. New-file interception and multi-agent propagation are proven, but existing-file/edit materialization and completion-boundary limitations prevent support promotion.
+- **EventCatalog** — retrieval-only ADR ingestion and effectiveness validation exist, but graph enrichment remains intentionally deferred pending a jointly useful hypothesis.
+
+The Architecture Audit Workspace is a separate product-facing vertical slice over the released Mneme core. Governability semantics remain owned by the core package rather than being reimplemented in the UI.
 
 ## What is deferred
 
-Layer 2 territory. Listed in the freeze doc under §Deferred Work. Promoting any of these requires Layer 1 exit criteria to be met first:
+Later-layer territory. Promote only with user pull or evidence that it strengthens the current validation program:
 
-- ADR lineage and versioning.
 - Multi-developer / team governance.
 - Shared policy packs.
-- MCP / HTTP API surface (core ships none today; see *What is experimental*).
-- Deeper IDE integrations (LSP, JetBrains).
-- CI enforcement evolution.
-- Policy compiler / higher-level DSL.
 - Cross-repo / org-wide governance.
+- Generic MCP / hosted HTTP control plane.
+- Deeper IDE integrations where no reliable control seam exists.
+- Higher-level policy DSL beyond the current typed-rule path.
+- EventCatalog graph enrichment without a validated retrieval hypothesis.
+- Claude Managed Agents production support until the required mutation/current-byte or blocking completion surfaces exist.
 
-The freeze doc also lists "Intentionally NOT Solved" items — those are not deferred, they are out of scope for Mneme as a project.
+The freeze doc also lists "Intentionally NOT Solved" items — those are not deferred; they are out of scope for Mneme as a project.
 
 ## What success means right now
 
-The Layer 1 exit criteria from the freeze doc:
+The Layer 1 exit criteria from the freeze doc remain the governing test:
 
-1. Benchmark integrity stabilized — **met** at `e73ff7d`.
-2. Deterministic enforcement validated — **met** at `e73ff7d`.
+1. Benchmark integrity stabilized — **met**.
+2. Deterministic enforcement validated — **met**.
 3. Real-world drift prevention demonstrated — **open**, requires external evidence.
 4. Design-partner validation complete — **open**.
 5. Governance wedge validated — **open**.
 
-Items 1 and 2 are mechanical. Items 3, 4, and 5 are the work of this validation phase. They cannot be completed by writing more code in this repo.
+Items 1 and 2 are mechanical. Items 3, 4, and 5 are the work of the current phase. They cannot be completed by adding more integrations or writing more core code without external evidence.
+
+## Current priorities
+
+See the [current roadmap](../roadmap/README.md). In brief:
+
+- **Now:** design-partner / real-repository pilots, Architecture Audit as an acquisition and evidence surface, and reproducible architecture-compliance benchmarking.
+- **Next:** evolve the existing Claude Skill toward an Architecture Review workflow; continue high-value ADR/source ingestion such as Confluence; extend the Audit workflow for migration use cases; run the planned Deep Agents capability POC.
+- **Research:** Slack Code/shared multi-agent constraints, AWS AgentCore benchmarking, Salesforce Skills interoperability, and revisit triggers for Claude Managed Agents.
 
 ## Links
 
+- **Current roadmap** — [docs/roadmap/README.md](../roadmap/README.md)
+- **Historical adoption roadmap** — [2026-04-24-adoption-and-enhancement-roadmap.md](../roadmap/2026-04-24-adoption-and-enhancement-roadmap.md)
+- **Canonical integration support matrix** — [docs/integrations/README.md](../integrations/README.md)
 - **Freeze artifact** — [layer1-freeze-e73ff7d.md](./layer1-freeze-e73ff7d.md)
-- **Governance representation** — [governance-representation.md](./governance-representation.md) — how ADRs become deterministic enforcement rules
+- **Governance representation** — [governance-representation.md](./governance-representation.md)
 - **Benchmark methodology (public)** — [/benchmark/](https://mnemehq.com/benchmark/) and [/docs/benchmark-methodology/](https://mnemehq.com/docs/benchmark-methodology/)
-- **Roadmap** — [docs/roadmap/](../roadmap/)
 - **ADRs** — [docs/adr/](../adr/)
 - **Repo governance source of truth** — [`.mneme/project_memory.json`](../../.mneme/project_memory.json)
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,167 @@
+# Mneme — Current Roadmap
+
+> **Current roadmap — August 2026.**
+>
+> The original [April 2026 adoption and enhancement roadmap](./2026-04-24-adoption-and-enhancement-roadmap.md) is retained as historical context. It describes the path from an early working implementation to a usable developer tool. Mneme has moved beyond that stage: the core enforcement mechanism and several native agent integrations now ship. This file is the current operational roadmap.
+
+## Current phase
+
+**External validation and adoption.**
+
+The central question is no longer whether Mneme can implement architectural enforcement. The current question is whether that control layer produces repeatable value on real repositories, with external developers and design partners, across the AI coding surfaces teams already use.
+
+The roadmap therefore prioritizes evidence, pilots, and interoperability over adding integrations for their own sake.
+
+## NOW — prove the wedge
+
+### P0 — Design partners and real-repository pilots
+
+Use real projects to validate whether recorded architectural decisions prevent meaningful drift during AI-assisted development.
+
+**Evidence sought**
+
+- first-attempt architectural compliance;
+- functional completion;
+- unrequested scope expansion;
+- setup and maintenance friction;
+- whether teams retain Mneme after the initial evaluation.
+
+### P0 — Architecture Audit as an acquisition and evidence surface
+
+Use the Architecture Audit Workspace to identify which existing architectural decisions are mechanically governable and where enforcement gaps remain.
+
+The Audit consumes the authoritative core `assess_governability()` result. It must not grow a second policy model in the UI.
+
+### P0 — Reproducible architecture-compliance benchmark
+
+Extend the existing benchmark discipline toward externally legible comparisons of architectural compliance across coding-agent workflows.
+
+Prefer frozen fixtures, deterministic scoring, clear treatment/control boundaries, and explicit separation of functional completion from architectural compliance.
+
+## NEXT — strengthen the product surface
+
+### P1 — Architecture Review Skill
+
+Evolve the existing Claude Code `mneme` Skill into a clearer executable architecture-review interface over existing Mneme capabilities.
+
+The intended workflow is:
+
+```text
+project decisions / ADRs
+        ↓
+relevant context
+        ↓
+proposed or pending change
+        ↓
+Mneme check / review / governability evidence
+        ↓
+structured architecture review
+```
+
+**Constraint:** the Skill is an interface over Mneme retrieval and deterministic enforcement. It must not become a second policy engine or substitute model judgment for `mneme check` verdicts.
+
+Initial work should reuse the shipped `/mneme:context`, `/mneme:check`, `/mneme:record`, and `/mneme:review` surfaces before adding new runtime behavior.
+
+### P1 — Confluence ADR ingestion
+
+Continue the ADR/source-ingestion track where it gives teams a lower-friction path from existing decision records into Mneme.
+
+Keep ingestion separate from enforcement semantics: source adapters import architectural intent; the Mneme core decides how that intent is represented and governed.
+
+### P1 — Migration-aware Architecture Audit
+
+Extend the existing Audit workflow for long-running migrations and modernization, where legacy and target architectures coexist and path applicability matters.
+
+Do not create a separate migration product unless pilot evidence justifies it.
+
+### P1.5 — Deep Agents capability POC
+
+Run the pinned Deep Agents validation already described in the integration roadmap. Determine whether filesystem mutation tools expose a reliable pre-mutation seam and whether nested/subagent behavior preserves the governance boundary.
+
+Promotion requires evidence; no support claim before the capability gate passes.
+
+## RESEARCH — evidence before integration
+
+### P2 — Slack Code and shared multi-agent constraints
+
+Investigate whether a shared coding workspace can consume one project architectural contract across multiple coding agents and sessions.
+
+The question is not generic workspace governance. It is whether Mneme can remain the architectural-control layer while the harness coordinates agents, permissions, and collaboration.
+
+### P2 — AWS AgentCore benchmark
+
+Retain the existing AgentCore experiment: use AgentCore as a controlled multi-agent execution substrate for architecture-compliance benchmarking before deciding whether a deeper product integration is justified.
+
+### P2 — Salesforce Skills interoperability
+
+Test whether Mneme adds measurable project-specific architectural compliance when Claude Code is already using Salesforce's domain Skills.
+
+Candidate treatment structure:
+
+```text
+A  Claude Code + Salesforce Skills
+B  Claude Code + Salesforce Skills + Mneme review/context workflow
+C  Claude Code + Salesforce Skills + Mneme workflow + deterministic hook
+```
+
+Measure architecture compliance, functional completion, and scope expansion.
+
+**This is an interoperability experiment, not a Claudeforce integration claim.** Do not add Salesforce or Claudeforce to the support matrix until Mneme has actual validation evidence or maintained adapter code.
+
+### P2 — Claude Managed Agents revisit
+
+The completed M0 is **PARTIAL** and remains evidence-only.
+
+Revisit only if Anthropic exposes one or more of the missing control surfaces identified by the validation:
+
+- current workspace bytes at approval time;
+- a filesystem-local confirmation/evaluation handler;
+- a blocking completion/Stop-equivalent boundary.
+
+## DEFERRED — wait for evidence or user pull
+
+- EventCatalog graph enrichment beyond the validated retrieval-only boundary, until there is a jointly useful hypothesis.
+- Team/org policy synchronization.
+- Cross-repository governance.
+- Shared policy packs.
+- Generic hosted MCP / HTTP control plane.
+- Broad SaaS administration, billing, or account surfaces.
+- Higher-level policy DSL beyond the current typed-rule path.
+- Deeper integrations that do not expose a reliable mutation or verification seam.
+
+## Shipped foundation
+
+The roadmap assumes the following foundation is already delivered:
+
+- deterministic decision retrieval and project memory;
+- ADR compiler / precedence path;
+- strict/warn enforcement;
+- typed `FORBID_LITERAL` rules;
+- explicit path applicability;
+- introduced-delta enforcement and prevent → catch → verify integration model;
+- authoritative governability assessment;
+- read-only ADR lifecycle reconciliation;
+- enforcement-quality benchmark discipline;
+- native integrations for Claude Code, Claude Agent SDK, Google Antigravity, Codex CLI, LangChain/LangGraph, and Kiro CLI v3;
+- validated Paperclip compatibility;
+- experimental Hermes integration;
+- evidence-only Claude Managed Agents validation;
+- EventCatalog retrieval-only ADR ingestion and effectiveness validation;
+- Architecture Audit Workspace vertical slice.
+
+For current support claims, always use [the canonical integration support matrix](../integrations/README.md), not this roadmap.
+
+## Roadmap rules
+
+1. **Evidence before promotion.** A planned or experimental surface does not become supported because an adapter looks feasible.
+2. **Reuse the core.** Integrations translate transport and lifecycle events into existing Mneme semantics; they do not copy retrieval or enforcement logic.
+3. **External validation outranks integration count.** A real design-partner result is more valuable than another unvalidated adapter.
+4. **Keep retrieval separate from enforcement.** Context, Skills, RAG, and source ingestion can improve what the agent knows; deterministic rules decide what Mneme can mechanically govern.
+5. **No speculative platform expansion.** Hosted/team/org layers wait for user pull and evidence from the current wedge.
+
+## Related
+
+- [Current phase](../architecture/current-phase.md)
+- [Canonical integration support matrix](../integrations/README.md)
+- [Historical April 2026 roadmap](./2026-04-24-adoption-and-enhancement-roadmap.md)
+- [Changelog](../../CHANGELOG.md)

--- a/integrations/claude-code-plugin/skills/mneme/SKILL.md
+++ b/integrations/claude-code-plugin/skills/mneme/SKILL.md
@@ -2,73 +2,125 @@
 name: mneme
 description: |
   Architectural governance for this project. Use this skill when the user
-  asks about project decisions, architectural constraints, or wants to
-  enforce / record / review decisions. Also use whenever Claude Code is
-  about to make a non-trivial edit and the project has a `.mneme/`
-  directory — check relevant decisions first.
+  asks about project decisions, ADRs, architectural constraints, or wants to
+  review, record, or enforce decisions. Also use before non-trivial edits when
+  the project has a `.mneme/` directory so the relevant architectural context
+  is visible before implementation.
 ---
 
-# Mneme — project memory & governance
+# Mneme — project memory & architectural governance
 
-This project uses Mneme to enforce architectural decisions. When this plugin is
-enabled, a `PreToolUse` hook checks `Edit` and `Write` tool calls against the
-project's recorded decisions and can block edits that violate them. Files
-written by shell commands are not covered.
+This project uses Mneme to keep AI-assisted changes aligned with recorded
+architectural decisions.
+
+The **Skill is the workflow interface**: it helps Claude retrieve decisions,
+record them, check proposed content, and review pending changes. The Skill does
+not implement a second policy engine. Deterministic verdicts come from the
+existing `mneme check` engine and the Claude Code hook.
+
+When the plugin is enabled, Mneme uses a prevent → catch → verify model:
+
+- `PreToolUse` evaluates reconstructable file mutations before they land.
+- `Stop` audits session-introduced changes that could not be safely preflighted.
+- CI remains the final verification boundary.
 
 ## When this skill activates
 
-- User mentions "ADR", "decision", "constraint", "anti-pattern", "architecture".
+- User mentions "ADR", "decision", "constraint", "anti-pattern", "architecture", or architectural review.
 - A `.mneme/project_memory.json` file exists in the repo.
 - About to make a non-trivial edit in an area that may be governed by recorded decisions.
+- Reviewing a proposed or completed change for architectural compliance.
 
 ## How to use it
 
 1. **Before non-trivial edits** — run `/mneme:context` with a descriptive task
-   phrase (e.g. "storage layer changes", "auth middleware refactor"). Use domain
-   language, not just the file name — retrieval is keyword-based and the query
-   must overlap with decision scope fields to surface relevant decisions.
+   phrase such as "storage layer changes" or "auth middleware refactor".
+   Domain language is more useful than a generic file name for retrieval-based
+   guidance.
 
-2. **To gate a draft** — run `/mneme:check` against the proposed content, again
-   with a descriptive `--query`.
+2. **To gate a draft** — run `/mneme:check` against the proposed content with
+   the real target path when available. Treat the command's verdict as the
+   authority; do not infer PASS from the Skill's own reasoning.
 
-3. **To record a new decision** — run `/mneme:record`. When choosing `scope`
-   keywords, pick terms that will appear in file names or task descriptions
-   where this decision applies, so the hook can retrieve it automatically.
+3. **To record a new decision** — run `/mneme:record`. Choose clear scope and
+   applicability so future retrieval and enforcement can identify where the
+   decision belongs.
 
-4. **To audit pending changes** — run `/mneme:review`.
+4. **To review pending changes** — run `/mneme:review`. Use the output as the
+   evidence layer for an architectural review: which decisions apply, which
+   changes comply, which are denied or warned, and which surfaces were not
+   mechanically evaluated.
+
+## Retrieval is not enforcement
+
+Mneme deliberately separates architectural context from deterministic policy
+checks.
+
+- `/mneme:context` retrieves relevant decisions for guidance.
+- Legacy text constraints may still depend on retrieval semantics.
+- Typed rules such as `FORBID_LITERAL` are enforced independently of retrieval
+  ranking across the decision corpus, subject to explicit path applicability.
+- `mneme check --target-path` is the authority for path-scoped evaluation.
+- An `UNKNOWN` / incomplete applicability state is not a PASS.
+
+Do not assume that a decision was unenforced merely because it was absent from
+the top retrieved context.
 
 ## Hook enforcement
 
-A `PreToolUse` hook runs automatically on `Edit` and `Write` tool calls (the
-matcher also lists `MultiEdit` for compatibility). It reconstructs the full
-post-edit file content, then calls `mneme check --json` with the query
-`"edit to <file_path>"`. Decisions whose scope or text share tokens with the
-file name are retrieved and checked.
+The plugin's `PreToolUse` hook covers direct `Edit`, `Write`, and compatible
+`MultiEdit` mutations by reconstructing the proposed post-edit content and
+calling the existing Mneme checker.
 
-**Not covered:** files written by `Bash` commands. A shell redirect or `sed`
-never fires a `PreToolUse` file-edit hook. Run `/mneme:review` after such
-changes.
+For shell mutations, Mneme only preflight-blocks forms whose resulting path and
+content can be proven from the command itself, such as supported simple quoted
+heredoc writes. Pipelines, substitutions, interpreters, generators, and other
+opaque shell forms are allowed to run and are evaluated at the `Stop` boundary
+from the session delta where possible.
 
-**Retrieval caveat:** The automatic hook query is derived from the file path, so
-decisions with scope keywords that don't appear in file names may not be retrieved
-automatically. Use `/mneme:context` before large edits to confirm coverage.
+The `Stop` audit is a catch boundary, not proof that every external or remote
+mutation surface is governed. If evaluation is unavailable or incomplete,
+Mneme must surface that state rather than silently calling it PASS.
 
-If the proposed change violates a decision in strict mode, Claude Code is blocked
-and the violated decision id is surfaced in the error.
+In strict mode, a trusted violating verdict can block the mutation or completion
+boundary and surfaces the violated decision id so Claude can correct course.
+Anything the adapter cannot evaluate reliably fails open visibly.
+
+## Architectural review workflow
+
+For a substantive review, use this order:
+
+1. State the implementation intent and affected paths.
+2. Retrieve the relevant project decisions with `/mneme:context`.
+3. Inspect the proposed or pending change.
+4. Use `/mneme:check` or `/mneme:review` for deterministic evidence.
+5. Separate the result into:
+   - mechanically enforced violations or passes;
+   - guidance-only architectural concerns;
+   - unevaluated / unsupported mutation surfaces.
+6. Recommend the smallest compliant correction rather than inventing new
+   architectural requirements.
+
+This is the foundation for a richer Architecture Review Skill surface on the
+roadmap; today it is an executable review workflow over existing Mneme commands,
+not a new enforcement subsystem.
 
 ## Requirements & configuration
 
-- **Mneme must be installed** and `mneme-hook` must be on `PATH`:
-  `pipx install "mneme-hq>=0.5.1"`. The version floor is required — earlier
-  releases lack the `--json` verdict the hook depends on. Without Mneme the
-  hook fails open (edits are never blocked). See the plugin README for details.
+- **Mneme must be installed** and `mneme-hook` must be on `PATH`. Use the
+  version documented by the plugin README; the runtime and plugin are separate
+  artifacts.
 - **Enforcement mode** is set by the plugin's `mode` configuration option and
   reaches the hook as `CLAUDE_PLUGIN_OPTION_MODE`. Precedence:
-  `MNEME_HOOK_MODE` > `CLAUDE_PLUGIN_OPTION_MODE` > `strict`; unknown values fall
-  back to `strict`. Use `warn` while iterating on decisions to avoid friction.
+  `MNEME_HOOK_MODE` > `CLAUDE_PLUGIN_OPTION_MODE` > `strict`; unknown values
+  fall back to `strict`.
+- Use `warn` while iterating on decisions if blocking would create unnecessary
+  friction, but do not represent WARN as PASS.
 
 ## Related
 
 - Project memory: `.mneme/project_memory.json`
 - CLI reference: `mneme --help`
 - Plugin README: `integrations/claude-code-plugin/README.md`
+- Canonical support matrix: `docs/integrations/README.md`
+- Current roadmap: `docs/roadmap/README.md`


### PR DESCRIPTION
## Summary

Refresh Mneme's current documentation around the actual August 2026 product state.

- add `docs/roadmap/README.md` as the current operational roadmap while retaining the April roadmap as historical context
- reframe `docs/architecture/current-phase.md` from capability-building to external validation and adoption
- align the shipped Claude Code `mneme` Skill with current prevent → catch → verify behavior, typed-rule enforcement independent of retrieval ranking, path applicability, and visible unevaluated states
- add the Architecture Review Skill as a P1 evolution of the existing Skill, not a second policy engine
- keep Salesforce Skills as an interoperability experiment only; no Claudeforce/support-matrix claim

## Boundaries

- docs / Skill instructions only
- no retrieval, enforcement, benchmark, ADR, memory-format, or integration runtime changes
- canonical integration support taxonomy remains `docs/integrations/README.md`

## Execution provenance

- Change author: agent
- Agent: chatgpt
- Agent model: GPT-5.6 Sol
- Agent session: not-exposed
- Task origin: chatgpt
- Human owner: @TheoV823
