### PR TITLE
Add enforcement-quality benchmark results

### DIFF
--- a/examples/benchmarks-enforcement-quality/reports/RESULTS.md
+++ b/examples/benchmarks-enforcement-quality/reports/RESULTS.md
@@ -1,0 +1,54 @@
+# Enforcement-Quality Benchmark Results
+
+Run against the frozen suite in `examples/benchmarks-enforcement-quality/`,
+authorized by [charter #318](../../../docs/plans/2026-08-24-benchmark-fpr-charter.md)
+and the `[layer1-freeze]` amendment (#319). See that directory's `README.md`
+for suite composition, invocation, and metric definitions.
+
+## Invocation
+
+```bash
+python -m mneme benchmark examples/benchmarks-enforcement-quality \
+  --memory examples/benchmarks-enforcement-quality/project_memory.json \
+  --json report.json --markdown report.md
+```
+
+## Results
+
+| Scenario | Type | Verdict | Baseline violations | Enhanced violations |
+|---|---|---|---|---|
+| benign_awin_programme | benign | PASS | 0 | 0 |
+| benign_foo_bar_incomplete | benign | PASS | 0 | 0 |
+| benign_governance_docs | benign | PASS | 0 | 0 |
+| benign_slug_prose | benign | PASS | 0 | 0 |
+| guard_awin_identifier | violation | PASS | 1 | 0 |
+| guard_foo_and_bar_compound | violation | PASS | 1 | 0 |
+| guard_unreviewed_changes | violation | PASS | 1 | 0 |
+
+## Summary
+
+**Violation catch rate (Layer 2 enforcement):** 3/3 (100%). All three guard
+scenarios were caught — the baseline (no Mneme) triggered the forbidden
+pattern in each; the Mneme-enhanced response did not.
+
+**False-positive rate:** 0/4 checkable (0%). None of the four benign
+controls were blocked. `benign_uncheckable`: 0/4.
+
+**Layer 1 (retrieval, n=3):** mean Recall@3 = 1.00, mean Precision@3 = 1.00,
+irrelevant injection rate = 0%.
+
+**By category:**
+
+- **enforcement_quality**: 3/3 PASS
+
+## What this proves and does not prove
+
+**Proves:** on this frozen regression suite, Mneme's enforcement path
+correctly blocked all three injected violations and did not block any of the
+four benign controls it was run against.
+
+**Does not prove:** false-positive behavior in production codebases, on
+scenarios outside this fixed suite, or under adversarial paraphrase. Per the
+`[layer1-freeze]` amendment, this suite is a fixed regression control, not an
+adversarial or continuously expanding benchmark — see the freeze document's
+"Why benchmark expansion is frozen" for that boundary.

--- a/examples/benchmarks-enforcement-quality/reports/RESULTS.md
+++ b/examples/benchmarks-enforcement-quality/reports/RESULTS.md
@@ -35,7 +35,13 @@ pattern in each; the Mneme-enhanced response did not.
 controls were blocked. `benign_uncheckable`: 0/4.
 
 **Layer 1 (retrieval, n=3):** mean Recall@3 = 1.00, mean Precision@3 = 1.00,
-irrelevant injection rate = 0%.
+irrelevant injection rate = 0%. These retrieval figures belong **only to
+this enforcement-quality suite's 3 violation scenarios** — they are a
+different, smaller suite from the canonical 7-scenario benchmark in
+`examples/benchmarks/`, whose own `RESULTS.md` reports mean Precision@3 =
+0.33 on n=5. The two numbers measure the same metric on different scenario
+sets and are not comparable or interchangeable; do not cite one suite's
+figure as if it were the other's.
 
 **By category:**
 

--- a/examples/benchmarks-enforcement-quality/reports/results.json
+++ b/examples/benchmarks-enforcement-quality/reports/results.json
@@ -1,0 +1,326 @@
+{
+  "summary": {
+    "total": 7,
+    "passed": 3,
+    "failed": 0,
+    "weak": 0,
+    "weak_retrieval": 0,
+    "pass_rate": 1.0,
+    "by_category": {
+      "enforcement_quality": {
+        "pass": 3,
+        "fail": 0,
+        "total": 3
+      }
+    },
+    "layer1": {
+      "k": 3,
+      "mean_recall_at_k": 1.0,
+      "mean_precision_at_k": 1.0,
+      "irrelevant_injection_rate": 0.0,
+      "scored_count": 3
+    },
+    "layer2": {
+      "passed": 3,
+      "failed": 0,
+      "weak": 0,
+      "weak_retrieval": 0,
+      "pass_rate": 1.0
+    },
+    "enforcement_quality": {
+      "violation_passed": 3,
+      "violation_checkable": 3,
+      "benign_total": 4,
+      "benign_blocked": 0,
+      "benign_checkable": 4,
+      "false_positive_rate": 0.0,
+      "benign_uncheckable": 0
+    }
+  },
+  "results": [
+    {
+      "name": "benign_awin_programme",
+      "verdict": "PASS",
+      "baseline_violation_count": 0,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [],
+      "enhanced_triggers": [],
+      "explanation": "Benign content passed with governing decision(s) awin-001 in enforcement scope.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "awin-001",
+          "gov-001"
+        ],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.0,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 0,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      },
+      "scenario_type": "benign",
+      "exposure": {
+        "expected_ids": [
+          "awin-001"
+        ],
+        "in_scope": [
+          "awin-001"
+        ]
+      }
+    },
+    {
+      "name": "benign_foo_bar_incomplete",
+      "verdict": "PASS",
+      "baseline_violation_count": 0,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [],
+      "enhanced_triggers": [],
+      "explanation": "Benign content passed with governing decision(s) fb-001 in enforcement scope.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "fb-001"
+        ],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.0,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 0,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      },
+      "scenario_type": "benign",
+      "exposure": {
+        "expected_ids": [
+          "fb-001"
+        ],
+        "in_scope": [
+          "fb-001"
+        ]
+      }
+    },
+    {
+      "name": "benign_governance_docs",
+      "verdict": "PASS",
+      "baseline_violation_count": 0,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [],
+      "enhanced_triggers": [],
+      "explanation": "Benign content passed with governing decision(s) gov-001 in enforcement scope.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "gov-001"
+        ],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.0,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 0,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      },
+      "scenario_type": "benign",
+      "exposure": {
+        "expected_ids": [
+          "gov-001"
+        ],
+        "in_scope": [
+          "gov-001"
+        ]
+      }
+    },
+    {
+      "name": "benign_slug_prose",
+      "verdict": "PASS",
+      "baseline_violation_count": 0,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [],
+      "enhanced_triggers": [],
+      "explanation": "Benign content passed with governing decision(s) slug-001 in enforcement scope.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "slug-001"
+        ],
+        "expected_ids": [],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 0.0,
+        "irrelevant_injection": true
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 0,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": []
+      },
+      "scenario_type": "benign",
+      "exposure": {
+        "expected_ids": [
+          "slug-001"
+        ],
+        "in_scope": [
+          "slug-001"
+        ]
+      }
+    },
+    {
+      "name": "guard_awin_identifier",
+      "verdict": "PASS",
+      "baseline_violation_count": 1,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [
+        "assume_awin_awin_us_same_source"
+      ],
+      "enhanced_triggers": [],
+      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (assume_awin_awin_us_same_source); enhanced response had none. Retrieved: awin-001.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "awin-001"
+        ],
+        "expected_ids": [
+          "awin-001"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 1.0,
+        "irrelevant_injection": false
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 1,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "assume_awin_awin_us_same_source"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "awin-001"
+        ]
+      },
+      "scenario_type": "violation",
+      "exposure": {
+        "expected_ids": [
+          "awin-001"
+        ],
+        "in_scope": [
+          "awin-001"
+        ]
+      }
+    },
+    {
+      "name": "guard_foo_and_bar_compound",
+      "verdict": "PASS",
+      "baseline_violation_count": 1,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [
+        "foo and bar"
+      ],
+      "enhanced_triggers": [],
+      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (foo and bar); enhanced response had none. Retrieved: fb-001.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "fb-001"
+        ],
+        "expected_ids": [
+          "fb-001"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 1.0,
+        "irrelevant_injection": false
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 1,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "foo and bar"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "fb-001"
+        ]
+      },
+      "scenario_type": "violation",
+      "exposure": {
+        "expected_ids": [
+          "fb-001"
+        ],
+        "in_scope": [
+          "fb-001"
+        ]
+      }
+    },
+    {
+      "name": "guard_unreviewed_changes",
+      "verdict": "PASS",
+      "baseline_violation_count": 1,
+      "enhanced_violation_count": 0,
+      "baseline_triggers": [
+        "unreviewed enforcement changes"
+      ],
+      "enhanced_triggers": [],
+      "explanation": "Mneme prevented the violation. Baseline triggered 1 violation(s) (unreviewed enforcement changes); enhanced response had none. Retrieved: gov-001.",
+      "layer1": {
+        "k": 3,
+        "retrieved_ids": [
+          "gov-001"
+        ],
+        "expected_ids": [
+          "gov-001"
+        ],
+        "acceptable_ids": [],
+        "recall_at_k": 1.0,
+        "precision_at_k": 1.0,
+        "irrelevant_injection": false
+      },
+      "layer2": {
+        "verdict": "PASS",
+        "baseline_violation_count": 1,
+        "enhanced_violation_count": 0,
+        "baseline_triggers": [
+          "unreviewed enforcement changes"
+        ],
+        "enhanced_triggers": [],
+        "protected_decision_ids_hit": [
+          "gov-001"
+        ]
+      },
+      "scenario_type": "violation",
+      "exposure": {
+        "expected_ids": [
+          "gov-001"
+        ],
+        "in_scope": [
+          "gov-001"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Publishes the first run results for the frozen `examples/benchmarks-enforcement-quality/` suite (authorized by charter #318 / freeze amendment #319). The suite existed with scenarios but no committed report. Adds `reports/RESULTS.md` and `reports/results.json`, run unchanged against the existing suite — no scenario, threshold, or methodology changes.

Result: 3/3 violation scenarios caught, 0/4 benign controls false-positived, mean Recall@3/Precision@3 = 1.00 on this suite's n=3 violation scenarios. RESULTS.md explicitly disambiguates this suite's Precision@3=1.00 from the canonical `examples/benchmarks/` suite's Precision@3=0.33 (different scenario sets, not comparable) to avoid citation confusion.

Needed as a public, linkable first-party evidence artifact for a citation-worthiness content pass on mnemehq.com (evidence unit "E2").

## Validation

- Ran `python -m mneme benchmark examples/benchmarks-enforcement-quality --memory examples/benchmarks-enforcement-quality/project_memory.json --json ... --markdown ...` twice; identical results both runs.
- Verified `results.json` summary fields match every number stated in `RESULTS.md`.
- No scenario files, fixture memory, or suite code touched.
- Confirmed no secrets, local paths, or transient data in either committed file.

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: claude-sonnet-5
- Agent session: not-exposed
- Task origin: local
- Human owner: @TheoV823