### PR TITLE
feat: resolve and complete audit setup references in mneme setup (M1.3b)

### DIFF
--- a/docs/plans/m1-3-execution-log.md
+++ b/docs/plans/m1-3-execution-log.md
@@ -3,12 +3,13 @@
 Contract: `docs/plans/m1-3-audit-to-setup-activation.md` (frozen).
 
 ## Current increment
-M1.3a — Setup state + CLI
+M1.3b — Audit baseline pairing (CLI side; site side in mnemehq-site#104)
 
 ## Status
-IN PROGRESS (PR open)
+IN PROGRESS (M1.3a PR open: MnemeHQ/mneme#345; M1.3b CLI PR stacked on it)
 
 ## Completed
+### M1.3a (PR MnemeHQ/mneme#345)
 - Activation state model (`mneme/setup_state.py`): `not_installed → setup → active`,
   persisted as an optional top-level `activation` key in the existing
   `.mneme/project_memory.json` (no parallel state file; all existing writers
@@ -19,51 +20,66 @@ IN PROGRESS (PR open)
   environment detection (read-only), readiness view, setup summary,
   idempotent reruns.
 - Readiness view (`mneme/readiness.py`): Protected / Mneme-ready /
-  Requires modelling / Guidance mapped from `assess_governability`.
+  Requires modelling / Guidance mapped from `assess_governance` semantics.
   Protected requires typed FORBID_LITERAL evidence.
 - Integration detection (`mneme/integrations/detect.py`): Claude Code,
   Codex CLI, Kiro, Cursor. Detection only; never writes configuration,
   never enables enforcement.
-- `--audit-ref` consumed and recorded verbatim as an opaque string.
-  Resolution/pairing is M1.3b (not implemented yet).
-- Extracted shared ADR diagnostics collection to `mneme/adr_diagnostics.py`
-  (used by both `check` and `setup`; no behavior change).
+- Extracted shared ADR diagnostics collection to `mneme/adr_diagnostics.py`.
 - README: setup-mode section.
 
+### M1.3b (this branch + MnemeHQ/mnemehq-site#104)
+- `mneme/audit_pairing.py`: stdlib-only client for the Audit service —
+  `resolve(reference)` (non-consuming) and `complete(reference, repository,
+  mneme_version)` (idempotent server-side); base URL from
+  `MNEME_AUDIT_API_URL` (default production Cloud Run URL).
+- `mneme setup --audit-ref REF` now REQUIRES resolution before any local
+  write: unknown/expired/mismatched/unreachable → fail-closed ERROR, no
+  mutation (G3). Resolved baseline provenance (whitelisted keys only) is
+  recorded in `activation.baseline`.
+- Setup completion is reported back to the Audit service after the local
+  write; a failed report leaves completion pending with a warning and is
+  retried automatically on the next `mneme setup` run (G7).
+- Local `git remote get-url origin` is passed to completion for the
+  server-side repository mismatch check.
+- Site backend (mnemehq-site#104): `setup_references` table, reference
+  issuance/resolution/completion endpoints, project `activation_state`
+  (`not_installed`/`setup`/`active` distinct from Audit lifecycle),
+  migration 002.
+
 ## Current work
-- PR for M1.3a; then M1.3b (Audit baseline pairing in mnemehq-site backend
-  + CLI resolution).
+- M1.3c — Audit activation UI (mnemehq-site frontend), after M1.3a/M1.3b
+  contracts are stable.
 
 ## Acceptance gates
-- G1 (safe setup): PASS — `test_setup_fresh_repo_initializes_in_setup_mode`
-  (fresh git repo → state `setup`, `enforcement: "not_enabled"`,
-  `activated_at: null`), `test_setup_creates_nothing_but_mneme_state`
-  (only `.mneme/project_memory.json` added),
-  `test_setup_does_not_touch_existing_agent_configuration`.
-- G2 (idempotency / existing projects): PASS —
-  `test_setup_rerun_is_byte_identical`,
-  `test_setup_existing_project_preserves_all_content`,
-  `test_setup_rerun_on_existing_project_preserves_first_completion`,
-  `test_setup_on_corrupt_memory_fails_without_mutation`,
-  `test_setup_on_schema_invalid_memory_fails_without_mutation`,
-  `test_setup_on_invalid_activation_record_fails_without_mutation`.
-- G3 (audit linking): NOT YET APPLICABLE — M1.3b.
-- G4 (no protection-score inflation): PASS —
-  `test_readiness_single_term_anti_pattern_is_not_protected`,
-  `test_setup_readiness_does_not_inflate_protection` (setup-only run keeps
-  Mneme-ready as Mneme-ready; no rule materialization);
-  readiness is a pure view over `assess_governability`.
-- G5 (integration detection): PASS —
-  `test_setup_detects_all_supported_environments`,
-  `test_setup_without_environments_reports_none`,
-  `test_detection_creates_no_files` (detection activates nothing).
-- G6 (audit UI activation state): NOT YET APPLICABLE — M1.3c.
-- G7 (funnel attribution): NOT YET APPLICABLE — M1.3b/d.
-- G8 (existing-product regression): PASS — full suite
-  `1179 passed, 6 skipped` (baseline suite, worktree HEAD), frozen
-  benchmark runs `examples/benchmarks` and
-  `examples/benchmarks-enforcement-quality` byte-identical to `main`
-  (exit 0 both, same verdicts).
+- G1 (safe setup): PASS — M1.3a tests unchanged and passing
+  (`test_setup_fresh_repo_initializes_in_setup_mode`,
+  `test_setup_creates_nothing_but_mneme_state`); pairing adds no
+  enforcement anywhere.
+- G2 (idempotency / existing projects): PASS — byte-identical no-op rerun,
+  existing project preservation, corrupt/invalid memory fail-safe tests;
+  rerun preserves first-completion timestamps.
+- G3 (audit linking): PASS — CLI: `test_setup_resolves_reference_and_records_baseline`
+  (provenance preserved: audit, project, commit SHA, Mneme version, schema
+  version), `test_setup_invalid_reference_fails_closed_before_writes`,
+  `test_setup_invalid_reference_on_existing_project_leaves_it_untouched`,
+  `test_setup_incomplete_resolution_payload_fails_closed`; site:
+  issuance requires saved baseline, 404 unknown / 410 expired / 409
+  mismatched repository (mnemehq-site#104 tests).
+- G4 (no protection-score inflation): PASS — readiness remains a pure view;
+  pairing records state only; site tests assert audit payload immutability
+  after completion.
+- G5 (integration detection): PASS — M1.3a detection tests unchanged.
+- G6 (audit UI activation state): PARTIAL — API surface done (project
+  endpoint exposes `activation_state`/`setup_completed_at`/`setup_audit_id`);
+  UI lands in M1.3c.
+- G7 (funnel attribution): PASS (recording + CLI reporting) —
+  `test_complete_receives_origin_remote`, completion retry
+  (`test_setup_rerun_retries_pending_completion`); site records
+  setup_audit_id/setup_completed_at/redeemed_mneme_version.
+- G8 (existing-product regression): PASS — full suite 1189 passed, 6
+  skipped; frozen benchmark runs byte-identical to `main` (verified in
+  M1.3a; no enforcement/retrieval code touched since).
 
 ## Implementation decisions
 - Activation state persisted inside `project_memory.json` (`activation` key)
@@ -87,25 +103,32 @@ IN PROGRESS (PR open)
   timestamps.
 - Setup on an `active` project refuses to downgrade: leaves the record
   untouched and reports a warning (no silent state transitions).
-- Readiness classification lives in core (`mneme/readiness.py`) and treats
-  only typed FORBID_LITERAL rules as Protected — single-term anti-patterns
-  (governability tier `enforceable`) remain Mneme-ready. This mirrors the
-  frozen P1.2 mapping in the audit workspace and is the G4-critical choice.
 - M1.3a does not configure integrations (contract: setup MAY configure
   non-blocking integration behavior; choosing detect-only minimizes risk of
   implicit enforcement; hooks default to strict and must never be installed
   implicitly).
 - Invalid audit refs (empty/whitespace/overlong) fail closed before any
-  write; M1.3b adds resolution semantics on top of the same guardrails.
+  write; resolution semantics build on the same guardrails.
+- Resolution is fail-closed and REQUIRED when `--audit-ref` is supplied via
+  the CLI: an unverifiable reference is never recorded (contract §4 G3).
+  `run_setup(pairing=None)` keeps verbatim recording for offline/embedded
+  use and is covered by tests.
+- Baseline provenance is whitelisted from the resolution payload — the raw
+  server response is never persisted.
+- Completion reporting happens after the local write; failure degrades to a
+  warning with automatic retry on next run (server-side completion is
+  idempotent via `already_redeemed`).
+- Rerun without a reference preserves the previously connected baseline and
+  performs no network calls.
 
 ## Verification
-- New tests: `tests/test_setup_state.py` (20), `tests/test_cli_setup.py`
-  (28) — all pass.
-- Full repository suite: `python -m pytest -q` → 1179 passed, 6 skipped.
-- Frozen benchmarks: `mneme benchmark examples/benchmarks` and
-  `mneme benchmark examples/benchmarks-enforcement-quality` — output and
-  exit codes identical to `main`.
+- New tests: `tests/test_cli_setup.py` pairing section (10 tests) +
+  updated ref tests; `tests/test_setup_state.py` unchanged (20).
+- Full repository suite: `python -m pytest -q` → 1189 passed, 6 skipped.
+- Site-side verification in mnemehq-site#104 (backend 89 passed, 3
+  skipped; root 2; scripts 60).
 - Worktree context verified via `scripts/check_worktree_context.py`.
 
 ## Escalations
 None
+

--- a/docs/plans/m1-3-execution-log.md
+++ b/docs/plans/m1-3-execution-log.md
@@ -77,9 +77,9 @@ IN PROGRESS (M1.3a PR open: MnemeHQ/mneme#345; M1.3b CLI PR stacked on it)
   `test_complete_receives_origin_remote`, completion retry
   (`test_setup_rerun_retries_pending_completion`); site records
   setup_audit_id/setup_completed_at/redeemed_mneme_version.
-- G8 (existing-product regression): PASS — full suite 1189 passed, 6
-  skipped; frozen benchmark runs byte-identical to `main` (verified in
-  M1.3a; no enforcement/retrieval code touched since).
+- G8 (existing-product regression): PASS — full suite 1212 passed, 6
+  skipped (reconciled M1.3a + M1.3b on P1.2 main); frozen benchmark runs
+  byte-identical to `main` (no enforcement/retrieval code touched).
 
 ## Implementation decisions
 - Activation state persisted inside `project_memory.json` (`activation` key)
@@ -124,7 +124,8 @@ IN PROGRESS (M1.3a PR open: MnemeHQ/mneme#345; M1.3b CLI PR stacked on it)
 ## Verification
 - New tests: `tests/test_cli_setup.py` pairing section (10 tests) +
   updated ref tests; `tests/test_setup_state.py` unchanged (20).
-- Full repository suite: `python -m pytest -q` → 1189 passed, 6 skipped.
+- Full repository suite: `python -m pytest -q` → 1212 passed, 6 skipped
+  (rebased on P1.2 main; includes the setup/audit parity tests).
 - Site-side verification in mnemehq-site#104 (backend 89 passed, 3
   skipped; root 2; scripts 60).
 - Worktree context verified via `scripts/check_worktree_context.py`.

--- a/mneme/audit_pairing.py
+++ b/mneme/audit_pairing.py
@@ -1,0 +1,142 @@
+"""
+audit_pairing.py — Resolution and completion of Audit setup references (M1.3b).
+
+A setup reference created by the Architecture Audit service is opaque,
+scoped to one audit/project, and expiring. This client resolves it to
+baseline provenance and reports setup completion back, so a setup initiated
+from an Audit is attributable to that audit/project (G3, G7).
+
+Failure semantics are fail-closed: any network or HTTP failure raises
+:class:`PairingError` and the setup flow aborts before any local mutation.
+Reference resolution is REQUIRED when ``--audit-ref`` is supplied: an
+unverifiable reference is never recorded silently.
+
+The base URL defaults to the production Architecture Audit API and can be
+overridden with ``MNEME_AUDIT_API_URL``. Uses only the standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+DEFAULT_AUDIT_API_URL = (
+    "https://mneme-audit-api-842519822929.us-central1.run.app"
+)
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+RESOLVE_PATH = "/api/v1/setup-references/{reference}"
+COMPLETE_PATH = "/api/v1/setup-references/{reference}/complete"
+
+
+class PairingError(Exception):
+    """A pairing request failed (network, HTTP, or unparseable response)."""
+
+    def __init__(self, message: str, status: int | None = None):
+        self.status = status
+        super().__init__(message)
+
+
+@dataclass
+class AuditPairingClient:
+    """HTTP client for Audit setup-reference resolve/complete (M1.3b)."""
+
+    base_url: str = ""
+    timeout: float = DEFAULT_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        if not self.base_url:
+            self.base_url = os.environ.get(
+                "MNEME_AUDIT_API_URL", DEFAULT_AUDIT_API_URL
+            ).rstrip("/")
+
+    def resolve(self, reference: str) -> dict:
+        """Resolve a reference to baseline provenance (non-consuming)."""
+        path = RESOLVE_PATH.format(reference=urllib.parse.quote(reference, safe=""))
+        return self._request("GET", path)
+
+    def complete(
+        self,
+        reference: str,
+        repository: str | None,
+        mneme_version: str,
+    ) -> dict:
+        """Report setup completion (idempotent server-side)."""
+        path = COMPLETE_PATH.format(reference=urllib.parse.quote(reference, safe=""))
+        payload = {
+            "repository": repository,
+            "mneme_version": mneme_version,
+        }
+        return self._request("POST", path, body=payload)
+
+    def _request(self, method: str, path: str, body: dict | None = None) -> dict:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                **({"Content-Type": "application/json"} if data else {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                raw = response.read()
+                status = getattr(response, "status", 200)
+        except urllib.error.HTTPError as exc:
+            detail = self._error_detail(exc)
+            raise PairingError(
+                detail or f"HTTP {exc.code} from Audit service", status=exc.code
+            ) from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise PairingError(
+                f"could not reach the Architecture Audit service at "
+                f"{self.base_url}: {exc}"
+            ) from exc
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PairingError(
+                f"Audit service returned a non-JSON response (HTTP {status})"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise PairingError(
+                f"Audit service returned an unexpected payload (HTTP {status})"
+            )
+        return payload
+
+    @staticmethod
+    def _error_detail(exc: urllib.error.HTTPError) -> str:
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+        except Exception:
+            return ""
+        error = payload.get("error") if isinstance(payload, dict) else None
+        return str(error) if error else ""
+
+
+def detect_origin_remote(project_root) -> str | None:
+    """Best-effort ``git remote get-url origin`` for the mismatch check."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    remote = (result.stdout or "").strip()
+    return remote or None

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -136,7 +136,25 @@ def _print_setup_summary(outcome: SetupOutcome) -> None:
         print(f"  Found {outcome.memory_path}")
     print()
     print("Architecture baseline")
-    if outcome.audit_ref:
+    if outcome.baseline:
+        repository = (
+            outcome.baseline.get("repository")
+            or outcome.baseline.get("repository_url")
+            or "repository not identified"
+        )
+        print(f"  Connected: {outcome.baseline.get('project_name') or 'Audit project'} ({repository})")
+        print(f"  Audit: {outcome.baseline.get('audit_id')}")
+        print(f"  Commit: {outcome.baseline.get('commit_sha')}")
+        print(
+            f"  Mneme (audit): {outcome.baseline.get('mneme_version')}"
+            f", schema {outcome.baseline.get('audit_schema')}"
+        )
+        completion = outcome.baseline.get("completion")
+        if completion:
+            print("  Setup recorded with the Audit service")
+        else:
+            print("  Setup recording pending (rerun `mneme setup` to retry)")
+    elif outcome.audit_ref:
         print(f"  Audit reference recorded: {outcome.audit_ref}")
     else:
         print("  Not connected (no audit reference provided)")

--- a/mneme/setup.py
+++ b/mneme/setup.py
@@ -1,5 +1,5 @@
 """
-setup.py — The ``mneme setup`` flow (M1.3a).
+setup.py — The ``mneme setup`` flow (M1.3a + M1.3b pairing).
 
 Initializes Mneme project state in *setup mode* under the frozen M1.3
 contract (docs/plans/m1-3-audit-to-setup-activation.md):
@@ -15,10 +15,13 @@ contract (docs/plans/m1-3-audit-to-setup-activation.md):
 All validation happens before the first write, so any pre-execution failure
 leaves the repository exactly as it was.
 
-Audit reference handling in M1.3a: ``--audit-ref`` is consumed and recorded
-verbatim as an opaque string. Resolution against the Architecture Audit
-service is the M1.3b pairing mechanism; recording an opaque reference is
-inert — no enforcement or classification follows from it.
+Audit reference handling (M1.3b): when ``--audit-ref`` is supplied, the
+reference is resolved against the Architecture Audit service BEFORE any
+local write; resolution failures (unknown/expired/mismatched/unreachable)
+abort with no mutation. The resolved baseline provenance is recorded in the
+activation record, and setup completion is reported back (idempotently) so
+the setup is attributable to the audit/project. Passing ``pairing=None``
+skips resolution and records the reference verbatim (offline/embedded use).
 """
 
 from __future__ import annotations
@@ -29,6 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from mneme.adr_diagnostics import collect_adr_diagnostics
+from mneme.audit_pairing import AuditPairingClient, PairingError, detect_origin_remote
 from mneme.integrations.detect import DetectedIntegration, detect_integrations
 from mneme.memory_store import MemoryStore
 from mneme.enforcer import ProtectionTier
@@ -53,15 +57,37 @@ GIT_MARKER = ".git"
 DEFAULT_ADR_DIR = "docs/adr"
 
 # The reference is opaque, but it must be a sane opaque token: a single
-# non-empty chunk with no internal whitespace and a bounded length. Any real
-# reference format introduced by M1.3b pairing must remain valid under these
-# constraints.
+# non-empty chunk with no internal whitespace and a bounded length. Server
+# references (token_urlsafe) must remain valid under these constraints.
 MAX_AUDIT_REF_LENGTH = 256
 _AUDIT_REF_PATTERN = re.compile(r"^\S+$")
+
+# Whitelisted baseline provenance persisted from a resolution payload. Only
+# these keys are recorded — never the raw server response.
+_BASELINE_KEYS = (
+    "audit_id",
+    "project_id",
+    "project_name",
+    "repository",
+    "repository_url",
+    "commit_sha",
+    "mneme_version",
+    "schema_version",
+    "audit_schema",
+    "summary",
+)
 
 
 class SetupError(Exception):
     """A pre-execution setup failure. No filesystem mutation has occurred."""
+
+
+def default_pairing() -> AuditPairingClient:
+    """Pairing client used by the CLI (overridable in tests)."""
+    return AuditPairingClient()
+
+
+_UNSET = object()
 
 
 @dataclass
@@ -80,6 +106,7 @@ class SetupOutcome:
     readiness: dict[ProtectionTier, int] = field(default_factory=dict)
     adr_diagnostics: int = 0
     adr_diagnostics_present: bool = False
+    baseline: dict | None = None
     warnings: list[str] = field(default_factory=list)
 
 
@@ -148,13 +175,20 @@ def run_setup(
     root: Path | None = None,
     memory: Path | None = None,
     audit_ref: str = "",
+    pairing: AuditPairingClient | None | object = _UNSET,
 ) -> SetupOutcome:
     """Run the setup flow and return its outcome.
 
     Raises :class:`SetupError` before any write on invalid context. On
     success the repository contains a project memory with an activation
     record in ``setup`` state and nothing else has changed.
+
+    ``pairing`` resolves/reports an ``--audit-ref`` against the Architecture
+    Audit service. ``None`` skips resolution and records the reference
+    verbatim (offline use). Unset resolves via :func:`default_pairing`.
     """
+    if pairing is _UNSET:
+        pairing = default_pairing()
     start = Path(root) if root is not None else Path.cwd()
     project_root = find_project_root(start)
     if project_root is None:
@@ -171,6 +205,14 @@ def run_setup(
         memory_path = project_root / DEFAULT_MEMORY_PATH
 
     ref = validate_audit_ref(audit_ref) if audit_ref.strip() else ""
+
+    # Resolution happens before any local write: an unverifiable reference
+    # (unknown, expired, mismatched, or unreachable service) must never be
+    # recorded silently (G3 fail-safety).
+    baseline: dict | None = None
+    if ref and pairing is not None:
+        resolved = _resolve_reference(pairing, ref)
+        baseline = _baseline_from_resolution(resolved, utc_now())
 
     integrations = detect_integrations(project_root)
 
@@ -211,6 +253,14 @@ def run_setup(
         )
         decisions = _load_validated_decisions(memory_path)
 
+    if baseline is None and previous_record is not None and not ref:
+        # Rerun without a reference: keep the previously connected baseline.
+        baseline = previous_record.baseline
+
+    pending_completion = bool(
+        baseline is not None and baseline.get("completion") is None
+    )
+
     outcome = SetupOutcome(
         project_root=project_root,
         memory_path=memory_path,
@@ -224,6 +274,7 @@ def run_setup(
         # P1.2 frozen semantics with CI-evidence scanning over this
         # repository — exactly what `mneme audit --repo-root` reports.
         readiness=readiness_counts(decisions, repo_root=project_root),
+        baseline=baseline,
     )
 
     record = ActivationRecord(
@@ -242,7 +293,7 @@ def run_setup(
         audit_ref=ref
         if ref
         else (previous_record.audit_ref if previous_record is not None else ""),
-        baseline=None,
+        baseline=baseline,
         integrations_detected=[i.key for i in integrations],
         integrations_configured=[],
         enforcement=ENFORCEMENT_NOT_ENABLED,
@@ -279,7 +330,70 @@ def run_setup(
     # ADR diagnostics run after the memory is on disk so they observe the
     # post-setup state (and a freshly created memory file does exist).
     _attach_adr_diagnostics(outcome)
+
+    # Report setup completion so the setup is attributable back to the
+    # audit/project (G7). The server is idempotent; a failed report leaves
+    # completion pending and is retried on the next setup run.
+    if ref and pairing is not None:
+        remote = detect_origin_remote(project_root)
+        try:
+            pairing.complete(ref, remote, record.mneme_version)
+        except PairingError as exc:
+            outcome.warnings.append(
+                "setup completed locally, but completion could not be "
+                f"recorded with the Architecture Audit service: {exc}; "
+                "rerun `mneme setup` to retry"
+            )
+        else:
+            baseline["completion"] = {
+                "reported_at": utc_now(),
+                "mneme_version": record.mneme_version,
+            }
+            write_activation(memory_path, record)
+    elif pending_completion and pairing is not None and baseline is not None:
+        remote = detect_origin_remote(project_root)
+        try:
+            pairing.complete(record.audit_ref, remote, record.mneme_version)
+        except PairingError as exc:
+            outcome.warnings.append(
+                "baseline connected, but setup completion could not be "
+                f"recorded with the Architecture Audit service: {exc}; "
+                "rerun `mneme setup` to retry"
+            )
+        else:
+            baseline["completion"] = {
+                "reported_at": utc_now(),
+                "mneme_version": record.mneme_version,
+            }
+            write_activation(memory_path, record)
+
     return outcome
+
+
+def _resolve_reference(pairing: AuditPairingClient, ref: str) -> dict:
+    """Resolve a reference, converting pairing failures to SetupError."""
+    try:
+        payload = pairing.resolve(ref)
+    except PairingError as exc:
+        raise SetupError(f"audit reference could not be verified: {exc}") from exc
+    missing = [
+        key for key in ("audit_id", "project_id", "commit_sha")
+        if not payload.get(key)
+    ]
+    if missing:
+        raise SetupError(
+            "Audit service returned an incomplete baseline payload "
+            f"(missing {', '.join(missing)})"
+        )
+    return payload
+
+
+def _baseline_from_resolution(payload: dict, resolved_at: str) -> dict:
+    """Whitelist resolution payload into the persisted baseline block."""
+    baseline: dict = {key: payload.get(key) for key in _BASELINE_KEYS}
+    baseline["resolved_at"] = resolved_at
+    baseline["completion"] = None
+    return baseline
 
 
 def _attach_adr_diagnostics(outcome: SetupOutcome) -> None:

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,13 +1,64 @@
-"""CLI — `mneme setup` (M1.3a: safe setup flow, G1/G2/G4/G5 evidence)."""
+﻿"""CLI — `mneme setup` (M1.3a setup flow; M1.3b pairing; G1/G2/G3/G4/G5)."""
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
+from mneme.audit_pairing import PairingError
 from mneme.cli import main
 
 
 MEMORY_REL = Path(".mneme") / "project_memory.json"
+
+RESOLVE_RESPONSE = {
+    "reference": "ref-abc",
+    "audit_id": "00000000-0000-0000-0000-000000000001",
+    "project_id": "00000000-0000-0000-0000-000000000002",
+    "project_name": "contract-fixture",
+    "repository": "example/contract-fixture",
+    "repository_url": "https://github.com/example/contract-fixture",
+    "commit_sha": "abc123def456",
+    "mneme_version": "0.6.0",
+    "schema_version": 1,
+    "audit_schema": "mneme.audit/v1",
+    "summary": {"protected": 2, "mneme_ready": 3},
+}
+
+
+class FakePairing:
+    """In-memory stand-in for the Architecture Audit pairing client."""
+
+    def __init__(self):
+        self.resolve_calls: list[str] = []
+        self.resolve_error: str | None = None
+        self.resolve_response: dict = dict(RESOLVE_RESPONSE)
+        self.complete_error: str | None = None
+        self.complete_calls: list[dict] = []
+
+    def resolve(self, reference: str) -> dict:
+        self.resolve_calls.append(reference)
+        if self.resolve_error:
+            raise PairingError(self.resolve_error, status=410)
+        return dict(self.resolve_response)
+
+    def complete(self, reference: str, repository, mneme_version: str) -> dict:
+        self.complete_calls.append({
+            "reference": reference,
+            "repository": repository,
+            "mneme_version": mneme_version,
+        })
+        if self.complete_error:
+            raise PairingError(self.complete_error, status=503)
+        return {"activation_state": "setup", "already_redeemed": False}
+
+
+@pytest.fixture(autouse=True)
+def fake_pairing(monkeypatch):
+    """No test talks to the network: the CLI pairing client is always faked."""
+    fake = FakePairing()
+    monkeypatch.setattr("mneme.setup.default_pairing", lambda: fake)
+    return fake
 
 
 def _make_repo(tmp_path: Path) -> Path:
@@ -267,7 +318,9 @@ def test_setup_rerun_with_new_audit_ref_updates_ref_only(tmp_path, monkeypatch, 
     second = _read_memory(root)["activation"]
     assert second["audit_ref"] == "ref-999"
     assert second["setup_completed_at"] == first["setup_completed_at"]
-    assert "Audit reference recorded: ref-999" in captured.out
+    # A fresh reference resolves to a connected baseline.
+    assert second["baseline"]["audit_id"] == RESOLVE_RESPONSE["audit_id"]
+    assert "Connected: contract-fixture" in captured.out
 
 
 def test_setup_on_corrupt_memory_fails_without_mutation(tmp_path, monkeypatch, capsys):
@@ -443,17 +496,31 @@ def test_detection_creates_no_files(tmp_path, monkeypatch):
 
 # ── Audit reference consumption (M1.3a scope) ────────────────────────────────
 
-def test_setup_records_audit_ref_verbatim(tmp_path, monkeypatch, capsys):
+def test_setup_resolves_reference_and_records_baseline(tmp_path, monkeypatch, capsys, fake_pairing):
     root = _make_repo(tmp_path)
     monkeypatch.chdir(root)
 
-    exit_code = main(["setup", "--audit-ref", "a1b2c3-opaque"])
+    exit_code = main(["setup", "--audit-ref", "ref-abc"])
     captured = capsys.readouterr()
 
     assert exit_code == 0
     record = _read_memory(root)["activation"]
-    assert record["audit_ref"] == "a1b2c3-opaque"
-    assert "Audit reference recorded: a1b2c3-opaque" in captured.out
+    assert record["audit_ref"] == "ref-abc"
+    baseline = record["baseline"]
+    assert baseline["audit_id"] == RESOLVE_RESPONSE["audit_id"]
+    assert baseline["project_id"] == RESOLVE_RESPONSE["project_id"]
+    assert baseline["commit_sha"] == RESOLVE_RESPONSE["commit_sha"]
+    assert baseline["mneme_version"] == RESOLVE_RESPONSE["mneme_version"]
+    assert baseline["schema_version"] == RESOLVE_RESPONSE["schema_version"]
+    assert baseline["audit_schema"] == "mneme.audit/v1"
+    assert baseline["summary"] == RESOLVE_RESPONSE["summary"]
+    assert baseline["resolved_at"]
+    # G7: setup completion reported back to the Audit service.
+    assert fake_pairing.complete_calls[0]["reference"] == "ref-abc"
+    assert fake_pairing.complete_calls[0]["mneme_version"]
+    assert baseline["completion"]["reported_at"]
+    assert "Connected: contract-fixture (example/contract-fixture)" in captured.out
+    assert "Setup recorded with the Audit service" in captured.out
 
 
 def test_setup_without_audit_ref_reports_not_connected(tmp_path, monkeypatch, capsys):
@@ -531,16 +598,138 @@ def test_setup_rejects_overlong_audit_ref(tmp_path, monkeypatch):
     assert not (root / MEMORY_REL).exists()
 
 
-def test_setup_preserves_existing_audit_ref_when_rerun_without_one(tmp_path, monkeypatch, capsys):
+def test_setup_preserves_existing_baseline_when_rerun_without_ref(tmp_path, monkeypatch, capsys, fake_pairing):
     root = _make_repo(tmp_path)
     monkeypatch.chdir(root)
 
     assert main(["setup", "--audit-ref", "keep-me"]) == 0
+    fake_pairing.resolve_calls.clear()
     exit_code = main(["setup"])
     captured = capsys.readouterr()
     assert exit_code == 0
 
     record = _read_memory(root)["activation"]
     assert record["audit_ref"] == "keep-me"
-    # The summary reflects the persisted linkage, not this run's arguments.
-    assert "Audit reference recorded: keep-me" in captured.out
+    # No network activity on a plain rerun; the connected baseline survives.
+    assert fake_pairing.resolve_calls == []
+    assert record["baseline"]["audit_id"] == RESOLVE_RESPONSE["audit_id"]
+    assert "Connected: contract-fixture" in captured.out
+
+
+# ── Pairing failure safety (G3) ───────────────────────────────────────────────
+
+def test_setup_invalid_reference_fails_closed_before_writes(tmp_path, monkeypatch, capsys, fake_pairing):
+    root = _make_repo(tmp_path)
+    fake_pairing.resolve_error = "Setup reference has expired."
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup", "--audit-ref", "expired-ref"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "expired" in captured.err
+    assert not (root / MEMORY_REL).exists()
+    assert not (root / ".mneme").exists()
+
+
+def test_setup_invalid_reference_on_existing_project_leaves_it_untouched(
+    tmp_path, monkeypatch, fake_pairing
+):
+    root = _make_repo(tmp_path)
+    _write_memory_with_decisions(root)
+    memory_file = root / MEMORY_REL
+    before = memory_file.read_text(encoding="utf-8")
+    fake_pairing.resolve_error = "Unknown setup reference"
+
+    monkeypatch.chdir(root)
+    exit_code = main(["setup", "--audit-ref", "unknown"])
+
+    assert exit_code == 2
+    assert memory_file.read_text(encoding="utf-8") == before
+
+
+def test_setup_incomplete_resolution_payload_fails_closed(tmp_path, monkeypatch, capsys, fake_pairing):
+    root = _make_repo(tmp_path)
+    fake_pairing.resolve_response = {"audit_id": "x"}  # no project_id/commit_sha
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup", "--audit-ref", "ref-abc"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "incomplete" in captured.err
+    assert not (root / MEMORY_REL).exists()
+
+
+def test_setup_completion_report_failure_warns_but_setup_succeeds(
+    tmp_path, monkeypatch, capsys, fake_pairing
+):
+    root = _make_repo(tmp_path)
+    fake_pairing.complete_error = "service unavailable"
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup", "--audit-ref", "ref-abc"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    record = _read_memory(root)["activation"]
+    assert record["baseline"]["completion"] is None
+    assert "could not be recorded" in captured.out
+
+
+def test_setup_rerun_retries_pending_completion(tmp_path, monkeypatch, fake_pairing):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+
+    fake_pairing.complete_error = "service unavailable"
+    assert main(["setup", "--audit-ref", "ref-abc"]) == 0
+    assert _read_memory(root)["activation"]["baseline"]["completion"] is None
+
+    fake_pairing.complete_error = None
+    exit_code = main(["setup"])
+    assert exit_code == 0
+
+    record = _read_memory(root)["activation"]
+    assert record["baseline"]["completion"]["reported_at"]
+    assert len(fake_pairing.complete_calls) == 2
+
+
+def test_setup_complete_receives_origin_remote(tmp_path, monkeypatch, fake_pairing):
+    root = tmp_path / "real-repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/example/contract-fixture.git"],
+        cwd=root, check=True,
+    )
+    monkeypatch.chdir(root)
+
+    exit_code = main(["setup", "--audit-ref", "ref-abc"])
+    assert exit_code == 0
+    assert fake_pairing.complete_calls[0]["repository"] == (
+        "https://github.com/example/contract-fixture.git"
+    )
+
+
+def test_setup_offline_mode_records_reference_verbatim(tmp_path, monkeypatch):
+    """pairing=None records the opaque reference without resolution."""
+    from mneme.setup import run_setup
+
+    root = _make_repo(tmp_path)
+    outcome = run_setup(root=root, audit_ref="opaque-token", pairing=None)
+
+    assert outcome.state == "setup"
+    assert outcome.baseline is None
+    record = _read_memory(root)["activation"]
+    assert record["audit_ref"] == "opaque-token"
+    assert record["baseline"] is None
+
+
+def test_setup_without_audit_ref_never_calls_pairing(tmp_path, monkeypatch, capsys, fake_pairing):
+    root = _make_repo(tmp_path)
+    monkeypatch.chdir(root)
+    assert main(["setup"]) == 0
+    out = capsys.readouterr().out
+    assert "Not connected" in out
+    assert fake_pairing.resolve_calls == []
+    assert fake_pairing.complete_calls == []


### PR DESCRIPTION
## Summary

Implements the **Mneme CLI side of M1.3b — Audit baseline pairing**, on top
of M1.3a (#345, stacked PR targeting that branch). Site-side backend is in
MnemeHQ/mnemehq-site#104. Contract:
`docs/plans/m1-3-audit-to-setup-activation.md` §4 M1.3b.

### Scope implemented

- **`mneme/audit_pairing.py`** — stdlib-only client (no new dependencies):
  - `resolve(reference)` — non-consuming resolution of baseline provenance
  - `complete(reference, repository, mneme_version)` — idempotent
    server-side completion report
  - base URL from `MNEME_AUDIT_API_URL` (default: production Audit API),
    15s timeout, URL-quoted references, HTTP/network errors →
    `PairingError` with server-provided detail
  - `detect_origin_remote()` — best-effort `git remote get-url origin`
- **`mneme setup --audit-ref REF` semantics (G3 fail-closed)**:
  - Resolution is REQUIRED before any local write when `--audit-ref` is
    supplied via the CLI. Unknown/expired/mismatched/unreachable →
    `ERROR: audit reference could not be verified: ...`, exit 2, **zero
    mutation** (fresh file never created; existing memory byte-identical).
  - On success, baseline provenance (whitelisted keys only — audit,
    project, commit SHA, Mneme version, schema version, summary) is
    recorded in `activation.baseline`; the raw server response is never
    persisted.
  - After the local write, setup completion is reported back to the Audit
    service (attribution, G7). A failed report degrades to a warning and
    is **retried automatically on the next `mneme setup` run** (server
    completion is idempotent via `already_redeemed`).
  - Rerun without a reference preserves the previously connected baseline
    and performs no network calls.
- Setup summary now renders the connected baseline (project, repository,
  audit id, commit, Mneme/schema versions, completion status).
- `run_setup(pairing=None)` retains verbatim-reference recording for
  offline/embedded use (unit-tested; not exposed as a CLI flag).
- Execution log updated (`docs/plans/m1-3-execution-log.md`).

### Key invariants honored

- No enforcement implications: pairing records provenance and state only;
  readiness remains a pure view (G4).
- Invalid/expired/mismatched references fail safely and never half-link a
  project (G3).
- Idempotency preserved: no-op rerun still writes nothing; rerun with a
  pending completion performs the minimal retry write.

## Validation

- New/updated tests in `tests/test_cli_setup.py` (pairing section, 10
  tests): resolution + baseline recording, invalid reference fail-closed
  (fresh + existing project), incomplete payload fail-closed, completion
  failure warning + retry-on-rerun, origin-remote passing (real git repo),
  offline verbatim mode, no-network-on-plain-rerun. All network I/O is
  faked in tests (autouse fixture); no test touches the network.
- Full repository suite: `python -m pytest -q` → **1189 passed, 6
  skipped** (M1.3a branch: 1181 — +8 net new).
- Note: `tests/test_cli_setup.py` shows a whole-file diff due to line-ending
  normalization from the edit tooling; content verified, no CRLF added.

### Acceptance gates (M1.3b CLI-side applicable)

| Gate | Status | Evidence |
|---|---|---|
| G3 Audit linking | PASS | provenance recorded + invalid/expired/mismatched fail closed (tests above; server-side counterpart in mnemehq-site#104) |
| G7 Funnel attribution | PASS | completion reported with reference + origin remote + Mneme version; retry logic; site records setup_audit_id/setup_completed_at |
| G1/G2/G4/G5/G8 | PASS (unchanged) | M1.3a tests green; full suite + suite growth accounted for; no enforcement/retrieval code touched |

## Known limitations

- With `--audit-ref`, an unreachable Audit service blocks setup (fail
  closed). Users offline should run `mneme setup` without a reference and
  re-link later by rerunning with the reference.
- The CLI passes the origin remote URL verbatim; server normalizes
  owner/repo for the mismatch check.

Out-of-scope capabilities were not introduced: no enforcement activation,
no ADR/guardrail generation, no billing/orgs/RBAC/auth, no fleet
management, no new dashboard/onboarding application.

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: manual
- Human owner: @TheoV823
