### PR TITLE
feat: add mneme setup command with activation state (M1.3a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ In strict mode, the prohibited YAML proposal returns a `FAIL` verdict and exit c
 
 The CLI is the common enforcement surface. Agent integrations translate their native events into the same Mneme decision and enforcement model.
 
+## Setup mode (no enforcement)
+
+`mneme setup` initializes Mneme in a repository without changing how the team works: it creates or detects project memory, detects supported agent environments, and reports protection readiness — all without enabling any blocking enforcement. Setup never turns warn/observe behavior into blocking behavior; activation of preventive enforcement is always a separate, explicit decision.
+
+```bash
+mneme setup
+```
+
+Optionally record an opaque Architecture Audit reference so the setup can be attributed back to a saved Audit baseline:
+
+```bash
+mneme setup --audit-ref <reference>
+```
+
+Setup is idempotent: rerunning it against an existing Mneme project leaves valid configuration untouched.
+
 ## How it works
 
 ```text

--- a/docs/plans/m1-3-execution-log.md
+++ b/docs/plans/m1-3-execution-log.md
@@ -69,6 +69,16 @@ IN PROGRESS (PR open)
 - Activation state persisted inside `project_memory.json` (`activation` key)
   rather than a new file — contract section 7 requires reusing existing
   project metadata; verified every memory writer preserves unknown keys.
+- **P1.2 reconciliation (post-merge of #346)**: readiness classification is
+  NOT an independent interpretation. `mneme/readiness.py` delegates to the
+  frozen P1.2 API (`assess_protection` / `generate_protection_report`),
+  and setup passes the project root so the CI-evidence scan matches
+  `mneme audit --repo-root`. Parity regression tests
+  (`tests/test_setup_audit_parity.py`) pin that `mneme audit` and
+  `mneme setup` agree on all four tier counts for the same
+  memory/repository — including verified-CI upgrades and status
+  (superseded/deprecated) exclusion — and that setup never upgrades
+  anything beyond the audit.
 - Legacy memory without an activation record derives as `setup` (Mneme
   present, enforcement never persisted as enabled); `not_installed` only
   when no memory file exists.

--- a/docs/plans/m1-3-execution-log.md
+++ b/docs/plans/m1-3-execution-log.md
@@ -1,0 +1,101 @@
+# M1.3 — Audit-to-Setup Activation: Execution Log
+
+Contract: `docs/plans/m1-3-audit-to-setup-activation.md` (frozen).
+
+## Current increment
+M1.3a — Setup state + CLI
+
+## Status
+IN PROGRESS (PR open)
+
+## Completed
+- Activation state model (`mneme/setup_state.py`): `not_installed → setup → active`,
+  persisted as an optional top-level `activation` key in the existing
+  `.mneme/project_memory.json` (no parallel state file; all existing writers
+  do raw read-modify-write and preserve unknown keys).
+- `mneme setup` CLI command (`mneme/setup.py` + `mneme/cli.py`):
+  git-repository context check, initialization of project memory when
+  required (scaffold reuses the init scaffold), memory validation, agent
+  environment detection (read-only), readiness view, setup summary,
+  idempotent reruns.
+- Readiness view (`mneme/readiness.py`): Protected / Mneme-ready /
+  Requires modelling / Guidance mapped from `assess_governability`.
+  Protected requires typed FORBID_LITERAL evidence.
+- Integration detection (`mneme/integrations/detect.py`): Claude Code,
+  Codex CLI, Kiro, Cursor. Detection only; never writes configuration,
+  never enables enforcement.
+- `--audit-ref` consumed and recorded verbatim as an opaque string.
+  Resolution/pairing is M1.3b (not implemented yet).
+- Extracted shared ADR diagnostics collection to `mneme/adr_diagnostics.py`
+  (used by both `check` and `setup`; no behavior change).
+- README: setup-mode section.
+
+## Current work
+- PR for M1.3a; then M1.3b (Audit baseline pairing in mnemehq-site backend
+  + CLI resolution).
+
+## Acceptance gates
+- G1 (safe setup): PASS — `test_setup_fresh_repo_initializes_in_setup_mode`
+  (fresh git repo → state `setup`, `enforcement: "not_enabled"`,
+  `activated_at: null`), `test_setup_creates_nothing_but_mneme_state`
+  (only `.mneme/project_memory.json` added),
+  `test_setup_does_not_touch_existing_agent_configuration`.
+- G2 (idempotency / existing projects): PASS —
+  `test_setup_rerun_is_byte_identical`,
+  `test_setup_existing_project_preserves_all_content`,
+  `test_setup_rerun_on_existing_project_preserves_first_completion`,
+  `test_setup_on_corrupt_memory_fails_without_mutation`,
+  `test_setup_on_schema_invalid_memory_fails_without_mutation`,
+  `test_setup_on_invalid_activation_record_fails_without_mutation`.
+- G3 (audit linking): NOT YET APPLICABLE — M1.3b.
+- G4 (no protection-score inflation): PASS —
+  `test_readiness_single_term_anti_pattern_is_not_protected`,
+  `test_setup_readiness_does_not_inflate_protection` (setup-only run keeps
+  Mneme-ready as Mneme-ready; no rule materialization);
+  readiness is a pure view over `assess_governability`.
+- G5 (integration detection): PASS —
+  `test_setup_detects_all_supported_environments`,
+  `test_setup_without_environments_reports_none`,
+  `test_detection_creates_no_files` (detection activates nothing).
+- G6 (audit UI activation state): NOT YET APPLICABLE — M1.3c.
+- G7 (funnel attribution): NOT YET APPLICABLE — M1.3b/d.
+- G8 (existing-product regression): PASS — full suite
+  `1179 passed, 6 skipped` (baseline suite, worktree HEAD), frozen
+  benchmark runs `examples/benchmarks` and
+  `examples/benchmarks-enforcement-quality` byte-identical to `main`
+  (exit 0 both, same verdicts).
+
+## Implementation decisions
+- Activation state persisted inside `project_memory.json` (`activation` key)
+  rather than a new file — contract section 7 requires reusing existing
+  project metadata; verified every memory writer preserves unknown keys.
+- Legacy memory without an activation record derives as `setup` (Mneme
+  present, enforcement never persisted as enabled); `not_installed` only
+  when no memory file exists.
+- Rerun with no material change performs no write (strongest idempotency);
+  rerun with changes (e.g. new `--audit-ref`) preserves first-completion
+  timestamps.
+- Setup on an `active` project refuses to downgrade: leaves the record
+  untouched and reports a warning (no silent state transitions).
+- Readiness classification lives in core (`mneme/readiness.py`) and treats
+  only typed FORBID_LITERAL rules as Protected — single-term anti-patterns
+  (governability tier `enforceable`) remain Mneme-ready. This mirrors the
+  frozen P1.2 mapping in the audit workspace and is the G4-critical choice.
+- M1.3a does not configure integrations (contract: setup MAY configure
+  non-blocking integration behavior; choosing detect-only minimizes risk of
+  implicit enforcement; hooks default to strict and must never be installed
+  implicitly).
+- Invalid audit refs (empty/whitespace/overlong) fail closed before any
+  write; M1.3b adds resolution semantics on top of the same guardrails.
+
+## Verification
+- New tests: `tests/test_setup_state.py` (20), `tests/test_cli_setup.py`
+  (28) — all pass.
+- Full repository suite: `python -m pytest -q` → 1179 passed, 6 skipped.
+- Frozen benchmarks: `mneme benchmark examples/benchmarks` and
+  `mneme benchmark examples/benchmarks-enforcement-quality` — output and
+  exit codes identical to `main`.
+- Worktree context verified via `scripts/check_worktree_context.py`.
+
+## Escalations
+None

--- a/mneme/adr_diagnostics.py
+++ b/mneme/adr_diagnostics.py
@@ -1,0 +1,31 @@
+"""
+adr_diagnostics.py — Shared warn-only ADR diagnostics collection.
+
+Combines ADR freshness issues and lifecycle findings into one deduplicated
+list. Consumers (``mneme check``, ``mneme setup``) render these as warnings;
+they never influence exit codes or enforcement behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mneme.adr_freshness import FreshnessIssue, check_freshness
+from mneme.adr_lifecycle import analyze_lifecycle
+
+
+def collect_adr_diagnostics(
+    memory_path: str | Path,
+    adr_dir: str | Path,
+) -> list[FreshnessIssue]:
+    """Collect ADR freshness issues and lifecycle findings (warn-only)."""
+    freshness = check_freshness(memory_path=memory_path, adr_dir=adr_dir)
+    lifecycle = analyze_lifecycle(corpus_dir=adr_dir, memory_path=memory_path)
+    seen: set[tuple[str, str, str]] = set()
+    combined: list[FreshnessIssue] = []
+    for issue in freshness + lifecycle:
+        key = (issue.code, issue.adr_id, issue.path)
+        if key not in seen:
+            seen.add(key)
+            combined.append(issue)
+    return combined

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -4,6 +4,8 @@ cli.py — Command-line interface for Mneme.
 Subcommands
 -----------
   init              Scaffold an empty project_memory.json.
+  setup             Initialize Mneme project state in setup mode (no
+                    enforcement). See docs/plans/m1-3-audit-to-setup-activation.md.
   add_decision      Append a new Decision to a project_memory.json file.
   list_decisions    Print every Decision in the memory file.
   test_query        Run a query through the retriever and show scores + injected.
@@ -33,8 +35,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from mneme.adr_freshness import FreshnessIssue, check_freshness
-from mneme.adr_lifecycle import analyze_lifecycle
+from mneme.adr_diagnostics import collect_adr_diagnostics
+from mneme.adr_freshness import FreshnessIssue
 from mneme.adr_import import (
     apply_import,
     compile_for_import,
@@ -59,6 +61,9 @@ from mneme.enforcer import (
     generate_protection_report,
 )
 from mneme.memory_store import MemoryStore
+from mneme.readiness import READINESS_LABELS, READINESS_ORDER
+from mneme.setup import SetupError, SetupOutcome, run_setup
+from mneme.setup_state import STATE_ACTIVE, scaffold_project_memory
 
 
 def _utc_now() -> str:
@@ -91,17 +96,7 @@ def _scaffold_memory() -> dict:
     enforce). meta.name and meta.description are the only fields the loader
     requires; created_by is recorded for provenance.
     """
-    return {
-        "meta": {
-            "name": "",
-            "description": "",
-            "created_by": "mneme init",
-            "created": _utc_now(),
-        },
-        "items": [],
-        "examples": [],
-        "decisions": [],
-    }
+    return scaffold_project_memory(created_by="mneme init")
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
@@ -122,6 +117,78 @@ def _cmd_init(args: argparse.Namespace) -> int:
     print(f"  mneme add_decision --memory {path} \\")
     print('      --id my_001 --decision "..." --scope <area> --constraint "..."')
     print(f"  mneme check --memory {path} --input <file> --query <context>")
+    return 0
+
+
+# ── Subcommand: setup ────────────────────────────────────────────────────────
+
+def _print_setup_summary(outcome: SetupOutcome) -> None:
+    """Render the human-readable setup summary (ASCII, existing CLI style)."""
+    print("Mneme setup")
+    print()
+    print("Repository")
+    print(f"  OK {outcome.project_root.name} ({outcome.project_root})")
+    print()
+    print("Project memory")
+    if outcome.created_memory:
+        print(f"  Created {outcome.memory_path}")
+    else:
+        print(f"  Found {outcome.memory_path}")
+    print()
+    print("Architecture baseline")
+    if outcome.audit_ref:
+        print(f"  Audit reference recorded: {outcome.audit_ref}")
+    else:
+        print("  Not connected (no audit reference provided)")
+    print()
+    print("Integrations")
+    if outcome.integrations:
+        for item in outcome.integrations:
+            surface = "native" if item.native else "rules export"
+            print(f"  {item.label} detected ({item.evidence}, {surface})")
+    else:
+        print("  None detected")
+    print()
+    print("Protection readiness")
+    for key in READINESS_ORDER:
+        print(f"  {READINESS_LABELS[key]}: {outcome.readiness.get(key, 0)}")
+    print()
+    print("Enforcement")
+    print("  Not enabled")
+    print()
+    print("Initial check")
+    check_line = f"  OK ({outcome.decision_count} decisions)"
+    if outcome.adr_diagnostics_present:
+        check_line += (
+            f" | ADR diagnostics: {outcome.adr_diagnostics} (warn-only)"
+        )
+    print(check_line)
+    if outcome.warnings:
+        print()
+        for warning in outcome.warnings:
+            print(f"WARN  {warning}")
+
+
+def _cmd_setup(args: argparse.Namespace) -> int:
+    audit_ref = args.audit_ref if args.audit_ref is not None else ""
+    if args.audit_ref is not None and not audit_ref.strip():
+        return _error_exit("audit reference must not be empty")
+    try:
+        outcome = run_setup(
+            memory=Path(args.memory) if args.memory else None,
+            audit_ref=audit_ref.strip(),
+        )
+    except SetupError as exc:
+        return _error_exit(str(exc))
+
+    _print_setup_summary(outcome)
+    print()
+    if outcome.state == STATE_ACTIVE:
+        print("Mneme remains in active mode (unchanged by setup).")
+    elif outcome.rerun:
+        print("Mneme is already in setup mode.")
+    else:
+        print("Mneme is installed in setup mode.")
     return 0
 
 
@@ -281,16 +348,7 @@ def _collect_adr_diagnostics(
     adr_dir: str | Path,
 ) -> list[FreshnessIssue]:
     """Collect ADR freshness issues and lifecycle findings (warn-only)."""
-    freshness = check_freshness(memory_path=memory_path, adr_dir=adr_dir)
-    lifecycle = analyze_lifecycle(corpus_dir=adr_dir, memory_path=memory_path)
-    seen: set[tuple[str, str, str]] = set()
-    combined: list[FreshnessIssue] = []
-    for issue in freshness + lifecycle:
-        key = (issue.code, issue.adr_id, issue.path)
-        if key not in seen:
-            seen.add(key)
-            combined.append(issue)
-    return combined
+    return collect_adr_diagnostics(memory_path=memory_path, adr_dir=adr_dir)
 
 
 def _cmd_check(args: argparse.Namespace) -> int:
@@ -659,6 +717,30 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Overwrite an existing file at --path",
     )
     p_init.set_defaults(func=_cmd_init)
+
+    # setup
+    p_setup = sub.add_parser(
+        "setup",
+        help=(
+            "Initialize Mneme project state in setup mode "
+            "(context and non-blocking checks only; never enforcement)"
+        ),
+    )
+    p_setup.add_argument(
+        "--memory", default=None,
+        help=(
+            "Path to project_memory.json "
+            f"(default: <repo-root>/{DEFAULT_MEMORY_PATH})"
+        ),
+    )
+    p_setup.add_argument(
+        "--audit-ref", dest="audit_ref", default=None,
+        help=(
+            "Opaque Architecture Audit setup reference to record with this "
+            "setup (recorded verbatim; resolved by Audit pairing)"
+        ),
+    )
+    p_setup.set_defaults(func=_cmd_setup)
 
     # list_decisions
     p_list = sub.add_parser("list_decisions", help="List all decisions")

--- a/mneme/integrations/detect.py
+++ b/mneme/integrations/detect.py
@@ -1,0 +1,59 @@
+"""
+integrations.detect — Read-only detection of supported agent environments.
+
+M1.3 setup detects which supported agent/developer environments are present
+in a repository (frozen contract section 4, M1.3a step 5). Detection is
+purely observational:
+
+- it never writes configuration;
+- it never installs hooks;
+- it never enables enforcement — detection and blocking behavior are
+  independent concerns (acceptance gate G5).
+
+``native`` marks surfaces Mneme can enforce in (hook/gate integrations);
+``False`` marks advisory surfaces such as Cursor, where Mneme can only export
+rules files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DetectedIntegration:
+    """One agent/developer environment detected in a repository."""
+
+    key: str
+    label: str
+    evidence: str
+    native: bool
+
+
+_INTEGRATION_MARKERS: tuple[tuple[str, str, str, bool], ...] = (
+    # (key, label, project-relative evidence path, native enforcement surface)
+    ("claude_code", "Claude Code", ".claude", True),
+    ("codex_cli", "Codex CLI", ".codex", True),
+    ("kiro", "Kiro", ".kiro", True),
+    ("cursor", "Cursor", ".cursor", False),
+)
+
+
+def detect_integrations(root: str | Path) -> list[DetectedIntegration]:
+    """Detect supported agent environments under ``root``.
+
+    Returns matches in the fixed marker order above so output is
+    deterministic. Directories are the detection evidence; existence checks
+    only, no filesystem mutation.
+    """
+    base = Path(root)
+    detected: list[DetectedIntegration] = []
+    for key, label, evidence, native in _INTEGRATION_MARKERS:
+        if (base / evidence).exists():
+            detected.append(
+                DetectedIntegration(
+                    key=key, label=label, evidence=evidence, native=native
+                )
+            )
+    return detected

--- a/mneme/readiness.py
+++ b/mneme/readiness.py
@@ -1,0 +1,86 @@
+"""
+readiness.py — Protection readiness view over project decisions.
+
+M1.3 setup translates Audit/decision classifications into a readiness view
+(frozen contract: docs/plans/m1-3-audit-to-setup-activation.md section 5):
+
+    Protected          → existing protection detected
+    Mneme-ready        → protection opportunity
+    Requires modelling → needs modelling or remains guidance
+    Guidance           → not appropriate for deterministic enforcement
+
+Critical frozen rule:
+
+    Installing Mneme does not make a Protectable decision Protected.
+
+A decision is reported ``protected`` ONLY where actual mechanical protection
+evidence exists — a typed FORBID_LITERAL rule — mirroring the frozen
+Architecture Audit metric semantics (P1.2: Protected = deterministic intent
+with verified existing enforcement). The governability tier ``enforceable``
+also covers single-term anti-patterns; those remain ``mneme_ready`` here
+because Mneme proposes that guardrail, it is not yet existing protection.
+
+Setup never mutates decisions, so readiness is a pure view: running setup
+cannot change any decision's classification and cannot inflate protection
+metrics (acceptance gate G4).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from mneme.enforcer import assess_governability
+from mneme.schemas import Decision
+
+ReadinessClass = Literal[
+    "protected",
+    "mneme_ready",
+    "requires_modelling",
+    "guidance",
+]
+
+READINESS_LABELS: dict[str, str] = {
+    "protected": "Protected",
+    "mneme_ready": "Mneme-ready",
+    "requires_modelling": "Requires modelling",
+    "guidance": "Guidance",
+}
+
+READINESS_ORDER: tuple[ReadinessClass, ...] = (
+    "protected",
+    "mneme_ready",
+    "requires_modelling",
+    "guidance",
+)
+
+
+def assess_readiness(decision: Decision) -> ReadinessClass:
+    """Classify one decision's protection readiness.
+
+    Uses Mneme's authoritative governability assessment (``assess_governability``)
+    and maps it to the frozen readiness vocabulary without inflating it:
+
+    - ``protected``          FORBID_LITERAL typed rules exist (verified
+                             mechanical enforcement evidence).
+    - ``mneme_ready``        No typed rule, but a concrete safe guardrail
+                             exists (single-term anti-pattern).
+    - ``requires_modelling`` Deterministic intent needs interpretation
+                             (multi-term anti-patterns or "no X" constraints).
+    - ``guidance``           No deterministic intent for enforcement.
+    """
+    a = assess_governability(decision)
+    if a.has_literal_rules:
+        return "protected"
+    if a.has_single_term_anti_patterns:
+        return "mneme_ready"
+    if a.has_multi_term_anti_patterns or a.has_no_constraints:
+        return "requires_modelling"
+    return "guidance"
+
+
+def readiness_counts(decisions: list[Decision]) -> dict[ReadinessClass, int]:
+    """Count decisions per readiness class, returning all four keys."""
+    counts: dict[ReadinessClass, int] = {key: 0 for key in READINESS_ORDER}
+    for decision in decisions:
+        counts[assess_readiness(decision)] += 1
+    return counts

--- a/mneme/readiness.py
+++ b/mneme/readiness.py
@@ -1,43 +1,42 @@
 """
-readiness.py — Protection readiness view over project decisions.
+readiness.py — Protection readiness view for Mneme setup (M1.3a).
 
-M1.3 setup translates Audit/decision classifications into a readiness view
-(frozen contract: docs/plans/m1-3-audit-to-setup-activation.md section 5):
+Setup translates the P1.2 Architecture Protection Audit classification into
+a readiness view (frozen contract:
+docs/plans/m1-3-audit-to-setup-activation.md section 5):
 
     Protected          → existing protection detected
     Mneme-ready        → protection opportunity
     Requires modelling → needs modelling or remains guidance
     Guidance           → not appropriate for deterministic enforcement
 
+This module adds NO interpretation of its own. It delegates to the frozen
+P1.2 semantics in ``mneme.enforcer`` — ``assess_protection`` /
+``generate_protection_report`` are the single source of truth for the
+Protected / Mneme-ready / Requires modelling / Guidance tiers, so setup and
+``mneme audit`` always agree on the same memory/repository (parity is
+pinned by tests). ``repo_root`` enables the same external CI evidence scan
+the audit command performs with ``--repo-root``.
+
 Critical frozen rule:
 
     Installing Mneme does not make a Protectable decision Protected.
 
-A decision is reported ``protected`` ONLY where actual mechanical protection
-evidence exists — a typed FORBID_LITERAL rule — mirroring the frozen
-Architecture Audit metric semantics (P1.2: Protected = deterministic intent
-with verified existing enforcement). The governability tier ``enforceable``
-also covers single-term anti-patterns; those remain ``mneme_ready`` here
-because Mneme proposes that guardrail, it is not yet existing protection.
-
 Setup never mutates decisions, so readiness is a pure view: running setup
-cannot change any decision's classification and cannot inflate protection
-metrics (acceptance gate G4).
+cannot change any decision's tier and cannot inflate protection metrics
+(acceptance gate G4). Only ``active`` decisions count toward the summary,
+exactly as in ``mneme audit``; superseded/deprecated decisions are reported
+for provenance but never counted.
 """
 
 from __future__ import annotations
 
-from typing import Literal
-
-from mneme.enforcer import assess_governability
+from mneme.enforcer import (
+    ProtectionTier,
+    assess_protection,
+    generate_protection_report,
+)
 from mneme.schemas import Decision
-
-ReadinessClass = Literal[
-    "protected",
-    "mneme_ready",
-    "requires_modelling",
-    "guidance",
-]
 
 READINESS_LABELS: dict[str, str] = {
     "protected": "Protected",
@@ -46,7 +45,7 @@ READINESS_LABELS: dict[str, str] = {
     "guidance": "Guidance",
 }
 
-READINESS_ORDER: tuple[ReadinessClass, ...] = (
+READINESS_ORDER: tuple[ProtectionTier, ...] = (
     "protected",
     "mneme_ready",
     "requires_modelling",
@@ -54,33 +53,29 @@ READINESS_ORDER: tuple[ReadinessClass, ...] = (
 )
 
 
-def assess_readiness(decision: Decision) -> ReadinessClass:
-    """Classify one decision's protection readiness.
+def assess_readiness(
+    decision: Decision,
+    repo_root: str | None = None,
+) -> ProtectionTier:
+    """Classify one decision's protection readiness via frozen P1.2 semantics."""
+    return assess_protection(decision, repo_root=repo_root).protection_tier
 
-    Uses Mneme's authoritative governability assessment (``assess_governability``)
-    and maps it to the frozen readiness vocabulary without inflating it:
 
-    - ``protected``          FORBID_LITERAL typed rules exist (verified
-                             mechanical enforcement evidence).
-    - ``mneme_ready``        No typed rule, but a concrete safe guardrail
-                             exists (single-term anti-pattern).
-    - ``requires_modelling`` Deterministic intent needs interpretation
-                             (multi-term anti-patterns or "no X" constraints).
-    - ``guidance``           No deterministic intent for enforcement.
+def readiness_counts(
+    decisions: list[Decision],
+    repo_root: str | None = None,
+) -> dict[ProtectionTier, int]:
+    """Count decisions per P1.2 protection tier for the setup summary.
+
+    Uses the canonical aggregate report so the counts are exactly the
+    ``mneme audit`` summary values for the same corpus and repository:
+    only active decisions count toward any tier (guidance excluded from the
+    protection-relevant denominator by the frozen semantics).
     """
-    a = assess_governability(decision)
-    if a.has_literal_rules:
-        return "protected"
-    if a.has_single_term_anti_patterns:
-        return "mneme_ready"
-    if a.has_multi_term_anti_patterns or a.has_no_constraints:
-        return "requires_modelling"
-    return "guidance"
-
-
-def readiness_counts(decisions: list[Decision]) -> dict[ReadinessClass, int]:
-    """Count decisions per readiness class, returning all four keys."""
-    counts: dict[ReadinessClass, int] = {key: 0 for key in READINESS_ORDER}
-    for decision in decisions:
-        counts[assess_readiness(decision)] += 1
-    return counts
+    report = generate_protection_report(decisions, repo_root=repo_root)
+    return {
+        "protected": report.protected,
+        "mneme_ready": report.mneme_ready,
+        "requires_modelling": report.requires_modelling,
+        "guidance": report.guidance,
+    }

--- a/mneme/setup.py
+++ b/mneme/setup.py
@@ -1,0 +1,289 @@
+"""
+setup.py — The ``mneme setup`` flow (M1.3a).
+
+Initializes Mneme project state in *setup mode* under the frozen M1.3
+contract (docs/plans/m1-3-audit-to-setup-activation.md):
+
+- setup NEVER enables blocking enforcement;
+- setup NEVER classifies a decision as Protected that lacks typed-rule
+  enforcement evidence (readiness is a pure view — see mneme.readiness);
+- setup NEVER mutates application code, unrelated configuration, or existing
+  memory content beyond adding the ``activation`` record;
+- setup is idempotent: rerunning with no material change writes nothing;
+- an ``active`` project is left untouched by setup (no silent downgrade).
+
+All validation happens before the first write, so any pre-execution failure
+leaves the repository exactly as it was.
+
+Audit reference handling in M1.3a: ``--audit-ref`` is consumed and recorded
+verbatim as an opaque string. Resolution against the Architecture Audit
+service is the M1.3b pairing mechanism; recording an opaque reference is
+inert — no enforcement or classification follows from it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from mneme.adr_diagnostics import collect_adr_diagnostics
+from mneme.integrations.detect import DetectedIntegration, detect_integrations
+from mneme.memory_store import MemoryStore
+from mneme.readiness import ReadinessClass, readiness_counts
+from mneme.setup_state import (
+    DEFAULT_MEMORY_PATH,
+    ACTIVATION_SCHEMA,
+    ENFORCEMENT_NOT_ENABLED,
+    ActivationRecord,
+    ActivationStateError,
+    STATE_ACTIVE,
+    STATE_NOT_INSTALLED,
+    STATE_SETUP,
+    atomic_write_json,
+    derive_activation_state,
+    scaffold_project_memory,
+    utc_now,
+    write_activation,
+)
+
+GIT_MARKER = ".git"
+DEFAULT_ADR_DIR = "docs/adr"
+
+# The reference is opaque, but it must be a sane opaque token: a single
+# non-empty chunk with no internal whitespace and a bounded length. Any real
+# reference format introduced by M1.3b pairing must remain valid under these
+# constraints.
+MAX_AUDIT_REF_LENGTH = 256
+_AUDIT_REF_PATTERN = re.compile(r"^\S+$")
+
+
+class SetupError(Exception):
+    """A pre-execution setup failure. No filesystem mutation has occurred."""
+
+
+@dataclass
+class SetupOutcome:
+    """Everything the CLI needs to render the setup summary."""
+
+    project_root: Path
+    memory_path: Path
+    created_memory: bool
+    previous_state: str
+    state: str
+    rerun: bool
+    audit_ref: str
+    integrations: list[DetectedIntegration] = field(default_factory=list)
+    decision_count: int = 0
+    readiness: dict[ReadinessClass, int] = field(default_factory=dict)
+    adr_diagnostics: int = 0
+    adr_diagnostics_present: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Walk up from ``start`` to the nearest git repository root.
+
+    Handles both ``.git`` directories and ``.git`` files (linked worktrees).
+    """
+    current = Path(start).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / GIT_MARKER).exists():
+            return candidate
+    return None
+
+
+def mneme_version() -> str:
+    """Best-effort version of the running Mneme distribution."""
+    import importlib.metadata
+
+    try:
+        return importlib.metadata.version("mneme-hq")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    marker = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if marker.exists():
+        match = re.search(
+            r'^version\s*=\s*"([^"]+)"', marker.read_text(encoding="utf-8"), re.M
+        )
+        if match:
+            return match.group(1)
+    return "unknown"
+
+
+def validate_audit_ref(audit_ref: str) -> str:
+    """Validate an opaque audit reference supplied on the command line."""
+    ref = audit_ref.strip()
+    if not ref:
+        raise SetupError("audit reference must not be empty")
+    if len(ref) > MAX_AUDIT_REF_LENGTH:
+        raise SetupError(
+            f"audit reference exceeds {MAX_AUDIT_REF_LENGTH} characters"
+        )
+    if not _AUDIT_REF_PATTERN.match(ref):
+        raise SetupError("audit reference must not contain whitespace")
+    return ref
+
+
+def _load_validated_decisions(memory_path: Path) -> list:
+    """Load an existing memory file, failing safely if it is invalid.
+
+    A file that raw JSON parsing accepts but MemoryStore rejects is broken
+    for every other Mneme surface; setup must not paper over it by writing
+    an activation record into it.
+    """
+    store = MemoryStore(memory_path)
+    try:
+        store.load()
+    except Exception as exc:
+        raise SetupError(
+            f"existing memory file {memory_path} failed validation: {exc}"
+        ) from exc
+    return store.decisions()
+
+
+def run_setup(
+    root: Path | None = None,
+    memory: Path | None = None,
+    audit_ref: str = "",
+) -> SetupOutcome:
+    """Run the setup flow and return its outcome.
+
+    Raises :class:`SetupError` before any write on invalid context. On
+    success the repository contains a project memory with an activation
+    record in ``setup`` state and nothing else has changed.
+    """
+    start = Path(root) if root is not None else Path.cwd()
+    project_root = find_project_root(start)
+    if project_root is None:
+        raise SetupError(
+            f"no git repository found above {start} — "
+            "Mneme setup requires a repository context"
+        )
+
+    if memory is not None:
+        memory_path = Path(memory)
+        if not memory_path.is_absolute():
+            memory_path = Path.cwd() / memory_path
+    else:
+        memory_path = project_root / DEFAULT_MEMORY_PATH
+
+    ref = validate_audit_ref(audit_ref) if audit_ref.strip() else ""
+
+    integrations = detect_integrations(project_root)
+
+    created_memory = not memory_path.exists()
+    previous_record: ActivationRecord | None = None
+    if created_memory:
+        previous_state: str = STATE_NOT_INSTALLED
+        document = scaffold_project_memory(created_by="mneme setup")
+        document["meta"]["name"] = project_root.name
+        document["meta"]["description"] = (
+            f"Architecture memory for {project_root.name}, created by mneme setup"
+        )
+        decisions: list = []
+    else:
+        with open(memory_path, encoding="utf-8") as f:
+            try:
+                raw_document = json.load(f)
+            except json.JSONDecodeError as exc:
+                raise SetupError(
+                    f"existing memory file {memory_path} is not valid JSON: {exc}"
+                ) from exc
+        raw_activation = raw_document.get("activation")
+        if raw_activation is not None:
+            if raw_activation.get("schema") not in (None, ACTIVATION_SCHEMA):
+                raise SetupError(
+                    f"activation record in {memory_path} uses unsupported "
+                    f"schema {raw_activation.get('schema')!r}; refusing to "
+                    "modify it"
+                )
+            try:
+                previous_record = ActivationRecord.from_dict(raw_activation)
+            except ActivationStateError as exc:
+                raise SetupError(
+                    f"existing activation record in {memory_path} is invalid: {exc}"
+                ) from exc
+        previous_state = (
+            previous_record.state if previous_record is not None else STATE_SETUP
+        )
+        decisions = _load_validated_decisions(memory_path)
+
+    outcome = SetupOutcome(
+        project_root=project_root,
+        memory_path=memory_path,
+        created_memory=created_memory,
+        previous_state=previous_state,
+        state=previous_state,
+        rerun=False,
+        audit_ref=ref,
+        integrations=integrations,
+        decision_count=len(decisions),
+        readiness=readiness_counts(decisions),
+    )
+
+    record = ActivationRecord(
+        state=STATE_SETUP,
+        mneme_version=mneme_version(),
+        setup_started_at=(
+            previous_record.setup_started_at
+            if previous_record is not None and previous_record.setup_started_at
+            else utc_now()
+        ),
+        setup_completed_at=(
+            previous_record.setup_completed_at
+            if previous_record is not None and previous_record.setup_completed_at
+            else utc_now()
+        ),
+        audit_ref=ref
+        if ref
+        else (previous_record.audit_ref if previous_record is not None else ""),
+        baseline=None,
+        integrations_detected=[i.key for i in integrations],
+        integrations_configured=[],
+        enforcement=ENFORCEMENT_NOT_ENABLED,
+    )
+
+    if previous_state == STATE_ACTIVE:
+        # Never silently downgrade an explicitly activated project. Setup
+        # re-reports status and leaves the record untouched.
+        outcome.state = STATE_ACTIVE
+        outcome.rerun = True
+        outcome.warnings.append(
+            "project is in active state; setup did not change activation"
+        )
+        _attach_adr_diagnostics(outcome)
+        return outcome
+
+    outcome.state = STATE_SETUP
+    outcome.rerun = previous_record is not None
+    # The summary reports the effective persisted reference, which preserves
+    # a previously recorded audit_ref when the rerun omits --audit-ref.
+    outcome.audit_ref = record.audit_ref
+
+    if created_memory:
+        document["activation"] = record.to_dict()
+        memory_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(memory_path, document)
+    else:
+        existing = (
+            previous_record.to_dict() if previous_record is not None else None
+        )
+        if existing != record.to_dict():
+            write_activation(memory_path, record)
+
+    # ADR diagnostics run after the memory is on disk so they observe the
+    # post-setup state (and a freshly created memory file does exist).
+    _attach_adr_diagnostics(outcome)
+    return outcome
+
+
+def _attach_adr_diagnostics(outcome: SetupOutcome) -> None:
+    adr_dir = outcome.project_root / DEFAULT_ADR_DIR
+    if not adr_dir.is_dir():
+        return
+    outcome.adr_diagnostics = len(
+        collect_adr_diagnostics(memory_path=outcome.memory_path, adr_dir=adr_dir)
+    )
+    outcome.adr_diagnostics_present = True

--- a/mneme/setup.py
+++ b/mneme/setup.py
@@ -31,7 +31,8 @@ from pathlib import Path
 from mneme.adr_diagnostics import collect_adr_diagnostics
 from mneme.integrations.detect import DetectedIntegration, detect_integrations
 from mneme.memory_store import MemoryStore
-from mneme.readiness import ReadinessClass, readiness_counts
+from mneme.enforcer import ProtectionTier
+from mneme.readiness import readiness_counts
 from mneme.setup_state import (
     DEFAULT_MEMORY_PATH,
     ACTIVATION_SCHEMA,
@@ -76,7 +77,7 @@ class SetupOutcome:
     audit_ref: str
     integrations: list[DetectedIntegration] = field(default_factory=list)
     decision_count: int = 0
-    readiness: dict[ReadinessClass, int] = field(default_factory=dict)
+    readiness: dict[ProtectionTier, int] = field(default_factory=dict)
     adr_diagnostics: int = 0
     adr_diagnostics_present: bool = False
     warnings: list[str] = field(default_factory=list)
@@ -220,7 +221,9 @@ def run_setup(
         audit_ref=ref,
         integrations=integrations,
         decision_count=len(decisions),
-        readiness=readiness_counts(decisions),
+        # P1.2 frozen semantics with CI-evidence scanning over this
+        # repository — exactly what `mneme audit --repo-root` reports.
+        readiness=readiness_counts(decisions, repo_root=project_root),
     )
 
     record = ActivationRecord(

--- a/mneme/setup_state.py
+++ b/mneme/setup_state.py
@@ -1,0 +1,275 @@
+"""
+setup_state.py — Mneme activation state for a project.
+
+M1.3 activation state model (frozen contract:
+docs/plans/m1-3-audit-to-setup-activation.md section 3):
+
+    not_installed → setup → active
+
+- ``not_installed``  No connected Mneme installation exists for the project.
+- ``setup``          Mneme is initialized and may provide context, integrations
+                     and non-blocking checks. Preventive enforcement has NOT
+                     been activated.
+- ``active``         At least one preventive protection has been explicitly
+                     enabled.
+
+This state is distinct from the Architecture Audit lifecycle
+(ephemeral → saved → pilot); the two lifecycles must never collapse.
+
+The record persists as an optional top-level ``activation`` key inside the
+existing ``project_memory.json``. MemoryStore ignores unknown top-level keys
+and every memory-file writer does raw read-modify-write, so adding the section
+is backward and forward compatible. No parallel state file is created.
+
+The record always carries ``enforcement: "not_enabled"`` when written by
+setup. Nothing in this module can enable enforcement; ``active`` is reachable
+only through an explicit future activation action, never implicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+ActivationState = Literal["not_installed", "setup", "active"]
+
+STATE_NOT_INSTALLED: ActivationState = "not_installed"
+STATE_SETUP: ActivationState = "setup"
+STATE_ACTIVE: ActivationState = "active"
+
+ACTIVATION_STATES: tuple[str, ...] = (
+    STATE_NOT_INSTALLED,
+    STATE_SETUP,
+    STATE_ACTIVE,
+)
+
+ENFORCEMENT_NOT_ENABLED = "not_enabled"
+
+ACTIVATION_SCHEMA = "mneme.setup/v1"
+
+# Allowed explicit transitions. ``setup`` → ``setup`` is the idempotent rerun.
+# ``setup`` → ``active`` requires an explicit user activation action that does
+# not exist in M1.3; no code path in this module performs it.
+VALID_TRANSITIONS: dict[str, frozenset[str]] = {
+    STATE_NOT_INSTALLED: frozenset({STATE_SETUP}),
+    STATE_SETUP: frozenset({STATE_SETUP, STATE_ACTIVE}),
+    STATE_ACTIVE: frozenset({STATE_ACTIVE}),
+}
+
+DEFAULT_MEMORY_PATH = ".mneme/project_memory.json"
+
+
+class ActivationStateError(ValueError):
+    """Raised when an activation record or transition is invalid."""
+
+
+def utc_now() -> str:
+    """ISO 8601 UTC timestamp (seconds precision, ``Z`` suffix)."""
+    from datetime import datetime, timezone
+
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def scaffold_project_memory(created_by: str = "mneme init") -> dict:
+    """Return a valid, empty, neutral project_memory.json skeleton.
+
+    Same shape as the ``mneme init`` scaffold: no seeded decisions, because
+    every decision is enforceable and sample content would create phantom
+    rules. ``created_by`` records which flow created the file.
+    """
+    return {
+        "meta": {
+            "name": "",
+            "description": "",
+            "created_by": created_by,
+            "created": utc_now(),
+        },
+        "items": [],
+        "examples": [],
+        "decisions": [],
+    }
+
+
+@dataclass
+class ActivationRecord:
+    """Persisted Mneme activation state for one project.
+
+    Attributes:
+        state:                  Current activation state (see module docstring).
+        mneme_version:          Version of the Mneme distribution that last
+                                performed setup.
+        setup_started_at:       ISO 8601 UTC timestamp of the setup run start.
+        setup_completed_at:     ISO 8601 UTC timestamp of first setup completion.
+        activated_at:           Timestamp of explicit activation to ``active``.
+                                Always ``None`` after setup; nothing in M1.3
+                                sets it.
+        audit_ref:              Opaque Architecture Audit setup reference as
+                                provided. Opaque locally: the CLI records it
+                                verbatim and assigns no meaning to it.
+        baseline:               Resolved Audit baseline provenance. ``None``
+                                until Audit pairing (M1.3b) resolves it.
+        integrations_detected:  Integration keys detected during setup.
+        integrations_configured: Integration keys actually configured. Setup
+                                in M1.3 does not configure integrations, so
+                                this stays empty by design.
+        enforcement:            Enforcement posture recorded at setup time.
+                                Only ``not_enabled`` is ever written here.
+    """
+
+    state: ActivationState
+    mneme_version: str = ""
+    setup_started_at: str = ""
+    setup_completed_at: str = ""
+    activated_at: str | None = None
+    audit_ref: str = ""
+    baseline: dict | None = None
+    integrations_detected: list[str] = field(default_factory=list)
+    integrations_configured: list[str] = field(default_factory=list)
+    enforcement: str = ENFORCEMENT_NOT_ENABLED
+
+    def __post_init__(self) -> None:
+        if self.state not in ACTIVATION_STATES:
+            raise ActivationStateError(
+                f"unknown activation state {self.state!r} "
+                f"(expected one of {list(ACTIVATION_STATES)})"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": ACTIVATION_SCHEMA,
+            "state": self.state,
+            "mneme_version": self.mneme_version,
+            "setup_started_at": self.setup_started_at,
+            "setup_completed_at": self.setup_completed_at,
+            "activated_at": self.activated_at,
+            "audit_ref": self.audit_ref,
+            "baseline": self.baseline,
+            "integrations_detected": list(self.integrations_detected),
+            "integrations_configured": list(self.integrations_configured),
+            "enforcement": self.enforcement,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ActivationRecord":
+        if not isinstance(raw, dict):
+            raise ActivationStateError("activation record must be an object")
+        state = raw.get("state")
+        if state not in ACTIVATION_STATES:
+            raise ActivationStateError(
+                f"unknown activation state {state!r} "
+                f"(expected one of {list(ACTIVATION_STATES)})"
+            )
+        baseline = raw.get("baseline")
+        if baseline is not None and not isinstance(baseline, dict):
+            raise ActivationStateError("activation baseline must be an object")
+        integrations_detected = raw.get("integrations_detected", [])
+        integrations_configured = raw.get("integrations_configured", [])
+        if not isinstance(integrations_detected, list) or not all(
+            isinstance(k, str) for k in integrations_detected
+        ):
+            raise ActivationStateError(
+                "integrations_detected must be a list of strings"
+            )
+        if not isinstance(integrations_configured, list) or not all(
+            isinstance(k, str) for k in integrations_configured
+        ):
+            raise ActivationStateError(
+                "integrations_configured must be a list of strings"
+            )
+        return cls(
+            state=state,
+            mneme_version=raw.get("mneme_version", ""),
+            setup_started_at=raw.get("setup_started_at", ""),
+            setup_completed_at=raw.get("setup_completed_at", ""),
+            activated_at=raw.get("activated_at"),
+            audit_ref=raw.get("audit_ref", ""),
+            baseline=baseline,
+            integrations_detected=list(integrations_detected),
+            integrations_configured=list(integrations_configured),
+            # Read as-is for forward compatibility; setup only ever writes
+            # ENFORCEMENT_NOT_ENABLED, and nothing here may enable enforcement.
+            enforcement=raw.get("enforcement", ENFORCEMENT_NOT_ENABLED),
+        )
+
+    def require_transition(self, to_state: ActivationState) -> None:
+        """Validate a proposed state transition, failing closed."""
+        allowed = VALID_TRANSITIONS.get(self.state, frozenset())
+        if to_state not in allowed:
+            raise ActivationStateError(
+                f"invalid activation transition {self.state!r} -> {to_state!r}"
+            )
+
+
+def read_activation(memory_path: str | Path) -> ActivationRecord | None:
+    """Read the activation record from a project_memory.json.
+
+    Returns ``None`` when the file has no ``activation`` section. Raises
+    ``ActivationStateError`` for a malformed record (callers fail safely on
+    that rather than guessing state).
+    """
+    path = Path(memory_path)
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    raw = data.get("activation")
+    if raw is None:
+        return None
+    return ActivationRecord.from_dict(raw)
+
+
+def derive_activation_state(memory_path: str | Path) -> ActivationState:
+    """Derive the activation state of a project from its memory file.
+
+    - No memory file                          → ``not_installed``.
+    - Memory file with an activation record   → the record's state.
+    - Memory file without an activation record → ``setup``.
+
+    The last case covers projects initialized before activation tracking
+    existed. Their de-facto posture already matches ``setup``: Mneme project
+    state exists and enforcement is never persisted as enabled.
+    """
+    path = Path(memory_path)
+    if not path.exists():
+        return STATE_NOT_INSTALLED
+    record = read_activation(path)
+    if record is None:
+        return STATE_SETUP
+    return record.state
+
+
+def atomic_write_json(path: Path, data: dict) -> None:
+    """Write JSON atomically: tempfile in the same directory, then replace."""
+    serialized = json.dumps(data, indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(serialized)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def write_activation(memory_path: str | Path, record: ActivationRecord) -> None:
+    """Persist the activation record inside an existing project_memory.json.
+
+    Raw read-modify-write: every other top-level key (meta, items, examples,
+    decisions, and any future sections) is preserved verbatim. The file must
+    already exist; creating project memory is the setup/init flow's job, not
+    this function's.
+    """
+    path = Path(memory_path)
+    if not path.exists():
+        raise FileNotFoundError(f"memory file {path} does not exist")
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    data["activation"] = record.to_dict()
+    atomic_write_json(path, data)

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,546 @@
+"""CLI — `mneme setup` (M1.3a: safe setup flow, G1/G2/G4/G5 evidence)."""
+import json
+from pathlib import Path
+
+import pytest
+
+from mneme.cli import main
+
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a minimal repository root. find_project_root only needs a
+    .git marker, so tests stay hermetic (no git subprocess required)."""
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _make_worktree_style_repo(tmp_path: Path) -> Path:
+    """Repository root whose .git is a file, as in linked worktrees."""
+    (tmp_path / ".git").write_text("gitdir: ../elsewhere/.git/worktrees/x\n", encoding="utf-8")
+    return tmp_path
+
+
+def _read_memory(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / MEMORY_REL).read_text(encoding="utf-8"))
+
+
+def _write_memory_with_decisions(tmp_path: Path) -> dict:
+    doc = {
+        "meta": {
+            "name": "payments-api",
+            "description": "existing project",
+            "created_by": "mneme init",
+            "created": "2026-01-01T00:00:00Z",
+        },
+        "items": [
+            {
+                "id": "legacy-1",
+                "type": "rule",
+                "title": "Use JSON config",
+                "content": "configuration must be JSON",
+                "tags": [],
+                "priority": "medium",
+            }
+        ],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "d_typed",
+                "decision": "Store data in sqlite",
+                "rationale": "embedded",
+                "scope": ["storage"],
+                "constraints": [],
+                "anti_patterns": [],
+                "rules": [{"type": "FORBID_LITERAL", "value": "postgres"}],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": "d_single_ap",
+                "decision": "Avoid ORM indirection",
+                "rationale": "",
+                "scope": ["storage"],
+                "constraints": [],
+                "anti_patterns": ["orm"],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": "d_multi_ap",
+                "decision": "Keep services isolated",
+                "rationale": "",
+                "scope": [],
+                "constraints": [],
+                "anti_patterns": ["share one database across services"],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": "d_guidance",
+                "decision": "Prefer small modules",
+                "rationale": "readability",
+                "scope": [],
+                "constraints": [],
+                "anti_patterns": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+        ],
+    }
+    (tmp_path / MEMORY_REL).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / MEMORY_REL).write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    return doc
+
+
+# ── G1: safe setup on a fresh repository ─────────────────────────────────────
+
+def test_setup_fresh_repo_initializes_in_setup_mode(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    data = _read_memory(root)
+    record = data["activation"]
+    assert record["state"] == "setup"
+    assert record["enforcement"] == "not_enabled"
+    assert record["schema"] == "mneme.setup/v1"
+    assert record["activated_at"] is None
+    assert record["integrations_configured"] == []
+    assert record["audit_ref"] == ""
+    assert data["meta"]["created_by"] == "mneme setup"
+    assert "Mneme is installed in setup mode." in captured.out
+    assert "Not enabled" in captured.out
+
+
+def test_setup_creates_nothing_but_mneme_state(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    pre_existing = root / "src"
+    pre_existing.mkdir()
+    (pre_existing / "app.py").write_text("print('hi')\n", encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    assert exit_code == 0
+
+    created = {p.relative_to(root).as_posix() for p in root.rglob("*")}
+    # Only the .mneme memory file may appear; no hook configs, no integrations.
+    assert created == {".git", "src", "src/app.py", ".mneme", MEMORY_REL.as_posix()}
+
+
+def test_setup_does_not_touch_existing_agent_configuration(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    claude_dir = root / ".claude"
+    claude_dir.mkdir()
+    settings = claude_dir / "settings.json"
+    original = '{"hooks": {}}'
+    settings.write_text(original, encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+
+    # Detection must not mutate the detected environment, and setup must not
+    # install any enforcement hook configuration (G1 + G5 invariant).
+    assert settings.read_text(encoding="utf-8") == original
+
+
+def test_setup_reports_project_and_memory(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    out = capsys.readouterr().out
+    assert root.name in out
+    assert "Project memory" in out
+    assert "Created" in out
+
+
+def test_setup_requires_git_repository(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)  # no .git anywhere above
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "ERROR" in captured.err
+    assert not (tmp_path / MEMORY_REL).exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_setup_from_subdirectory_targets_repo_root(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    subdir = root / "services" / "billing"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    assert main(["setup"]) == 0
+    data = _read_memory(root)
+    assert data["activation"]["state"] == "setup"
+    assert data["meta"]["name"] == root.name
+    assert not (subdir / MEMORY_REL).exists()
+
+
+def test_setup_accepts_worktree_style_git_file(tmp_path, monkeypatch):
+    root = _make_worktree_style_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    assert _read_memory(root)["activation"]["state"] == "setup"
+
+
+def test_setup_scaffold_loads_through_memory_store(tmp_path, monkeypatch):
+    from mneme.memory_store import MemoryStore
+
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    store = MemoryStore(root / MEMORY_REL)
+    store.load()
+    assert store.decisions() == []
+
+
+# ── G2: idempotency and existing projects ────────────────────────────────────
+
+def test_setup_rerun_is_byte_identical(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    assert main(["setup"]) == 0
+    first = (root / MEMORY_REL).read_text(encoding="utf-8")
+
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (root / MEMORY_REL).read_text(encoding="utf-8") == first
+    assert "already in setup mode" in captured.out
+
+
+def test_setup_existing_project_preserves_all_content(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    original = _write_memory_with_decisions(root)
+    memory_file = root / MEMORY_REL
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    after = json.loads(memory_file.read_text(encoding="utf-8"))
+    # Every pre-existing top-level section survives byte-for-byte in content.
+    for key, value in original.items():
+        assert after[key] == value, key
+    # Only the activation section is added.
+    assert set(after) - set(original) == {"activation"}
+    assert after["activation"]["state"] == "setup"
+    assert "already in setup mode" not in captured.out
+
+
+def test_setup_rerun_on_existing_project_preserves_first_completion(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    assert main(["setup"]) == 0
+    first_record = _read_memory(root)["activation"]
+
+    exit_code = main(["setup"])
+    assert exit_code == 0
+    second_record = _read_memory(root)["activation"]
+
+    assert second_record["setup_completed_at"] == first_record["setup_completed_at"]
+    assert second_record["setup_started_at"] == first_record["setup_started_at"]
+
+
+def test_setup_rerun_with_new_audit_ref_updates_ref_only(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    assert main(["setup"]) == 0
+    first = _read_memory(root)["activation"]
+
+    exit_code = main(["setup", "--audit-ref", "ref-999"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+
+    second = _read_memory(root)["activation"]
+    assert second["audit_ref"] == "ref-999"
+    assert second["setup_completed_at"] == first["setup_completed_at"]
+    assert "Audit reference recorded: ref-999" in captured.out
+
+
+def test_setup_on_corrupt_memory_fails_without_mutation(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    memory_file = root / MEMORY_REL
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+    original = "{not json"
+    memory_file.write_text(original, encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "ERROR" in captured.err
+    assert memory_file.read_text(encoding="utf-8") == original
+
+
+def test_setup_on_invalid_activation_record_fails_without_mutation(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    _write_memory_with_decisions(root)
+    memory_file = root / MEMORY_REL
+    before = memory_file.read_text(encoding="utf-8")
+
+    data = json.loads(before)
+    data["activation"] = {"state": "enforcing"}
+    memory_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    broken = memory_file.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+
+    assert exit_code == 2
+    assert memory_file.read_text(encoding="utf-8") == broken
+
+
+def test_setup_on_schema_invalid_memory_fails_without_mutation(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    memory_file = root / MEMORY_REL
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "meta": {"name": "x", "description": "y"},
+        "items": [],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "bad",
+                "decision": "bad rule",
+                "rules": [{"type": "FORBID_DEPENDENCY", "value": "x"}],
+            }
+        ],
+    }
+    memory_file.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    original = memory_file.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+
+    assert exit_code == 2
+    assert memory_file.read_text(encoding="utf-8") == original
+
+
+def test_setup_never_downgrades_active_project(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    _write_memory_with_decisions(root)
+    memory_file = root / MEMORY_REL
+
+    data = json.loads(memory_file.read_text(encoding="utf-8"))
+    data["activation"] = {
+        "schema": "mneme.setup/v1",
+        "state": "active",
+        "setup_completed_at": "2026-01-01T00:00:00Z",
+        "activated_at": "2026-02-01T00:00:00Z",
+        "enforcement": "not_enabled",
+    }
+    memory_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    before = memory_file.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert memory_file.read_text(encoding="utf-8") == before
+    assert "remains in active mode" in captured.out
+    assert "WARN" in captured.out
+
+
+# ── G4: no protection-score inflation ────────────────────────────────────────
+
+def test_setup_readiness_does_not_inflate_protection(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    _write_memory_with_decisions(root)
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+
+    # Frozen P1.2 semantics: Protected requires a FORBID_LITERAL typed rule.
+    # The single-term anti-pattern decision (d_single_ap) is enforceable by
+    # the core engine but is NOT existing protection: it must surface as
+    # Mneme-ready, never as Protected, after setup.
+    assert "Protected: 1" in captured.out
+    assert "Mneme-ready: 1" in captured.out
+    assert "Requires modelling: 1" in captured.out
+    # The guidance decision plus the legacy "rule" item (migrated at load)
+    # both classify as Guidance.
+    assert "Guidance: 2" in captured.out
+
+    # Setup is a pure view: decisions are untouched.
+    after = json.loads((root / MEMORY_REL).read_text(encoding="utf-8"))
+    by_id = {d["id"]: d for d in after["decisions"]}
+    assert by_id["d_single_ap"]["anti_patterns"] == ["orm"]
+    # Setup did not materialize a typed rule for the anti-pattern decision:
+    # no guardrail generation happens implicitly (frozen M1.3 invariant).
+    assert "rules" not in by_id["d_single_ap"]
+
+
+def test_setup_does_not_write_any_enforcement_configuration(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup"])
+    assert exit_code == 0
+
+    data = _read_memory(root)
+    assert data["activation"]["enforcement"] == "not_enabled"
+    # No persisted enforcement-mode field exists anywhere in the document.
+    assert "mode" not in json.dumps(data)
+
+
+# ── G5: integration detection ────────────────────────────────────────────────
+
+def test_setup_detects_all_supported_environments(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    for marker in (".claude", ".codex", ".kiro", ".cursor"):
+        (root / marker).mkdir()
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Claude Code detected (.claude, native)" in captured.out
+    assert "Codex CLI detected (.codex, native)" in captured.out
+    assert "Kiro detected (.kiro, native)" in captured.out
+    assert "Cursor detected (.cursor, rules export)" in captured.out
+
+    record = _read_memory(root)["activation"]
+    assert record["integrations_detected"] == [
+        "claude_code", "codex_cli", "kiro", "cursor",
+    ]
+    assert record["integrations_configured"] == []
+
+
+def test_setup_without_environments_reports_none(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    out = capsys.readouterr().out
+    assert "None detected" in out
+    assert _read_memory(root)["activation"]["integrations_detected"] == []
+
+
+def test_detection_creates_no_files(tmp_path, monkeypatch):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    for marker in (".claude", ".codex", ".kiro", ".cursor"):
+        assert not (root / marker).exists()
+
+
+# ── Audit reference consumption (M1.3a scope) ────────────────────────────────
+
+def test_setup_records_audit_ref_verbatim(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup", "--audit-ref", "a1b2c3-opaque"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    record = _read_memory(root)["activation"]
+    assert record["audit_ref"] == "a1b2c3-opaque"
+    assert "Audit reference recorded: a1b2c3-opaque" in captured.out
+
+
+def test_setup_without_audit_ref_reports_not_connected(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    out = capsys.readouterr().out
+    assert "Not connected" in out
+
+
+def test_setup_rejects_unknown_activation_schema(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    _write_memory_with_decisions(root)
+    memory_file = root / MEMORY_REL
+
+    data = json.loads(memory_file.read_text(encoding="utf-8"))
+    data["activation"] = {"schema": "mneme.setup/v9", "state": "setup"}
+    memory_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    before = memory_file.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "unsupported" in captured.err
+    # A future schema must never be silently rewritten to the current one.
+    assert memory_file.read_text(encoding="utf-8") == before
+
+
+def test_setup_with_adr_dir_on_fresh_repo_succeeds(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    adr_dir = root / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "ADR-001-choice.md").write_text(
+        "# ADR-001: choice\n\n## Decision\n\nUse JSON.\n", encoding="utf-8"
+    )
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    # Diagnostics are warn-only and never block setup.
+    assert "ADR diagnostics" in captured.out
+    assert "Mneme is installed in setup mode." in captured.out
+    assert _read_memory(root)["activation"]["state"] == "setup"
+
+
+def test_setup_rejects_empty_audit_ref(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    exit_code = main(["setup", "--audit-ref", "   "])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "ERROR" in captured.err
+    assert not (root / MEMORY_REL).exists()
+
+
+def test_setup_rejects_whitespace_audit_ref(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    exit_code = main(["setup", "--audit-ref", "bad ref with spaces"])
+    assert exit_code == 2
+    assert not (root / MEMORY_REL).exists()
+
+
+def test_setup_rejects_overlong_audit_ref(tmp_path, monkeypatch):
+    from mneme.setup import MAX_AUDIT_REF_LENGTH
+
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    exit_code = main(["setup", "--audit-ref", "x" * (MAX_AUDIT_REF_LENGTH + 1)])
+    assert exit_code == 2
+    assert not (root / MEMORY_REL).exists()
+
+
+def test_setup_preserves_existing_audit_ref_when_rerun_without_one(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    assert main(["setup", "--audit-ref", "keep-me"]) == 0
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+
+    record = _read_memory(root)["activation"]
+    assert record["audit_ref"] == "keep-me"
+    # The summary reflects the persisted linkage, not this run's arguments.
+    assert "Audit reference recorded: keep-me" in captured.out

--- a/tests/test_setup_audit_parity.py
+++ b/tests/test_setup_audit_parity.py
@@ -1,0 +1,206 @@
+"""Parity regression (M1.3 reconciliation with canonical P1.2).
+
+For the same project memory/repository, `mneme audit` and `mneme setup`
+must agree on Protected / Mneme-ready / Requires modelling / Guidance
+counts, and setup must never upgrade anything beyond the audit.
+"""
+import json
+import re
+from pathlib import Path
+
+from mneme.cli import main
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+
+DECISIONS = [
+    {
+        "id": "d_typed",
+        "decision": "Store data in sqlite",
+        "rationale": "embedded",
+        "scope": ["storage"],
+        "constraints": [],
+        "anti_patterns": [],
+        "rules": [{"type": "FORBID_LITERAL", "value": "sqlite"}],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_ci",
+        "decision": "No postgres in the service layer",
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": ["postgres"],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_single_ap",
+        "decision": "Avoid ORM indirection",
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": ["orm"],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_single_no",
+        "decision": "Keep config in JSON",
+        "rationale": "",
+        "scope": [],
+        "constraints": ["no yaml"],
+        "anti_patterns": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_multi_ap",
+        "decision": "Keep services isolated",
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": ["share one database across services"],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_guidance",
+        "decision": "Prefer small modules",
+        "rationale": "readability",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "id": "d_superseded",
+        "decision": "Old config rule",
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": [],
+        "rules": [{"type": "FORBID_LITERAL", "value": "xml"}],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "status": "superseded",
+    },
+]
+
+# Verified CI enforcement for the "postgres" token: a single-line guard
+# whose failure is deterministically linked to detecting the token
+# (frozen P1.2 verified linkage shape).
+CI_WORKFLOW = """name: guard
+on: [push]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - run: if grep -rq postgres src/; then exit 1; fi
+"""
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "parity", "description": "parity fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": DECISIONS,
+    }, indent=2) + "\n", encoding="utf-8")
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "guard.yml").write_text(CI_WORKFLOW, encoding="utf-8")
+    return root
+
+
+def _setup_counts(out: str) -> dict[str, int]:
+    counts = {}
+    for key in ("Protected", "Mneme-ready", "Requires modelling", "Guidance"):
+        match = re.search(rf"^\s*{re.escape(key)}: (\d+)$", out, re.M)
+        assert match, f"setup summary missing {key}: {out}"
+        counts[key] = int(match.group(1))
+    return counts
+
+
+def test_setup_and_audit_agree_on_tier_counts(tmp_path, monkeypatch, capsys):
+    root = _make_repo(tmp_path)
+    audit_json = tmp_path / "audit.json"
+
+    monkeypatch.chdir(root)
+    exit_code = main([
+        "audit", "--memory", str(root / MEMORY_REL),
+        "--repo-root", str(root), "--json", str(audit_json),
+    ])
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.out + captured.err
+    summary = json.loads(audit_json.read_text(encoding="utf-8"))["summary"]
+
+    capsys.readouterr()
+    exit_code = main(["setup"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    setup_counts = _setup_counts(captured.out)
+
+    audit_counts = {
+        "Protected": summary["protected"],
+        "Mneme-ready": summary["mneme_ready"],
+        "Requires modelling": summary["requires_modelling"],
+        "Guidance": summary["guidance"],
+    }
+    # Frozen P1.2 semantics are shared: setup must agree with the audit.
+    assert setup_counts == audit_counts
+
+    # Expected canonical values for this corpus: verified CI evidence
+    # upgrades d_ci to protected; the superseded decision is provenance
+    # only and never counted.
+    assert audit_counts == {
+        "Protected": 2,            # d_typed (typed rule) + d_ci (verified CI)
+        "Mneme-ready": 2,          # d_single_ap + d_single_no
+        "Requires modelling": 1,   # d_multi_ap
+        "Guidance": 1,             # d_guidance
+    }
+    assert summary["total_decisions"] == 7
+    assert summary["protection_relevant"] == 5
+
+    # Setup must not upgrade anything beyond the audit.
+    for key in audit_counts:
+        assert setup_counts[key] <= audit_counts[key], key
+
+
+def test_setup_agrees_with_audit_without_repo_root(tmp_path, monkeypatch, capsys):
+    """Without CI evidence both views reduce to the same tiers."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "parity", "description": "parity fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": [d for d in DECISIONS if d["id"] not in ("d_ci", "d_superseded")],
+    }, indent=2) + "\n", encoding="utf-8")
+    audit_json = tmp_path / "audit.json"
+
+    monkeypatch.chdir(root)
+    exit_code = main(["audit", "--memory", str(memory), "--json", str(audit_json)])
+    capsys.readouterr()
+    assert exit_code == 0
+    summary = json.loads(audit_json.read_text(encoding="utf-8"))["summary"]
+
+    capsys.readouterr()
+    assert main(["setup"]) == 0
+    setup_counts = _setup_counts(capsys.readouterr().out)
+
+    assert setup_counts == {
+        "Protected": summary["protected"],
+        "Mneme-ready": summary["mneme_ready"],
+        "Requires modelling": summary["requires_modelling"],
+        "Guidance": summary["guidance"],
+    }

--- a/tests/test_setup_state.py
+++ b/tests/test_setup_state.py
@@ -1,0 +1,213 @@
+"""setup_state — activation record, transitions, persistence, readiness."""
+import json
+from pathlib import Path
+
+import pytest
+
+from mneme.readiness import assess_readiness, readiness_counts
+from mneme.setup_state import (
+    ACTIVATION_SCHEMA,
+    STATE_ACTIVE,
+    STATE_NOT_INSTALLED,
+    STATE_SETUP,
+    ActivationRecord,
+    ActivationStateError,
+    derive_activation_state,
+    read_activation,
+    scaffold_project_memory,
+    write_activation,
+)
+from mneme.schemas import Decision, Rule
+
+
+# ── Scaffold ──────────────────────────────────────────────────────────────────
+
+def test_scaffold_shape():
+    doc = scaffold_project_memory(created_by="mneme setup")
+    assert doc["meta"]["created_by"] == "mneme setup"
+    assert doc["meta"]["name"] == ""
+    assert doc["items"] == []
+    assert doc["examples"] == []
+    assert doc["decisions"] == []
+    assert "activation" not in doc
+
+
+# ── ActivationRecord ─────────────────────────────────────────────────────────
+
+def test_record_roundtrip():
+    record = ActivationRecord(
+        state=STATE_SETUP,
+        mneme_version="0.6.0",
+        setup_started_at="2026-09-05T00:00:00Z",
+        setup_completed_at="2026-09-05T00:00:01Z",
+        audit_ref="ref-123",
+        integrations_detected=["claude_code"],
+        integrations_configured=[],
+        enforcement="not_enabled",
+    )
+    raw = record.to_dict()
+    assert raw["schema"] == ACTIVATION_SCHEMA
+    assert raw["enforcement"] == "not_enabled"
+    parsed = ActivationRecord.from_dict(raw)
+    assert parsed == record
+
+
+def test_record_from_dict_rejects_unknown_state():
+    with pytest.raises(ActivationStateError):
+        ActivationRecord.from_dict({"state": "enforcing"})
+
+
+def test_record_from_dict_rejects_non_object():
+    with pytest.raises(ActivationStateError):
+        ActivationRecord.from_dict("setup")
+
+
+def test_record_from_dict_rejects_bad_baseline():
+    with pytest.raises(ActivationStateError):
+        ActivationRecord.from_dict({"state": "setup", "baseline": "x"})
+
+
+def test_record_from_dict_rejects_bad_integrations():
+    with pytest.raises(ActivationStateError):
+        ActivationRecord.from_dict({"state": "setup", "integrations_detected": [1]})
+
+
+# ── Transitions ───────────────────────────────────────────────────────────────
+
+def test_transition_not_installed_to_setup_allowed():
+    ActivationRecord(state=STATE_NOT_INSTALLED).require_transition(STATE_SETUP)
+
+
+def test_transition_not_installed_to_active_rejected():
+    # Activation to active without setup would be an implicit bypass of the
+    # frozen state model; it must fail.
+    with pytest.raises(ActivationStateError):
+        ActivationRecord(state=STATE_NOT_INSTALLED).require_transition(STATE_ACTIVE)
+
+
+def test_transition_setup_to_active_allowed_only_explicitly():
+    ActivationRecord(state=STATE_SETUP).require_transition(STATE_ACTIVE)
+
+
+def test_transition_active_to_setup_rejected():
+    # Setup must never downgrade an active project.
+    with pytest.raises(ActivationStateError):
+        ActivationRecord(state=STATE_ACTIVE).require_transition(STATE_SETUP)
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+def _write_memory(path: Path, **extra) -> None:
+    doc = scaffold_project_memory()
+    doc["decisions"].append(
+        {
+            "id": "d1",
+            "decision": "Use JSON",
+            "constraints": ["no yaml"],
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+    )
+    doc.update(extra)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+
+def test_read_activation_missing_section_returns_none(tmp_path):
+    memory = tmp_path / "project_memory.json"
+    _write_memory(memory)
+    assert read_activation(memory) is None
+
+
+def test_derive_state_lifecycle(tmp_path):
+    memory = tmp_path / "project_memory.json"
+    # No file at all → not_installed.
+    assert derive_activation_state(memory) == STATE_NOT_INSTALLED
+    _write_memory(memory)
+    # File without activation record (pre-M1.3 project) → setup.
+    assert derive_activation_state(memory) == STATE_SETUP
+    write_activation(
+        memory,
+        ActivationRecord(state=STATE_SETUP, setup_completed_at="t"),
+    )
+    assert derive_activation_state(memory) == STATE_SETUP
+    write_activation(memory, ActivationRecord(state=STATE_ACTIVE))
+    assert derive_activation_state(memory) == STATE_ACTIVE
+
+
+def test_write_activation_preserves_all_other_content(tmp_path):
+    memory = tmp_path / "project_memory.json"
+    _write_memory(memory, custom_section={"keep": [1, 2]})
+    before = json.loads(memory.read_text(encoding="utf-8"))
+
+    write_activation(memory, ActivationRecord(state=STATE_SETUP))
+
+    after = json.loads(memory.read_text(encoding="utf-8"))
+    after_without_activation = {k: v for k, v in after.items() if k != "activation"}
+    assert after_without_activation == before
+    assert after["activation"]["state"] == "setup"
+    assert after["activation"]["enforcement"] == "not_enabled"
+    # decisions content untouched
+    assert after["decisions"] == before["decisions"]
+    assert after["meta"] == before["meta"]
+    assert after["custom_section"] == {"keep": [1, 2]}
+
+
+def test_write_activation_requires_existing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        write_activation(tmp_path / "missing.json", ActivationRecord(state=STATE_SETUP))
+
+
+def test_read_activation_invalid_record_raises(tmp_path):
+    memory = tmp_path / "project_memory.json"
+    _write_memory(memory, activation={"state": "bogus"})
+    with pytest.raises(ActivationStateError):
+        read_activation(memory)
+
+
+# ── Readiness (G4 semantics) ─────────────────────────────────────────────────
+
+def test_readiness_protected_requires_typed_rule():
+    # FORBID_LITERAL typed rule = verified mechanical protection evidence.
+    d = Decision(id="a", decision="x", rules=[Rule(type="FORBID_LITERAL", value="postgres")])
+    assert assess_readiness(d) == "protected"
+
+
+def test_readiness_single_term_anti_pattern_is_not_protected():
+    # Single-term anti-patterns are "enforceable" by the core enforcer, but
+    # without a typed rule there is no existing protection evidence: the
+    # decision is Mneme-ready, NOT Protected. Installing Mneme must never
+    # cross this line (G4).
+    d = Decision(id="b", decision="x", anti_patterns=["postgres"])
+    assert assess_readiness(d) == "mneme_ready"
+
+
+def test_readiness_multi_term_anti_pattern_requires_modelling():
+    d = Decision(id="c", decision="x", anti_patterns=["no shared database between services"])
+    assert assess_readiness(d) == "requires_modelling"
+
+
+def test_readiness_no_x_constraint_requires_modelling():
+    d = Decision(id="d", decision="x", constraints=["no postgres"])
+    assert assess_readiness(d) == "requires_modelling"
+
+
+def test_readiness_prose_only_is_guidance():
+    d = Decision(id="e", decision="prefer small modules", rationale="style")
+    assert assess_readiness(d) == "guidance"
+
+
+def test_readiness_counts_all_keys_present():
+    decisions = [
+        Decision(id="a", decision="x", rules=[Rule(type="FORBID_LITERAL", value="sqlite")]),
+        Decision(id="b", decision="x", anti_patterns=["orm"]),
+        Decision(id="c", decision="x", constraints=["no postgres"]),
+        Decision(id="d", decision="prefer clarity"),
+    ]
+    counts = readiness_counts(decisions)
+    assert counts == {
+        "protected": 1,
+        "mneme_ready": 1,
+        "requires_modelling": 1,
+        "guidance": 1,
+    }

--- a/tests/test_setup_state.py
+++ b/tests/test_setup_state.py
@@ -165,7 +165,7 @@ def test_read_activation_invalid_record_raises(tmp_path):
         read_activation(memory)
 
 
-# ── Readiness (G4 semantics) ─────────────────────────────────────────────────
+# ── Readiness (G4 semantics — delegated to frozen P1.2) ─────────────────────
 
 def test_readiness_protected_requires_typed_rule():
     # FORBID_LITERAL typed rule = verified mechanical protection evidence.
@@ -187,8 +187,15 @@ def test_readiness_multi_term_anti_pattern_requires_modelling():
     assert assess_readiness(d) == "requires_modelling"
 
 
-def test_readiness_no_x_constraint_requires_modelling():
+def test_readiness_single_term_no_x_constraint_is_mneme_ready():
+    # Canonical P1.2: a single-term "no X" constraint carries a concrete
+    # safe guardrail (FORBID_LITERAL: <term>), so it is Mneme-ready.
     d = Decision(id="d", decision="x", constraints=["no postgres"])
+    assert assess_readiness(d) == "mneme_ready"
+
+
+def test_readiness_multi_term_no_x_constraint_requires_modelling():
+    d = Decision(id="d2", decision="x", constraints=["no shared database between services"])
     assert assess_readiness(d) == "requires_modelling"
 
 
@@ -197,14 +204,43 @@ def test_readiness_prose_only_is_guidance():
     assert assess_readiness(d) == "guidance"
 
 
-def test_readiness_counts_all_keys_present():
+def test_readiness_is_never_upgraded_without_verified_ci_evidence(tmp_path):
+    # A CI file merely MENTIONING the token is candidate evidence at best:
+    # candidate evidence annotates but never upgrades a tier (frozen P1.2).
+    root = tmp_path / "repo"
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(
+        "jobs:\n  scan:\n    steps:\n      - run: grep postgres src/\n",
+        encoding="utf-8",
+    )
+    d = Decision(id="f", decision="x", anti_patterns=["postgres"])
+    assert assess_readiness(d, repo_root=str(root)) == "mneme_ready"
+
+
+def test_readiness_counts_match_audit_report_for_active_decisions():
+    # The setup counts are exactly the canonical aggregate report values.
+    from mneme.enforcer import generate_protection_report
+
     decisions = [
         Decision(id="a", decision="x", rules=[Rule(type="FORBID_LITERAL", value="sqlite")]),
         Decision(id="b", decision="x", anti_patterns=["orm"]),
-        Decision(id="c", decision="x", constraints=["no postgres"]),
+        Decision(id="c", decision="x", anti_patterns=["share one database across services"]),
         Decision(id="d", decision="prefer clarity"),
+        # Superseded/deprecated decisions are provenance-only in P1.2.
+        Decision(id="old-1", decision="superseded rule", anti_patterns=["yaml"], status="superseded"),
+        Decision(id="old-2", decision="deprecated rule", rules=[Rule(type="FORBID_LITERAL", value="yaml")], status="deprecated"),
     ]
     counts = readiness_counts(decisions)
+    report = generate_protection_report(decisions)
+    assert counts == {
+        "protected": report.protected,
+        "mneme_ready": report.mneme_ready,
+        "requires_modelling": report.requires_modelling,
+        "guidance": report.guidance,
+    }
+    # Inactive decisions never enter the counts (G4: setup cannot inflate
+    # protection via status games either way — both views agree).
     assert counts == {
         "protected": 1,
         "mneme_ready": 1,


### PR DESCRIPTION
## Summary

Implements **M1.3a — Setup state + CLI** from the frozen contract
`docs/plans/m1-3-audit-to-setup-activation.md`.

### Scope implemented

- Activation state model `not_installed → setup → active` persisted as an
  optional top-level `activation` key inside the existing
  `.mneme/project_memory.json` (schema `mneme.setup/v1`). No parallel state
  file; every existing memory-file writer does raw read-modify-write, so the
  new section is preserved by `add_decision`, ADR import, and EventCatalog
  import.
- New CLI command `mneme setup [--memory PATH] [--audit-ref REF]`:
  git-repository context check, project-memory initialization (reusing the
  init scaffold), memory validation, read-only agent-environment detection
  (Claude Code, Codex CLI, Kiro, Cursor), protection-readiness summary,
  idempotent reruns.
- Readiness view (`mneme/readiness.py`): Protected / Mneme-ready /
  Requires modelling / Guidance mapped from `assess_governability`.
  **Protected requires typed FORBID_LITERAL evidence** — a single-term
  anti-pattern (governability tier `enforceable`) is reported Mneme-ready,
  never Protected.
- `--audit-ref` consumed and recorded verbatim as an opaque string;
  resolution/pairing is M1.3b and intentionally not attempted here.
- Refactor: shared ADR diagnostics collection extracted to
  `mneme/adr_diagnostics.py` (used by `check` and `setup`; no behavior
  change). `_scaffold_memory` now delegates to the shared scaffold.

### Key invariants honored

- Setup never enables blocking enforcement (record always carries
  `enforcement: "not_enabled"`; no hook configuration is written; nothing
  outside `.mneme/` is created or modified).
- Setup never classifies a decision as Protected without mechanical
  enforcement evidence; setup does not mutate decisions (pure view).
- Setup never downgrades an `active` project (leaves record untouched,
  warns) and refuses to modify activation records with an unknown future
  schema.
- Idempotency: rerun with no material change performs no write; rerun with
  changes preserves first-completion timestamps.
- Fail-closed: all validation (git context, ref format, memory validity)
  happens before the first write; corrupt/invalid memory → `ERROR` exit 2
  with zero mutation.

## Validation

- New tests (50): `tests/test_setup_state.py` (record model, transitions,
  persistence, readiness semantics), `tests/test_cli_setup.py` (fresh/existing/
  corrupt/active projects, detection, refs, byte-identical rerun).
- Full suite: `python -m pytest -q` → **1181 passed, 6 skipped**
  (baseline before change: 1179 passed, 6 skipped).
- Frozen benchmarks: `mneme benchmark examples/benchmarks` and
  `mneme benchmark examples/benchmarks-enforcement-quality` — output and
  exit codes identical to `main` (exit 0 both, same verdicts).
- Governance hygiene: `mneme check --mode warn` → PASS.
- Worktree context verified with `scripts/check_worktree_context.py`.

### Acceptance gates (M1.3a applicable)

| Gate | Status | Evidence |
|---|---|---|
| G1 Safe setup | PASS | `test_setup_fresh_repo_initializes_in_setup_mode`, `test_setup_creates_nothing_but_mneme_state`, `test_setup_does_not_touch_existing_agent_configuration` |
| G2 Idempotency / existing projects | PASS | `test_setup_rerun_is_byte_identical`, `test_setup_existing_project_preserves_all_content`, `test_setup_on_corrupt_memory_fails_without_mutation`, `test_setup_on_schema_invalid_memory_fails_without_mutation`, `test_setup_never_downgrades_active_project` |
| G3 Audit linking | NOT YET APPLICABLE (M1.3b) | — |
| G4 No protection-score inflation | PASS | `test_readiness_single_term_anti_pattern_is_not_protected`, `test_setup_readiness_does_not_inflate_protection` (setup-only run keeps Mneme-ready as Mneme-ready, no rule materialization) |
| G5 Integration detection | PASS | `test_setup_detects_all_supported_environments`, `test_setup_without_environments_reports_none`, `test_detection_creates_no_files` |
| G6 Audit UI activation state | NOT YET APPLICABLE (M1.3c) | — |
| G7 Funnel attribution | NOT YET APPLICABLE (M1.3b/d) | — |
| G8 Existing-product regression | PASS | Full suite + frozen benchmarks byte-identical to `main` |

## Implementation decisions

- State persisted inside `project_memory.json` (`activation` key) per
  contract §7 (reuse existing project metadata; no new files). Legacy
  projects without a record derive as `setup` (Mneme present, enforcement
  never persisted as enabled).
- M1.3a deliberately detects integrations but configures none (contract §6:
  MAY configure non-blocking behavior). Hooks default to strict; installing
  them implicitly would violate the core invariant.
- Readiness classification lives in core and mirrors the frozen P1.2
  mapping used by the audit workspace classifier.
- Rerun rewrites the record only when content changes; unknown future
  activation schemas are refused (fail-closed) rather than silently
  rewritten to v1.

## Known limitations

- `--audit-ref` is recorded but not yet resolved against the Audit service
  (M1.3b adds reference issuance/resolution/attribution).
- Integration detection is directory-presence based; hook-configuration
  detection ("configured vs detected") is deferred until any integration is
  actually configurable via setup.
- No `mneme status` command (not in contract scope); state is inspectable
  from `project_memory.json`.

Out-of-scope capabilities were not introduced: no ADR invention, no
guardrail generation, no enforcement activation, no billing/orgs/RBAC/auth,
no fleet management, no new dashboard or onboarding application.

Execution log: `docs/plans/m1-3-execution-log.md`.

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: manual
- Human owner: @TheoV823
