### PR TITLE
feat: per-decision protection activation with canonical verification (M1.4)

### DIFF
--- a/docs/plans/m1-4-protection-activation.md
+++ b/docs/plans/m1-4-protection-activation.md
@@ -1,0 +1,136 @@
+# M1.4 — Protection Activation (P0)
+
+## Status
+
+Implemented.
+
+## Mission
+
+Close the first complete Mneme product loop:
+
+```text
+Audit → Setup → candidate → validate → activate → canonical verify → Protected
+```
+
+M1.4 turns an already-classified Mneme-ready architectural decision into a real,
+verifiable deterministic protection. It is an activation layer over the frozen
+P1.2 Architecture Protection Audit semantics — not a new classifier, not a new
+rule language, and not an enforcement engine.
+
+## Frozen semantics consumed (not reinterpreted)
+
+- `mneme.enforcer.assess_protection` / `generate_protection_report` remain the
+  single source of truth for Protected / Mneme-ready / Requires modelling /
+  Guidance tiers.
+- `mneme.readiness` remains a thin view over the canonical assessment; Audit
+  and Setup classification parity is unchanged.
+- The typed rule vocabulary stays `FORBID_LITERAL` (ADR-019) with ADR-020 path
+  applicability; activation proposes no new rule type, no path selectors.
+- Guidance decisions stay outside the protection denominator; superseded /
+  deprecated decisions never count.
+- Conservative multi-term ambiguity handling is untouched.
+
+Core invariant:
+
+> A decision does NOT become Protected because Mneme generated a rule,
+> validated a rule, or recorded an activation. It becomes Protected only when
+> the canonical protection assessment can observe real mechanical enforcement
+> evidence in the repository.
+
+## Lifecycle (derived, not stored)
+
+```text
+candidate → validated → activated → verified
+```
+
+No persistent per-decision lifecycle state is created. Final truth is always
+re-derived from repository evidence:
+
+- the installed typed rule in the decision's memory record is the enforcement
+  artifact (enforced by the existing `mneme check` / hook path);
+- the canonical assessment independently observes it and classifies Protected;
+- activation metadata (the `activation` record) stays separate from protection
+  truth and only carries the M1.3 `setup → active` state transition that
+  M1.3 reserved for exactly this explicit user action.
+
+## CLI surface
+
+```bash
+mneme protect list                 # Mneme-ready activation candidates
+mneme protect status <id>          # canonical status of one decision
+mneme protect validate <decision-id>   # deterministic dry validation
+mneme protect activate <decision-id>   # explicit activation + canonical verify
+```
+
+All subcommands take `--memory <project_memory.json>` (required) and optional
+`--repo-root <dir>` for the same external CI-evidence scan `mneme audit`
+performs. Exit codes: `0` success / desired state; `1` actionable failure
+(not eligible, validation failed, verification failed); `2` usage error
+(missing file, unknown decision id, refused unsafe record).
+
+## Activation mechanics
+
+`activate` performs, in order:
+
+1. canonical eligibility precheck (frozen P1.2 semantics only);
+2. deterministic validation of the proposed rule against the existing
+   enforcement engine (`check_prompt`); failure writes nothing;
+3. idempotent install: the typed rule is appended to the decision's
+   `rules[]` record in `project_memory.json` via raw read-modify-write
+   (atomic, everything else preserved verbatim); an identical existing rule
+   is left alone; a `setup`-state activation record transitions to `active`;
+   unsupported/invalid records are refused before any write;
+4. verification: reload from disk and re-run the canonical assessment.
+   Only an independently observed Protected tier is reported as verified.
+
+Result distinctions (never faked):
+
+- `verified` — artifact installed (now or earlier) and canonical assessment
+  observes Protected;
+- `already_protected` — canonical assessment already observed Protected;
+  nothing written;
+- `verification_failed` — artifact written but canonical assessment did not
+  observe Protected: the decision remains NOT Protected (exit 1);
+- `validation_failed` — validation rejected the proposal; nothing written;
+- `not_eligible` — Requires-modelling, Guidance, superseded/inactive, or
+  already-Protected decisions are not activation candidates.
+
+## Acceptance gates
+
+| Gate | Status |
+| --- | --- |
+| G1 — Canonical readiness | PASS: eligibility via `activation_precheck` over `assess_protection` only (`tests/test_protection_activation.py`) |
+| G2 — No implicit enforcement | PASS: audit/setup/discovery/validation file-equality tests |
+| G3 — Deterministic validation | PASS: four engine-backed checks, no model judgment |
+| G4 — Explicit activation | PASS: only `protect activate` writes; idempotency + refusal tests |
+| G5 — Correct applicability | PASS: enforcement/exemption tests incl. canonical policy source |
+| G6 — Evidence before score | PASS: no-evidence activation leaves Current Protection unchanged |
+| G7 — Re-audit parity | PASS: fresh audit + setup observe the same Protected classification |
+| G8 — Regression safety | PASS: full suite green (1237 passed, 6 skipped) |
+
+## Verification
+
+```bash
+python -m pytest tests/test_protection_activation.py   # new M1.4 tests
+python -m pytest tests                                 # full suite
+```
+
+## Out of scope (unchanged from the milestone contract)
+
+LLM-generated rules, Requires-modelling conversion, automatic ADR generation,
+protection during install/setup, bulk activation, approvals, RBAC,
+organizations, billing, hosted source access, cloud execution, drift
+monitoring, migration functionality, conflict resolution, remediation of
+existing violations, rule-authoring UI, site UX.
+
+## Known limitations (deliberate)
+
+- Legacy-migrated decisions (derived from `items[]`, not `decisions[]`) are
+  not activatable — there is no raw record to attach a rule to; activation
+  fails closed with a clear error.
+- Only the canonical proposal shape (a global `FORBID_LITERAL` token) is
+  activation-ready; scoped rules return `unsupported` from validation.
+- Activation flips the project `activation` record `setup → active` only when
+  that record exists; projects without one gain no invented record.
+- No `--json` output for `protect` (P0 is the human workflow; `mneme audit
+  --json` remains the machine surface).

--- a/docs/plans/m1-4-protection-activation.md
+++ b/docs/plans/m1-4-protection-activation.md
@@ -50,8 +50,12 @@ re-derived from repository evidence:
   artifact (enforced by the existing `mneme check` / hook path);
 - the canonical assessment independently observes it and classifies Protected;
 - activation metadata (the `activation` record) stays separate from protection
-  truth and only carries the M1.3 `setup → active` state transition that
-  M1.3 reserved for exactly this explicit user action.
+  truth and only carries the M1.3 activation-state completion for this
+  explicit user action: a `setup` record transitions to `active`, and a
+  pre-M1.3 memory file without a record — which
+  `derive_activation_state` already interprets as `setup` — gains one valid
+  `active` record, so verified protection never coexists with a `setup`
+  project state.
 
 ## CLI surface
 
@@ -78,7 +82,9 @@ performs. Exit codes: `0` success / desired state; `1` actionable failure
 3. idempotent install: the typed rule is appended to the decision's
    `rules[]` record in `project_memory.json` via raw read-modify-write
    (atomic, everything else preserved verbatim); an identical existing rule
-   is left alone; a `setup`-state activation record transitions to `active`;
+   is left alone; a `setup`-state activation record transitions to `active`,
+   and a pre-M1.3 file without a record gains one valid `active` record with
+   `activated_at` set (via the existing M1.3 schema and transition table);
    unsupported/invalid records are refused before any write;
 4. verification: reload from disk and re-run the canonical assessment.
    Only an independently observed Protected tier is reported as verified.
@@ -130,7 +136,9 @@ existing violations, rule-authoring UI, site UX.
   fails closed with a clear error.
 - Only the canonical proposal shape (a global `FORBID_LITERAL` token) is
   activation-ready; scoped rules return `unsupported` from validation.
-- Activation flips the project `activation` record `setup → active` only when
-  that record exists; projects without one gain no invented record.
+- A rule present in memory without any Mneme activation (e.g. hand-authored
+  as a `[memory]` change) makes the decision `already_protected`; activation
+  confirms but writes nothing, so such a project's record is not rewritten —
+  the state model is only completed by activations that install evidence.
 - No `--json` output for `protect` (P0 is the human workflow; `mneme audit
   --json` remains the machine surface).

--- a/docs/protect-activation.md
+++ b/docs/protect-activation.md
@@ -1,0 +1,131 @@
+# Protection Activation
+
+Mneme can turn a classified Mneme-ready architectural decision into a real,
+mechanically enforced guardrail. This page describes the activation workflow
+and the exact guarantees behind it.
+
+## Mneme-ready is not Protected
+
+`mneme audit` classifies every active decision:
+
+| Tier | Meaning |
+| --- | --- |
+| Protected | Deterministic intent **with** verified enforcement evidence |
+| Mneme-ready | Deterministic intent with a concrete safe guardrail identified — an opportunity |
+| Requires modelling | Deterministic intent that needs modelling before it can be a guardrail |
+| Guidance | Not appropriate for deterministic enforcement |
+
+Mneme-ready means "Mneme knows exactly which deterministic rule would protect
+this, and none exists yet". It does not mean the decision is protected.
+
+## The workflow
+
+```bash
+mneme protect list --memory .mneme/project_memory.json
+```
+
+Lists decisions that are active, currently unprotected, and canonically
+Mneme-ready. Already-Protected, Requires-modelling, Guidance, and
+superseded decisions are never candidates, and no model decides eligibility —
+the audit's frozen classification decides it.
+
+```bash
+mneme protect validate <decision-id> --memory .mneme/project_memory.json
+```
+
+Runs four deterministic checks through the existing enforcement engine —
+without writing anything and without enabling protection:
+
+1. a prohibited input containing the forbidden token is detected as a FAIL;
+2. a permitted input is not blocked by the proposed rule;
+3. applicability is respected: ordinary artifact paths are enforced and the
+   canonical policy sources (the memory file carrying the rule) stay exempt;
+4. unrelated paths are unaffected.
+
+**Validation is not activation.** A VALID result changes nothing in the
+repository and moves no audit metric.
+
+```bash
+mneme protect activate <decision-id> --memory .mneme/project_memory.json
+```
+
+**Activation is an explicit user action.** Audit, setup, rule generation and
+validation never enable protection; only this command installs enforcement.
+It appends the typed `FORBID_LITERAL` rule to that one decision's record in
+project memory — the same artifact `mneme check` and the agent hooks enforce —
+and refuses on any unsafe or unsupported state. Activation is idempotent:
+rerunning does not create duplicate rules.
+
+```bash
+mneme protect status <decision-id> --memory .mneme/project_memory.json
+```
+
+Shows the decision's canonical tier, guardrail, evidence, and whether the
+activation rule is installed — all derived from the repository, never stored.
+
+## Activation is not verified protection
+
+After activation Mneme does not simply mark the decision Protected. It
+re-loads project memory from disk and re-runs the same canonical assessment
+`mneme audit` uses. Only when that independent assessment observes real
+enforcement evidence is the activation reported as verified:
+
+```text
+Protection activated and verified: [config-format] (rule installed)
+  rule: FORBID_LITERAL "yaml"
+  verification: canonical assessment reports protected
+```
+
+If activation is requested but no enforcement evidence is observable, the
+decision remains NOT Protected, Current Protection does not increase, and the
+command says so. The audit score is always a consequence of canonical
+classification — never edited directly.
+
+## Walkthrough
+
+```bash
+# What can be activated?
+$ mneme protect list --memory .mneme/project_memory.json
+Protection activation candidates
+============================================================
+Protected: 1  Mneme-ready: 2  Requires modelling: 1  Guidance: 1
+Candidates: 1
+
+[1] config-format: Use JSON for configuration files
+    guardrail: FORBID_LITERAL: yaml
+    rule to install: FORBID_LITERAL "yaml"
+    applies to: global applicability (canonical policy sources exempt)
+    enforcement: FORBID_LITERAL fails on an exact case-sensitive match, ...
+
+# Prove the rule behaves correctly before touching anything
+$ mneme protect validate config-format --memory .mneme/project_memory.json
+Validating proposed protection for [config-format]
+  proposal:  FORBID_LITERAL "yaml"
+  checks:
+    PASS prohibited_detected: input containing 'yaml' is a typed FAIL
+    PASS permitted_allowed: permitted input without 'yaml' is not blocked
+    PASS path_scope_respected: artifact path enforced=True, canonical policy source exempt=True
+    PASS unrelated_paths_unaffected: unrelated artifact path enforced=True, permitted content blocked=False
+Result: VALID
+Validation never activates protection.
+
+# Activate (explicit) — verified by a fresh canonical assessment
+$ mneme protect activate config-format --memory .mneme/project_memory.json
+Protection activated and verified: [config-format] (rule installed)
+  rule: FORBID_LITERAL "yaml"
+  verification: canonical assessment reports protected
+Re-run `mneme audit` to observe the new Protected decision.
+
+# The audit now independently observes the protection
+$ mneme audit --memory .mneme/project_memory.json --repo-root .
+```
+
+## Boundaries
+
+- One decision per activation; there is no "protect everything".
+- Activation never overwrites user-authored rules or unrelated configuration.
+- No network, cloud, or model involvement anywhere in the path.
+- Requires-modelling and Guidance decisions are not activatable; converting
+  them is a separate modelling task.
+- Legacy-migrated decisions (from `items[]` rather than `decisions[]`) cannot
+  be activated; the command fails closed.

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -10,6 +10,10 @@ Subcommands
   list_decisions    Print every Decision in the memory file.
   test_query        Run a query through the retriever and show scores + injected.
   cursor generate   Generate a Cursor .mdc rules file from retrieved decisions.
+  audit             Run the P1.2 Architecture Protection Audit.
+  protect           M1.4 per-decision protection activation:
+                    list | status | validate | activate.
+                    See docs/protect-activation.md.
 
 Usage::
 
@@ -61,6 +65,17 @@ from mneme.enforcer import (
     generate_protection_report,
 )
 from mneme.memory_store import MemoryStore
+from mneme.protection import (
+    ENFORCEMENT_BEHAVIOR,
+    ProtectionError,
+    activate_protection,
+    activation_precheck,
+    find_candidates,
+    find_decision,
+    load_decisions,
+    protection_status,
+    validate_proposal,
+)
 from mneme.readiness import READINESS_LABELS, READINESS_ORDER
 from mneme.setup import SetupError, SetupOutcome, run_setup
 from mneme.setup_state import STATE_ACTIVE, scaffold_project_memory
@@ -551,6 +566,202 @@ def _cmd_audit(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── Subcommand: protect (M1.4 per-decision protection activation) ────────────
+
+def _require_memory(
+    memory: str,
+) -> tuple[Path, list] | None:
+    """Load and validate project memory for a protect subcommand.
+
+    Returns ``(memory_path, decisions)`` or ``None`` after printing the
+    usage-style error, so callers can ``return _error_exit(...)``-style
+    exit 2 immediately.
+    """
+    memory_path = Path(memory)
+    if not memory_path.exists():
+        _error_exit(f"memory file {memory_path} does not exist")
+        return None
+    try:
+        decisions = load_decisions(memory_path)
+    except ProtectionError as exc:
+        _error_exit(str(exc))
+        return None
+    return memory_path, decisions
+
+
+def _cmd_protect_list(args: argparse.Namespace) -> int:
+    memory_path, decisions = _require_memory(args.memory)
+    if memory_path is None:
+        return 2
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    if repo_root is not None and not repo_root.exists():
+        return _error_exit(f"repo root {repo_root} does not exist")
+    discovered = find_candidates(decisions, repo_root=repo_root)
+    report = discovered.report
+
+    print("Protection activation candidates")
+    print("=" * 60)
+    print(
+        f"Protected: {report.protected}  Mneme-ready: {report.mneme_ready}  "
+        f"Requires modelling: {report.requires_modelling}  "
+        f"Guidance: {report.guidance}"
+    )
+    print(f"Candidates: {len(discovered.candidates)}")
+    print()
+    if not discovered.candidates:
+        print("(no activation candidates)")
+        return 0
+    for i, candidate in enumerate(discovered.candidates, start=1):
+        print(f"[{i}] {candidate.decision_id}: {candidate.decision_text}")
+        if candidate.source_path:
+            print(f"    source: {candidate.source_path}")
+        print(f"    guardrail: {candidate.guardrail}")
+        print(
+            f"    rule to install: {candidate.proposal.type} "
+            f"\"{candidate.proposal.value}\""
+        )
+        scope = (
+            "global applicability (canonical policy sources exempt)"
+            if candidate.proposal.include_paths is None
+            else ", ".join(candidate.proposal.include_paths)
+        )
+        print(f"    applies to: {scope}")
+        print(f"    enforcement: {ENFORCEMENT_BEHAVIOR}")
+    print()
+    print(
+        "Validate before activating:  mneme protect validate <decision-id>"
+    )
+    print(
+        "Activate (explicit):         mneme protect activate <decision-id>"
+    )
+    return 0
+
+
+def _cmd_protect_status(args: argparse.Namespace) -> int:
+    memory_path, _decisions = _require_memory(args.memory)
+    if memory_path is None:
+        return 2
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    if repo_root is not None and not repo_root.exists():
+        return _error_exit(f"repo root {repo_root} does not exist")
+    try:
+        status = protection_status(
+            args.decision_id, memory_path, repo_root=repo_root
+        )
+    except ProtectionError as exc:
+        return _error_exit(str(exc))
+
+    print(f"Decision [{status.decision_id}] {status.decision_text}")
+    print(f"  lifecycle status: {status.lifecycle_status}")
+    print(f"  protection tier:  {status.tier}")
+    if status.guardrail:
+        print(f"  guardrail:        {status.guardrail}")
+    print(f"  evidence:         {status.evidence_confidence}")
+    for src in status.evidence_sources:
+        print(f"      {src}")
+    print(f"  rule installed:   {'yes' if status.rule_installed else 'no'}")
+    if status.proposal is not None:
+        print(
+            f"  proposal:         {status.proposal.type} "
+            f"\"{status.proposal.value}\""
+        )
+    return 0
+
+
+def _cmd_protect_validate(args: argparse.Namespace) -> int:
+    memory_path, decisions = _require_memory(args.memory)
+    if memory_path is None:
+        return 2
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    if repo_root is not None and not repo_root.exists():
+        return _error_exit(f"repo root {repo_root} does not exist")
+    decision = find_decision(decisions, args.decision_id)
+    if decision is None:
+        return _error_exit(f"decision {args.decision_id!r} not found")
+
+    precheck = activation_precheck(decision, repo_root=repo_root)
+    if not precheck.eligible:
+        print(f"NOT ELIGIBLE: [{decision.id}] {precheck.reason}")
+        print(
+            "Protection was not validated and nothing was activated."
+        )
+        return 1
+
+    result = validate_proposal(decision, precheck.proposal)
+    print(f"Validating proposed protection for [{decision.id}]")
+    print(f"  decision:  {decision.decision}")
+    print(f"  proposal:  {result.proposal.type} \"{result.proposal.value}\"")
+    print("  checks:")
+    for check in result.checks:
+        mark = "PASS" if check.passed else "FAIL"
+        print(f"    {mark} {check.name}: {check.detail}")
+    if result.status == "valid":
+        print("Result: VALID")
+        print("Validation never activates protection.")
+        return 0
+    print(f"Result: {result.status.upper()}")
+    return 1
+
+
+def _cmd_protect_activate(args: argparse.Namespace) -> int:
+    memory_path, _decisions = _require_memory(args.memory)
+    if memory_path is None:
+        return 2
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    if repo_root is not None and not repo_root.exists():
+        return _error_exit(f"repo root {repo_root} does not exist")
+    try:
+        outcome = activate_protection(
+            args.decision_id, memory_path, repo_root=repo_root
+        )
+    except ProtectionError as exc:
+        return _error_exit(str(exc))
+
+    if outcome.result == "verified":
+        state = (
+            "installed"
+            if outcome.rule_installed
+            else "already present"
+        )
+        print(
+            f"Protection activated and verified: [{outcome.decision_id}] "
+            f"(rule {state})"
+        )
+        if outcome.proposal is not None:
+            print(
+                f"  rule: {outcome.proposal.type} \"{outcome.proposal.value}\""
+            )
+        print(f"  verification: {outcome.detail}")
+        print("Re-run `mneme audit` to observe the new Protected decision.")
+        return 0
+    if outcome.result == "already_protected":
+        print(f"Already Protected: [{outcome.decision_id}]")
+        print(f"  {outcome.detail}")
+        print("  Nothing to activate.")
+        return 0
+    if outcome.result == "not_eligible":
+        print(f"NOT ELIGIBLE: [{outcome.decision_id}] {outcome.detail}")
+        return 1
+    if outcome.result == "validation_failed":
+        print(
+            f"VALIDATION FAILED: [{outcome.decision_id}] {outcome.detail}"
+        )
+        if outcome.validation is not None:
+            for check in outcome.validation.checks:
+                if not check.passed:
+                    print(f"    FAIL {check.name}: {check.detail}")
+        print("Nothing was written.")
+        return 1
+    # verification_failed
+    print(
+        f"ERROR: activation artifact written for [{outcome.decision_id}], "
+        "but canonical verification did not observe Protected — "
+        "the decision remains NOT Protected."
+    )
+    print(f"  verification: {outcome.detail}")
+    return 1
+
+
 # ── Subcommand: cursor generate ──────────────────────────────────────────────
 
 def _cmd_cursor_generate(args: argparse.Namespace) -> int:
@@ -847,6 +1058,67 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Write the mneme.audit/v1 JSON report to FILE",
     )
     p_audit.set_defaults(func=_cmd_audit)
+
+    # protect (M1.4 per-decision protection activation)
+    p_protect = sub.add_parser(
+        "protect",
+        help=(
+            "Per-decision protection activation: list Mneme-ready candidates, "
+            "deterministically validate a proposed protection, explicitly "
+            "activate it, and inspect its canonical status"
+        ),
+    )
+    protect_sub = p_protect.add_subparsers(dest="protect_cmd", required=True)
+
+    _REPO_ROOT_HELP = (
+        "Repository root to scan for external enforcement evidence, exactly "
+        "like `mneme audit --repo-root`; omitted means no CI-evidence scan"
+    )
+
+    p_protect_list = protect_sub.add_parser(
+        "list",
+        help="List Mneme-ready protection activation candidates",
+    )
+    p_protect_list.add_argument("--memory", required=True, help="Path to project_memory.json")
+    p_protect_list.add_argument("--repo-root", dest="repo_root", default=None,
+                                help=_REPO_ROOT_HELP)
+    p_protect_list.set_defaults(func=_cmd_protect_list)
+
+    p_protect_status = protect_sub.add_parser(
+        "status",
+        help="Show the canonical protection status of one decision",
+    )
+    p_protect_status.add_argument("decision_id", help="Decision id, e.g. mneme_001")
+    p_protect_status.add_argument("--memory", required=True, help="Path to project_memory.json")
+    p_protect_status.add_argument("--repo-root", dest="repo_root", default=None,
+                                  help=_REPO_ROOT_HELP)
+    p_protect_status.set_defaults(func=_cmd_protect_status)
+
+    p_protect_validate = protect_sub.add_parser(
+        "validate",
+        help=(
+            "Deterministically validate a decision's proposed protection "
+            "against the existing enforcement engine; never activates anything"
+        ),
+    )
+    p_protect_validate.add_argument("decision_id", help="Decision id, e.g. mneme_001")
+    p_protect_validate.add_argument("--memory", required=True, help="Path to project_memory.json")
+    p_protect_validate.add_argument("--repo-root", dest="repo_root", default=None,
+                                    help=_REPO_ROOT_HELP)
+    p_protect_validate.set_defaults(func=_cmd_protect_validate)
+
+    p_protect_activate = protect_sub.add_parser(
+        "activate",
+        help=(
+            "Explicitly install the proposed typed rule for one decision, "
+            "then verify via the canonical protection assessment"
+        ),
+    )
+    p_protect_activate.add_argument("decision_id", help="Decision id, e.g. mneme_001")
+    p_protect_activate.add_argument("--memory", required=True, help="Path to project_memory.json")
+    p_protect_activate.add_argument("--repo-root", dest="repo_root", default=None,
+                                    help=_REPO_ROOT_HELP)
+    p_protect_activate.set_defaults(func=_cmd_protect_activate)
 
     # cursor (parent for cursor subcommands)
     p_cursor = sub.add_parser("cursor", help="Cursor.ai integration commands")

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -574,8 +574,13 @@ def _require_memory(
     """Load and validate project memory for a protect subcommand.
 
     Returns ``(memory_path, decisions)`` or ``None`` after printing the
-    usage-style error, so callers can ``return _error_exit(...)``-style
-    exit 2 immediately.
+    usage-style error. Callers MUST test the tuple for ``None`` before
+    unpacking it::
+
+        loaded = _require_memory(args.memory)
+        if loaded is None:
+            return 2
+        memory_path, decisions = loaded
     """
     memory_path = Path(memory)
     if not memory_path.exists():
@@ -590,9 +595,10 @@ def _require_memory(
 
 
 def _cmd_protect_list(args: argparse.Namespace) -> int:
-    memory_path, decisions = _require_memory(args.memory)
-    if memory_path is None:
+    loaded = _require_memory(args.memory)
+    if loaded is None:
         return 2
+    memory_path, decisions = loaded
     repo_root = Path(args.repo_root) if args.repo_root else None
     if repo_root is not None and not repo_root.exists():
         return _error_exit(f"repo root {repo_root} does not exist")
@@ -638,9 +644,10 @@ def _cmd_protect_list(args: argparse.Namespace) -> int:
 
 
 def _cmd_protect_status(args: argparse.Namespace) -> int:
-    memory_path, _decisions = _require_memory(args.memory)
-    if memory_path is None:
+    loaded = _require_memory(args.memory)
+    if loaded is None:
         return 2
+    memory_path, _decisions = loaded
     repo_root = Path(args.repo_root) if args.repo_root else None
     if repo_root is not None and not repo_root.exists():
         return _error_exit(f"repo root {repo_root} does not exist")
@@ -669,9 +676,10 @@ def _cmd_protect_status(args: argparse.Namespace) -> int:
 
 
 def _cmd_protect_validate(args: argparse.Namespace) -> int:
-    memory_path, decisions = _require_memory(args.memory)
-    if memory_path is None:
+    loaded = _require_memory(args.memory)
+    if loaded is None:
         return 2
+    memory_path, decisions = loaded
     repo_root = Path(args.repo_root) if args.repo_root else None
     if repo_root is not None and not repo_root.exists():
         return _error_exit(f"repo root {repo_root} does not exist")
@@ -704,9 +712,10 @@ def _cmd_protect_validate(args: argparse.Namespace) -> int:
 
 
 def _cmd_protect_activate(args: argparse.Namespace) -> int:
-    memory_path, _decisions = _require_memory(args.memory)
-    if memory_path is None:
+    loaded = _require_memory(args.memory)
+    if loaded is None:
         return 2
+    memory_path, _decisions = loaded
     repo_root = Path(args.repo_root) if args.repo_root else None
     if repo_root is not None and not repo_root.exists():
         return _error_exit(f"repo root {repo_root} does not exist")

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -641,6 +641,39 @@ def _scan_ci_evidence(
     return "none", []
 
 
+def _proposed_literal_tokens(decision: "Decision") -> list[str]:
+    """Literalizable tokens a Mneme guardrail could carry, canonical order.
+
+    Exactly the derivation ``assess_protection`` uses to classify a decision
+    ``mneme_ready``: the terms of each single-term anti-pattern, then the
+    forbidden terms of single-term "no X" constraints. Kept beside the
+    assessment so the proposal below and the classification above are the
+    same computation, not two interpretations of it.
+    """
+    single_aps = [ap for ap in decision.anti_patterns if _is_literal_rule(ap)]
+    single_nos, _ = _split_no_constraints(decision.constraints)
+    return [t for ap in single_aps for t in _rule_terms(ap)] + single_nos
+
+
+def propose_literal_rule(decision: "Decision") -> "Rule | None":
+    """The canonical deterministic protection proposal for one Decision.
+
+    Returns the typed rule whose activation the P1.2 audit proposes for a
+    Mneme-ready decision — ``FORBID_LITERAL`` carrying the first literalizable
+    token, with global applicability (ADR-019/ADR-020 semantics) — and ``None``
+    for every other tier. This is the same primitive the audit consults, not a
+    second classifier: eligibility always comes from
+    :func:`assess_protection`, and this function only materializes the
+    guardrail string that assessment already reports.
+    """
+    from mneme.schemas import Rule
+
+    tokens = _proposed_literal_tokens(decision)
+    if not tokens:
+        return None
+    return Rule(type="FORBID_LITERAL", value=tokens[0])
+
+
 def assess_protection(
     decision: "Decision",
     repo_root: str | Path | None = None,
@@ -690,7 +723,7 @@ def assess_protection(
             evidence_sources=[],
         )
 
-    tokens = [t for ap in single_aps for t in _rule_terms(ap)] + single_nos
+    tokens = _proposed_literal_tokens(decision)
     tier: ProtectionTier = "mneme_ready" if tokens else "requires_modelling"
     proposed_guardrail = f"FORBID_LITERAL: {tokens[0]}" if tokens else None
 
@@ -780,4 +813,5 @@ __all__ = [
     "ArchitectureProtectionReport",
     "assess_protection",
     "generate_protection_report",
+    "propose_literal_rule",
 ]

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -656,15 +656,21 @@ def _proposed_literal_tokens(decision: "Decision") -> list[str]:
 
 
 def propose_literal_rule(decision: "Decision") -> "Rule | None":
-    """The canonical deterministic protection proposal for one Decision.
+    """Materialize a decision's canonical deterministic guardrail as a Rule.
 
-    Returns the typed rule whose activation the P1.2 audit proposes for a
-    Mneme-ready decision — ``FORBID_LITERAL`` carrying the first literalizable
-    token, with global applicability (ADR-019/ADR-020 semantics) — and ``None``
-    for every other tier. This is the same primitive the audit consults, not a
-    second classifier: eligibility always comes from
-    :func:`assess_protection`, and this function only materializes the
-    guardrail string that assessment already reports.
+    Returns ``FORBID_LITERAL`` carrying the first literalizable token, with
+    global applicability (ADR-019/ADR-020 semantics), when the decision's
+    legacy intent can be literalized exactly as ``assess_protection`` does
+    for a Mneme-ready decision; ``None`` when it cannot.
+
+    This is a rule-materialization helper, not an assessor: it performs no
+    tier classification and may return a rule for a decision whose canonical
+    tier is not ``mneme_ready`` (for example one already carrying verified
+    external evidence). Every caller MUST gate eligibility through
+    :func:`assess_protection` — the single source of protection truth — and
+    consult this function only for the concrete rule shape. Kept beside the
+    assessment so the proposal and the classification are the same
+    computation, not two interpretations of it.
     """
     from mneme.schemas import Rule
 

--- a/mneme/protection.py
+++ b/mneme/protection.py
@@ -1,0 +1,771 @@
+"""
+protection.py — Per-decision protection activation (M1.4 P0).
+
+Closes the first complete product loop:
+
+    Audit → Setup → candidate → validate → activate → canonical verify → Protected
+
+Everything here is a thin layer over the frozen P1.2 semantics in
+``mneme.enforcer``. ``assess_protection`` / ``generate_protection_report``
+remain the single source of truth for Protected / Mneme-ready / Requires
+modelling / Guidance; this module never reclassifies a decision and never
+reports protection that the canonical assessment does not independently
+observe.
+
+Lifecycle (derived, not stored):
+
+    candidate → validated → activated → verified
+
+There is no persistent per-decision lifecycle state. Truth is derived from
+repository evidence:
+
+- a decision is an activation candidate iff the canonical assessment classifies
+  it ``mneme_ready`` (active, protection-relevant, unprotected);
+- the proposed protection is the canonical deterministic typed rule
+  (``propose_literal_rule``) — no new rule language, no model involvement;
+- activation is an explicit user action that installs exactly that typed rule
+  into the decision record of ``project_memory.json``, which is the same
+  artifact the existing enforcement path (``mneme check``, hooks) enforces;
+- verification re-runs the canonical assessment against the repository from
+  disk. Activation is reported verified only when that independent
+  assessment observes Protected.
+
+Core invariant:
+
+    activation requested + no observable enforcement evidence
+    = decision remains NOT Protected
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal
+
+from mneme.decision_retriever import ScoredDecision
+from mneme.enforcer import (
+    ArchitectureProtectionReport,
+    ProtectionDecisionReport,
+    ProtectionTier,
+    assess_protection,
+    check_prompt,
+    generate_protection_report,
+    propose_literal_rule,
+)
+from mneme.memory_store import MemoryStore
+from mneme.path_selectors import SelectorOutcome, policy_root
+from mneme.rule_matcher import literal_in_text
+from mneme.schemas import Decision, Rule
+from mneme.setup_state import (
+    ACTIVATION_SCHEMA,
+    STATE_ACTIVE,
+    STATE_SETUP,
+    ActivationRecord,
+    ActivationStateError,
+    atomic_write_json,
+    utc_now,
+)
+
+ACTIVATION_RESULT = Literal[
+    "verified",
+    "already_protected",
+    "verification_failed",
+    "validation_failed",
+    "not_eligible",
+]
+
+VALIDATION_STATUS = Literal["valid", "invalid", "unsupported"]
+
+# Frozen enforcement behavior of the activation-ready rule type, for display.
+ENFORCEMENT_BEHAVIOR = (
+    "FORBID_LITERAL fails on an exact case-sensitive match, enforced "
+    "independently of retrieval score; canonical policy sources are exempt "
+    "(ADR-019/ADR-020)"
+)
+
+# Conservative boundary: M1.4 activates only the guardrail shape the frozen
+# Mneme-ready classification proposes (a global FORBID_LITERAL token). The
+# canonical assessment never proposes a scoped rule today; anything else is
+# refused rather than guessed at.
+_ACTIVATION_RULE_TYPE = "FORBID_LITERAL"
+
+
+class ProtectionError(Exception):
+    """A pre-execution protection failure. No filesystem mutation occurred."""
+
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+
+def load_decisions(memory_path: str | Path) -> list[Decision]:
+    """Load and validate project memory, failing safely before any write."""
+    store = MemoryStore(memory_path)
+    try:
+        store.load()
+    except Exception as exc:
+        raise ProtectionError(
+            f"memory file {memory_path} failed validation: {exc}"
+        ) from exc
+    return store.decisions()
+
+
+def find_decision(decisions: list[Decision], decision_id: str) -> Decision | None:
+    """Return the first decision with the given id, or ``None``."""
+    return next((d for d in decisions if d.id == decision_id), None)
+
+
+# ── Candidate discovery (A) ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProtectionCandidate:
+    """One canonically Mneme-ready, currently unprotected decision."""
+
+    decision_id: str
+    decision_text: str
+    source_path: str
+    guardrail: str  # canonical mneme_guardrail string from the assessment
+    proposal: Rule  # the deterministic typed rule activation would install
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    """Activation candidates plus the canonical aggregate they derive from."""
+
+    candidates: tuple[ProtectionCandidate, ...]
+    report: ArchitectureProtectionReport
+
+
+def find_candidates(
+    decisions: list[Decision],
+    repo_root: str | Path | None = None,
+) -> CandidateReport:
+    """Discover activation candidates via the frozen P1.2 assessment.
+
+    A candidate is an active decision the canonical assessment classifies
+    ``mneme_ready``: protection-relevant, currently unprotected, and carrying
+    a concrete safe guardrail. Already-Protected, Requires-modelling and
+    Guidance decisions are never candidates; superseded/inactive decisions
+    never enter the canonical counts. Eligibility is entirely canonical —
+    no model or heuristic decides it.
+    """
+    report = generate_protection_report(decisions, repo_root=repo_root)
+    by_id: dict[str, Decision] = {}
+    for decision in decisions:
+        by_id.setdefault(decision.id, decision)
+    candidates: list[ProtectionCandidate] = []
+    for item in report.decisions:
+        if item.status != "active" or item.protection_tier != "mneme_ready":
+            continue
+        decision = by_id.get(item.id)
+        if decision is None:
+            continue
+        proposal = propose_literal_rule(decision)
+        if proposal is None:
+            # Unreachable under frozen semantics (mneme_ready always carries
+            # an explicit guardrail), but never present a candidate without
+            # a deterministic proposal.
+            continue
+        candidates.append(ProtectionCandidate(
+            decision_id=decision.id,
+            decision_text=decision.decision,
+            source_path=decision.source_path,
+            guardrail=item.mneme_guardrail or f"{proposal.type}: {proposal.value}",
+            proposal=proposal,
+        ))
+    return CandidateReport(candidates=tuple(candidates), report=report)
+
+
+# ── Eligibility (frozen; shared by validate and activate) ────────────────────
+
+
+@dataclass(frozen=True)
+class Precheck:
+    """Canonical activation eligibility for one decision."""
+
+    decision_id: str
+    tier: ProtectionTier
+    proposal: Rule | None
+    eligible: bool
+    reason: str
+
+
+def activation_precheck(
+    decision: Decision,
+    repo_root: str | Path | None = None,
+) -> Precheck:
+    """Classify activation eligibility exclusively from frozen semantics."""
+    assessment = assess_protection(decision, repo_root=repo_root)
+    tier = assessment.protection_tier
+    if decision.status != "active":
+        return Precheck(
+            decision_id=decision.id,
+            tier=tier,
+            proposal=None,
+            eligible=False,
+            reason=(
+                f"decision status is {decision.status!r}; only active "
+                "decisions can be activated"
+            ),
+        )
+    if tier == "protected":
+        return Precheck(
+            decision_id=decision.id,
+            tier=tier,
+            proposal=None,
+            eligible=False,
+            reason="already Protected under the canonical assessment",
+        )
+    if tier != "mneme_ready":
+        return Precheck(
+            decision_id=decision.id,
+            tier=tier,
+            proposal=None,
+            eligible=False,
+            reason=f"canonical tier is {tier}; not Mneme-ready",
+        )
+    proposal = propose_literal_rule(decision)
+    if proposal is None:
+        return Precheck(
+            decision_id=decision.id,
+            tier=tier,
+            proposal=None,
+            eligible=False,
+            reason="canonical assessment carries no FORBID_LITERAL proposal",
+        )
+    return Precheck(
+        decision_id=decision.id,
+        tier=tier,
+        proposal=proposal,
+        eligible=True,
+        reason=f"FORBID_LITERAL: {proposal.value}",
+    )
+
+
+# ── Deterministic validation (C) ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ValidationCheck:
+    """One deterministic validation probe and its outcome."""
+
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Deterministic outcome of validating one proposed protection."""
+
+    decision_id: str
+    status: str  # "valid" | "invalid" | "unsupported"
+    checks: tuple[ValidationCheck, ...]
+    proposal: Rule
+
+
+# Fixed benign fixtures for the permitted case; the first one that does not
+# contain the forbidden token is used, keeping validation deterministic for
+# every token while never exercising the rule under test.
+_BENIGN_TEXTS: tuple[str, ...] = (
+    "Use an approved internal helper for this work.",
+    "Keep the module small and covered by tests.",
+    "Wire the logger through the shared facade.",
+)
+
+
+def _prohibited_text(token: str) -> str:
+    return f"Use {token} for this component."
+
+
+def _permitted_text(token: str) -> str | None:
+    for text in _BENIGN_TEXTS:
+        if not literal_in_text(token, text):
+            return text
+    return None
+
+
+def _proposed_violations(
+    result,
+    decision_id: str,
+    token: str,
+):
+    """Violations attributable specifically to the proposed rule."""
+    return [
+        v for v in result.violations
+        if v.decision_id == decision_id
+        and v.kind == "typed_rule"
+        and v.rule_type == _ACTIVATION_RULE_TYPE
+        and v.rule == token
+    ]
+
+
+def _proposed_traces(result, decision_id: str, index: int, token: str):
+    """Applicability traces for the proposed rule inside a check run."""
+    return [
+        item for item in result.applicability
+        if item.decision_id == decision_id
+        and item.rule_type == _ACTIVATION_RULE_TYPE
+        and item.rule_value == token
+        and item.rule_index == index
+    ]
+
+
+def validate_proposal(
+    decision: Decision,
+    proposal: Rule,
+    memory_path: str | Path | None = None,
+) -> ValidationResult:
+    """Validate a proposed protection mechanically, before activation.
+
+    Reuses the existing enforcement engine (``check_prompt``) on an
+    in-memory copy of the decision carrying the proposed rule; nothing is
+    written and no protection is enabled. Checks:
+
+    1. the expected prohibited case is detected as a typed FAIL;
+    2. an expected permitted case is not blocked by the proposed rule;
+    3. intended applicability is respected: an ordinary artifact path is
+       enforced and the canonical policy source (the memory file that would
+       carry the rule) stays exempt;
+    4. unrelated paths are unaffected: permitted content on a different
+       artifact path also passes.
+
+    Only the activation-ready shape (a global ``FORBID_LITERAL``, which is
+    what frozen Mneme-ready semantics propose) is validated; any other shape
+    returns ``unsupported`` rather than invented behavior. No model judges
+    anything and the outcome is deterministic.
+    """
+    if proposal.type != _ACTIVATION_RULE_TYPE or proposal.include_paths is not None:
+        return ValidationResult(
+            decision_id=decision.id,
+            status="unsupported",
+            checks=(),
+            proposal=proposal,
+        )
+    policy_memory = memory_path or decision.memory_path
+    if not policy_memory:
+        return ValidationResult(
+            decision_id=decision.id,
+            status="unsupported",
+            checks=(),
+            proposal=proposal,
+        )
+
+    token = proposal.value
+    prohibited = _prohibited_text(token)
+    permitted = _permitted_text(token)
+    index = len(decision.rules)
+    candidate = replace(decision, rules=[*decision.rules, proposal])
+    scored = [ScoredDecision(decision=candidate, score=1.0, matches={})]
+
+    checks: list[ValidationCheck] = []
+
+    # 1 — prohibited case detected.
+    result = check_prompt(prohibited, scored, input_path=None)
+    fired = bool(_proposed_violations(result, decision.id, token))
+    checks.append(ValidationCheck(
+        name="prohibited_detected",
+        passed=fired,
+        detail=(
+            f"input containing {token!r} is a typed FAIL"
+            if fired
+            else f"input containing {token!r} produced no typed violation"
+        ),
+    ))
+
+    # 2 — permitted case not blocked.
+    if permitted is None:
+        checks.append(ValidationCheck(
+            name="permitted_allowed",
+            passed=False,
+            detail="no permitted fixture free of the token could be built",
+        ))
+    else:
+        result = check_prompt(permitted, scored, input_path=None)
+        blocked = bool(_proposed_violations(result, decision.id, token))
+        checks.append(ValidationCheck(
+            name="permitted_allowed",
+            passed=not blocked,
+            detail=(
+                f"permitted input containing {token!r} would be blocked"
+                if blocked
+                else f"permitted input without {token!r} is not blocked"
+            ),
+        ))
+
+    # 3 — applicability scope respected (artifact enforced, policy source exempt).
+    root = policy_root(policy_memory)
+    artifact = (root / "src" / "component.py").resolve()
+    result = check_prompt(prohibited, scored, input_path=artifact)
+    applied = _proposed_traces(result, decision.id, index, token)
+    applied_ok = (
+        bool(applied)
+        and applied[0].outcome == SelectorOutcome.APPLIED
+        and bool(_proposed_violations(result, decision.id, token))
+    )
+    result = check_prompt(prohibited, scored, input_path=policy_memory)
+    exempt = _proposed_traces(result, decision.id, index, token)
+    exempt_ok = (
+        bool(exempt)
+        and exempt[0].outcome == SelectorOutcome.EXCLUDED
+        and not _proposed_violations(result, decision.id, token)
+    )
+    checks.append(ValidationCheck(
+        name="path_scope_respected",
+        passed=applied_ok and exempt_ok,
+        detail=(
+            f"artifact path enforced={applied_ok}, "
+            f"canonical policy source exempt={exempt_ok}"
+        ),
+    ))
+
+    # 4 — unrelated paths unaffected by the proposed rule.
+    if permitted is None:
+        checks.append(ValidationCheck(
+            name="unrelated_paths_unaffected",
+            passed=False,
+            detail="no permitted fixture free of the token could be built",
+        ))
+    else:
+        unrelated = (root / "docs" / "notes.md").resolve()
+        result = check_prompt(permitted, scored, input_path=unrelated)
+        blocked = bool(_proposed_violations(result, decision.id, token))
+        traces = _proposed_traces(result, decision.id, index, token)
+        applied = bool(traces) and traces[0].outcome == SelectorOutcome.APPLIED
+        checks.append(ValidationCheck(
+            name="unrelated_paths_unaffected",
+            passed=applied and not blocked,
+            detail=(
+                f"unrelated artifact path enforced={applied}, "
+                f"permitted content blocked={blocked}"
+            ),
+        ))
+
+    status = "valid" if all(c.passed for c in checks) else "invalid"
+    return ValidationResult(
+        decision_id=decision.id,
+        status=status,
+        checks=tuple(checks),
+        proposal=proposal,
+    )
+
+
+# ── Explicit activation (D) + canonical verification (3) ─────────────────────
+
+
+@dataclass(frozen=True)
+class ActivationOutcome:
+    """Result of one explicit activation request.
+
+    ``result`` distinguishes, without faking success:
+
+    - ``verified``            the artifact was installed (now or earlier) and
+                              the canonical assessment independently observes
+                              Protected from repository evidence;
+    - ``already_protected``   the canonical assessment already observed
+                              Protected before this call; nothing written;
+    - ``verification_failed`` an artifact was written but the canonical
+                              assessment did not observe Protected — the
+                              decision remains NOT Protected;
+    - ``validation_failed``   deterministic validation rejected the proposal;
+                              nothing was written;
+    - ``not_eligible``        the decision is not an activation candidate.
+    """
+
+    decision_id: str
+    result: str
+    tier: ProtectionTier | None
+    verification_tier: ProtectionTier | None
+    detail: str
+    rule_installed: bool
+    proposal: Rule | None
+    validation: ValidationResult | None
+
+
+def _rule_record_matches(record: object, proposal: Rule) -> bool:
+    """Whether a raw memory rule record already carries this exact rule."""
+    if not isinstance(record, dict):
+        return False
+    if record.get("type") != proposal.type or record.get("value") != proposal.value:
+        return False
+    if "include_paths" in record:
+        include = record["include_paths"]
+        if not isinstance(include, list):
+            return False
+        if tuple(include) != proposal.include_paths:
+            return False
+    elif proposal.include_paths is not None:
+        return False
+    exclude = record.get("exclude_paths", ())
+    if not isinstance(exclude, list):
+        return False
+    return tuple(exclude) == proposal.exclude_paths
+
+
+def _install_rule(
+    memory_path: Path,
+    decision_id: str,
+    proposal: Rule,
+) -> bool:
+    """Append the typed rule to one decision's record in the memory file.
+
+    Raw read-modify-write preserving every other key verbatim (meta, items,
+    examples, other decisions, and any future sections). Idempotent: an
+    identical existing rule is left alone and no duplicate is created. When
+    the project activation record exists in ``setup`` state, the explicit
+    activation also performs the frozen ``setup → active`` transition the
+    M1.3 contract reserved for exactly this user action.
+
+    Returns ``True`` when this call wrote the file, ``False`` when the rule
+    was already installed.
+
+    Raises :class:`ProtectionError` before any write on unsafe input.
+    """
+    with open(memory_path, encoding="utf-8") as f:
+        raw = json.load(f)
+    entries = raw.get("decisions")
+    if not isinstance(entries, list):
+        raise ProtectionError(
+            f"memory file {memory_path} has no decisions[] list"
+        )
+    index = next(
+        (i for i, entry in enumerate(entries)
+         if isinstance(entry, dict) and entry.get("id") == decision_id),
+        None,
+    )
+    if index is None:
+        raise ProtectionError(
+            f"decision {decision_id!r} not found in {memory_path}"
+        )
+    entry = entries[index]
+    existing = entry.get("rules", [])
+    if not isinstance(existing, list):
+        raise ProtectionError(
+            f"decision {decision_id!r} carries a malformed rules list"
+        )
+    if any(_rule_record_matches(record, proposal) for record in existing):
+        return False
+
+    record: dict[str, object] = {
+        "type": proposal.type,
+        "value": proposal.value,
+    }
+    if proposal.include_paths is not None:
+        record["include_paths"] = list(proposal.include_paths)
+    if proposal.exclude_paths:
+        record["exclude_paths"] = list(proposal.exclude_paths)
+    entry["rules"] = [*existing, record]
+
+    raw_activation = raw.get("activation")
+    if raw_activation is not None:
+        if (
+            not isinstance(raw_activation, dict)
+            or raw_activation.get("schema") not in (None, ACTIVATION_SCHEMA)
+        ):
+            raise ProtectionError(
+                f"activation record in {memory_path} uses unsupported "
+                f"schema {raw_activation.get('schema')!r}; refusing to "
+                "modify it"
+            )
+        try:
+            record_state = ActivationRecord.from_dict(raw_activation)
+        except ActivationStateError as exc:
+            raise ProtectionError(
+                f"existing activation record in {memory_path} is invalid: {exc}"
+            ) from exc
+        if record_state.state == STATE_SETUP:
+            record_state.require_transition(STATE_ACTIVE)
+            record_state.state = STATE_ACTIVE
+            record_state.activated_at = utc_now()
+            raw["activation"] = record_state.to_dict()
+
+    atomic_write_json(memory_path, raw)
+    return True
+
+
+def _verify(
+    memory_path: Path,
+    decision_id: str,
+    repo_root: str | Path | None,
+) -> tuple[ProtectionTier | None, str, ProtectionDecisionReport | None]:
+    """Re-derive protection truth from the repository via canonical assessment.
+
+    Reloads the memory file from disk and runs the frozen P1.2 assessment —
+    the same function ``mneme audit`` uses — over the reloaded decision. This
+    is the only accepted proof that activation produced real enforcement
+    evidence; the caller's claim never verifies anything by itself.
+    """
+    store = MemoryStore(memory_path)
+    try:
+        store.load()
+    except Exception as exc:
+        return None, f"verification could not reload memory: {exc}", None
+    decision = find_decision(store.decisions(), decision_id)
+    if decision is None:
+        return None, "decision disappeared from memory after activation", None
+    assessment = assess_protection(decision, repo_root=repo_root)
+    return (
+        assessment.protection_tier,
+        f"canonical assessment reports {assessment.protection_tier}",
+        assessment,
+    )
+
+
+def activate_protection(
+    decision_id: str,
+    memory_path: str | Path,
+    repo_root: str | Path | None = None,
+) -> ActivationOutcome:
+    """Explicitly activate deterministic protection for one decision.
+
+    Requires an explicit caller decision (the CLI ``protect activate``
+    command); nothing else may call this. Eligibility comes exclusively from
+    the frozen P1.2 assessment. The proposal is deterministically validated
+    first; a failed validation writes nothing. Activation installs the
+    canonical typed rule into the decision's memory record — the minimum
+    enforcement artifact the existing ``mneme check``/hook path enforces —
+    then verification re-runs the canonical assessment against the actual
+    repository. Only an independently observed Protected tier is reported
+    as verified.
+    """
+    memory_path = Path(memory_path)
+    decisions = load_decisions(memory_path)
+    decision = find_decision(decisions, decision_id)
+    if decision is None:
+        raise ProtectionError(
+            f"decision {decision_id!r} not found in {memory_path}"
+        )
+    precheck = activation_precheck(decision, repo_root=repo_root)
+    if not precheck.eligible:
+        if precheck.tier == "protected":
+            return ActivationOutcome(
+                decision_id=decision.id,
+                result="already_protected",
+                tier=precheck.tier,
+                verification_tier=precheck.tier,
+                detail=precheck.reason,
+                rule_installed=False,
+                proposal=None,
+                validation=None,
+            )
+        return ActivationOutcome(
+            decision_id=decision.id,
+            result="not_eligible",
+            tier=precheck.tier,
+            verification_tier=None,
+            detail=precheck.reason,
+            rule_installed=False,
+            proposal=None,
+            validation=None,
+        )
+
+    validation = validate_proposal(decision, precheck.proposal)
+    if validation.status != "valid":
+        failed = [c.name for c in validation.checks if not c.passed]
+        return ActivationOutcome(
+            decision_id=decision.id,
+            result="validation_failed",
+            tier=precheck.tier,
+            verification_tier=None,
+            detail=(
+                "deterministic validation failed: " + ", ".join(failed)
+            ),
+            rule_installed=False,
+            proposal=precheck.proposal,
+            validation=validation,
+        )
+
+    installed = _install_rule(memory_path, decision.id, precheck.proposal)
+    tier, detail, _assessment = _verify(memory_path, decision.id, repo_root)
+    if tier == "protected":
+        return ActivationOutcome(
+            decision_id=decision.id,
+            result="verified",
+            tier=precheck.tier,
+            verification_tier=tier,
+            detail=detail,
+            rule_installed=installed,
+            proposal=precheck.proposal,
+            validation=validation,
+        )
+    return ActivationOutcome(
+        decision_id=decision.id,
+        result="verification_failed",
+        tier=precheck.tier,
+        verification_tier=tier,
+        detail=detail,
+        rule_installed=installed,
+        proposal=precheck.proposal,
+        validation=validation,
+    )
+
+
+# ── Status (derived, not stored) ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProtectionStatus:
+    """Canonical protection status of one decision, freshly derived."""
+
+    decision_id: str
+    decision_text: str
+    lifecycle_status: str
+    tier: ProtectionTier
+    guardrail: str | None
+    evidence_confidence: str
+    evidence_sources: tuple[str, ...]
+    rule_installed: bool
+    proposal: Rule | None
+
+
+def protection_status(
+    decision_id: str,
+    memory_path: str | Path,
+    repo_root: str | Path | None = None,
+) -> ProtectionStatus:
+    """Report one decision's canonical protection state from repository evidence."""
+    decisions = load_decisions(memory_path)
+    decision = find_decision(decisions, decision_id)
+    if decision is None:
+        raise ProtectionError(
+            f"decision {decision_id!r} not found in {memory_path}"
+        )
+    assessment = assess_protection(decision, repo_root=repo_root)
+    return ProtectionStatus(
+        decision_id=decision.id,
+        decision_text=decision.decision,
+        lifecycle_status=decision.status,
+        tier=assessment.protection_tier,
+        guardrail=assessment.mneme_guardrail,
+        evidence_confidence=assessment.evidence_confidence,
+        evidence_sources=tuple(assessment.evidence_sources),
+        rule_installed=any(
+            rule.type == _ACTIVATION_RULE_TYPE for rule in decision.rules
+        ),
+        proposal=(
+            propose_literal_rule(decision)
+            if assessment.protection_tier == "mneme_ready"
+            else None
+        ),
+    )
+
+
+__all__ = [
+    "ProtectionError",
+    "ProtectionCandidate",
+    "CandidateReport",
+    "find_candidates",
+    "Precheck",
+    "activation_precheck",
+    "ValidationCheck",
+    "ValidationResult",
+    "validate_proposal",
+    "ActivationOutcome",
+    "activate_protection",
+    "ProtectionStatus",
+    "protection_status",
+    "load_decisions",
+    "find_decision",
+    "ENFORCEMENT_BEHAVIOR",
+]

--- a/mneme/protection.py
+++ b/mneme/protection.py
@@ -57,6 +57,7 @@ from mneme.memory_store import MemoryStore
 from mneme.path_selectors import SelectorOutcome, policy_root
 from mneme.rule_matcher import literal_in_text
 from mneme.schemas import Decision, Rule
+from mneme.setup import mneme_version
 from mneme.setup_state import (
     ACTIVATION_SCHEMA,
     STATE_ACTIVE,
@@ -512,10 +513,17 @@ def _install_rule(
 
     Raw read-modify-write preserving every other key verbatim (meta, items,
     examples, other decisions, and any future sections). Idempotent: an
-    identical existing rule is left alone and no duplicate is created. When
-    the project activation record exists in ``setup`` state, the explicit
-    activation also performs the frozen ``setup → active`` transition the
-    M1.3 contract reserved for exactly this user action.
+    identical existing rule is left alone and no duplicate is created.
+
+    The explicit activation also completes the frozen M1.3 activation-state
+    model (``setup`` = no preventive protection, ``active`` = at least one
+    preventive protection explicitly enabled): a ``setup``-state record
+    transitions to ``active`` via the frozen transition table, and a
+    pre-M1.3 memory file without an activation record — which
+    ``derive_activation_state`` already interprets as ``setup`` — gains one
+    valid record in ``active`` state with ``activated_at`` set. An already
+    ``active`` record is left untouched; an unsupported or invalid record is
+    refused before any write.
 
     Returns ``True`` when this call wrote the file, ``False`` when the rule
     was already installed.
@@ -558,7 +566,15 @@ def _install_rule(
     entry["rules"] = [*existing, record]
 
     raw_activation = raw.get("activation")
-    if raw_activation is not None:
+    if raw_activation is None:
+        # A pre-M1.3 memory file with no activation record is de-facto
+        # ``setup`` state (``derive_activation_state``). Explicitly
+        # activating the first protection completes the frozen M1.3 state
+        # model here: persist one valid record in ``active`` state instead
+        # of leaving the invalid "Protected decision + setup project"
+        # combination.
+        record_state = ActivationRecord(state=STATE_SETUP)
+    else:
         if (
             not isinstance(raw_activation, dict)
             or raw_activation.get("schema") not in (None, ACTIVATION_SCHEMA)
@@ -574,11 +590,19 @@ def _install_rule(
             raise ProtectionError(
                 f"existing activation record in {memory_path} is invalid: {exc}"
             ) from exc
-        if record_state.state == STATE_SETUP:
+    if record_state.state != STATE_ACTIVE:
+        try:
             record_state.require_transition(STATE_ACTIVE)
-            record_state.state = STATE_ACTIVE
-            record_state.activated_at = utc_now()
-            raw["activation"] = record_state.to_dict()
+        except ActivationStateError as exc:
+            raise ProtectionError(
+                f"activation record in {memory_path} cannot transition "
+                f"from {record_state.state!r} to {STATE_ACTIVE!r}: {exc}"
+            ) from exc
+        record_state.state = STATE_ACTIVE
+        record_state.activated_at = utc_now()
+        if raw_activation is None:
+            record_state.mneme_version = mneme_version()
+        raw["activation"] = record_state.to_dict()
 
     atomic_write_json(memory_path, raw)
     return True

--- a/tests/test_protection_activation.py
+++ b/tests/test_protection_activation.py
@@ -1,0 +1,751 @@
+"""M1.4 — Per-decision protection activation.
+
+Covers the first complete product loop:
+
+    Audit → Setup → candidate → validate → activate → canonical verify → Protected
+
+Frozen invariants pinned here:
+
+- eligibility comes exclusively from the canonical P1.2 assessment (G1);
+- audit, setup, candidate discovery and validation never enable protection (G2);
+- validation is deterministic engine behavior, never model judgment (G3);
+- only the explicit activation path installs enforcement (G4);
+- activated protection respects existing applicability semantics (G5);
+- a decision cannot become Protected before canonical enforcement evidence
+  is observable, and Current Protection never moves without it (G6);
+- after successful activation a fresh audit independently observes the
+  decision Protected and setup agrees (G7).
+"""
+import json
+import os
+import re
+from dataclasses import replace as dc_replace
+from pathlib import Path
+
+import pytest
+
+from mneme.cli import main
+from mneme.enforcer import generate_protection_report
+from mneme.memory_store import MemoryStore
+from mneme.protection import (
+    ProtectionError,
+    activate_protection,
+    activation_precheck,
+    find_candidates,
+    protection_status,
+    validate_proposal,
+)
+from mneme.schemas import Rule
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+
+BASE_TS = "2026-01-01T00:00:00Z"
+
+DECISIONS = [
+    {
+        "id": "d_typed",
+        "decision": "Store data in sqlite",
+        "constraints": [],
+        "anti_patterns": [],
+        "rules": [{"type": "FORBID_LITERAL", "value": "sqlite"}],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+    {
+        "id": "d_ready",
+        "decision": "No postgres in the service layer",
+        "constraints": [],
+        "anti_patterns": ["postgres"],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+    {
+        "id": "d_single_no",
+        "decision": "Keep configuration in JSON",
+        "constraints": ["no yaml"],
+        "anti_patterns": [],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+    {
+        "id": "d_multi",
+        "decision": "Keep services isolated",
+        "constraints": [],
+        "anti_patterns": ["share one database across services"],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+    {
+        "id": "d_guid",
+        "decision": "Prefer small modules",
+        "constraints": [],
+        "anti_patterns": [],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+    {
+        "id": "d_superseded",
+        "decision": "Old config rule",
+        "constraints": [],
+        "anti_patterns": ["xml"],
+        "status": "superseded",
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    },
+]
+
+
+def _write_repo(
+    tmp_path: Path,
+    decisions: list[dict],
+    activation: dict | None = None,
+) -> tuple[Path, Path]:
+    """Create a temporary repository with the fixture memory; return (root, memory)."""
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    document = {
+        "meta": {"name": "m14", "description": "M1.4 fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": decisions,
+    }
+    if activation is not None:
+        document["activation"] = activation
+    memory.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return root, memory
+
+
+def _load_store(memory: Path) -> MemoryStore:
+    store = MemoryStore(memory)
+    store.load()
+    return store
+
+
+def _decision_by_id(store: MemoryStore, decision_id: str):
+    return next(d for d in store.decisions() if d.id == decision_id)
+
+
+def _audit_summary(memory: Path) -> dict:
+    """Canonical audit metrics for the memory file, recomputed from disk."""
+    store = _load_store(memory)
+    report = generate_protection_report(store.decisions())
+    return {
+        "protected": report.protected,
+        "mneme_ready": report.mneme_ready,
+        "requires_modelling": report.requires_modelling,
+        "guidance": report.guidance,
+        "current_protection_pct": report.current_protection_pct,
+    }
+
+
+_SETUP_ACTIVATION = {
+    "schema": "mneme.setup/v1",
+    "state": "setup",
+    "mneme_version": "0.6.0",
+    "setup_started_at": BASE_TS,
+    "setup_completed_at": BASE_TS,
+    "activated_at": None,
+    "audit_ref": "",
+    "baseline": None,
+    "integrations_detected": [],
+    "integrations_configured": [],
+    "enforcement": "not_enabled",
+}
+
+
+# ── G1: candidate eligibility is exclusively canonical ───────────────────────
+
+
+def test_candidates_are_exactly_the_canonical_mneme_ready(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    store = _load_store(memory)
+    discovered = find_candidates(store.decisions())
+
+    ids = [c.decision_id for c in discovered.candidates]
+    assert ids == ["d_ready", "d_single_no"]
+    for candidate in discovered.candidates:
+        assert candidate.proposal.type == "FORBID_LITERAL"
+    by_id = {c.decision_id: c for c in discovered.candidates}
+    assert by_id["d_ready"].guardrail == "FORBID_LITERAL: postgres"
+    assert by_id["d_ready"].proposal.value == "postgres"
+    assert by_id["d_single_no"].proposal.value == "yaml"
+
+    report = discovered.report
+    assert (report.protected, report.mneme_ready,
+            report.requires_modelling, report.guidance) == (1, 2, 1, 1)
+
+
+def test_already_protected_decision_is_not_a_candidate(tmp_path):
+    _, memory = _write_repo(
+        tmp_path, [d for d in DECISIONS if d["id"] == "d_typed"]
+    )
+    store = _load_store(memory)
+    discovered = find_candidates(store.decisions())
+    assert discovered.candidates == ()
+    assert discovered.report.protected == 1
+    assert discovered.report.mneme_ready == 0
+
+
+def test_precheck_rejects_every_non_candidate(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    store = _load_store(memory)
+
+    pre = activation_precheck(_decision_by_id(store, "d_multi"))
+    assert pre.eligible is False and pre.tier == "requires_modelling"
+
+    pre = activation_precheck(_decision_by_id(store, "d_guid"))
+    assert pre.eligible is False and pre.tier == "guidance"
+
+    pre = activation_precheck(_decision_by_id(store, "d_superseded"))
+    assert pre.eligible is False
+    assert "superseded" in pre.reason
+
+    pre = activation_precheck(_decision_by_id(store, "d_typed"))
+    assert pre.eligible is False and pre.tier == "protected"
+
+    pre = activation_precheck(_decision_by_id(store, "d_ready"))
+    assert pre.eligible is True and pre.proposal.value == "postgres"
+
+
+# ── G2: nothing but the explicit activation path writes ──────────────────────
+
+
+def test_discovery_and_validation_never_write(tmp_path, capsys):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    store = _load_store(memory)
+    before = memory.read_text(encoding="utf-8")
+
+    discovered = find_candidates(store.decisions())
+    candidate = discovered.candidates[0]
+    decision = _decision_by_id(store, candidate.decision_id)
+    pre = activation_precheck(decision)
+    assert validate_proposal(decision, pre.proposal).status == "valid"
+
+    assert main(["protect", "list", "--memory", str(memory)]) == 0
+    capsys.readouterr()
+    assert main([
+        "protect", "status", "d_ready", "--memory", str(memory),
+    ]) == 0
+    capsys.readouterr()
+    assert main([
+        "protect", "validate", "d_ready", "--memory", str(memory),
+    ]) == 0
+    capsys.readouterr()
+    assert memory.read_text(encoding="utf-8") == before, (
+        "a read-only protect operation wrote to the memory file"
+    )
+
+
+def test_audit_and_setup_never_activate(tmp_path, capsys):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    before = memory.read_text(encoding="utf-8")
+
+    assert main([
+        "audit", "--memory", str(memory), "--repo-root", str(root),
+    ]) == 0
+    capsys.readouterr()
+    assert memory.read_text(encoding="utf-8") == before
+
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        assert main(["setup"]) == 0
+        capsys.readouterr()
+    finally:
+        os.chdir(old)
+    before_doc = json.loads(before)
+    after_doc = json.loads(memory.read_text(encoding="utf-8"))
+    before_rules = {
+        e["id"]: e.get("rules", []) for e in before_doc["decisions"]
+    }
+    after_rules = {
+        e["id"]: e.get("rules", []) for e in after_doc["decisions"]
+    }
+    assert after_rules == before_rules, "setup added or changed a rule"
+
+
+# ── G3: deterministic validation ─────────────────────────────────────────────
+
+
+def test_validation_success_all_four_checks(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    store = _load_store(memory)
+    decision = _decision_by_id(store, "d_ready")
+    pre = activation_precheck(decision)
+    result = validate_proposal(decision, pre.proposal, memory_path=memory)
+
+    assert result.status == "valid"
+    assert [c.name for c in result.checks] == [
+        "prohibited_detected",
+        "permitted_allowed",
+        "path_scope_respected",
+        "unrelated_paths_unaffected",
+    ]
+    assert all(c.passed for c in result.checks)
+
+
+def test_validation_unsupported_outside_activation_ready_shape(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    store = _load_store(memory)
+    decision = _decision_by_id(store, "d_ready")
+
+    scoped = Rule(
+        type="FORBID_LITERAL", value="postgres",
+        include_paths=("src/**",),
+    )
+    assert validate_proposal(
+        decision, scoped, memory_path=memory
+    ).status == "unsupported"
+
+    bare = dc_replace(decision, memory_path="")
+    pre = activation_precheck(bare)
+    assert pre.eligible is True
+    assert validate_proposal(
+        bare, pre.proposal, memory_path=None
+    ).status == "unsupported"
+
+
+def test_validation_failure_refuses_activation(tmp_path, capsys, monkeypatch):
+    """A failed deterministic validation writes nothing and protects nothing."""
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    before = memory.read_text(encoding="utf-8")
+    baseline = _audit_summary(memory)
+    assert baseline["protected"] == 1 and baseline["mneme_ready"] == 2
+
+    import mneme.protection as protection
+
+    real_check = protection.check_prompt
+
+    def blind_check(text, scored, top=3, input_path=None):
+        result = real_check(text, scored, top=top, input_path=input_path)
+        result.violations = [
+            v for v in result.violations if v.kind != "typed_rule"
+        ]
+        return result
+
+    monkeypatch.setattr(protection, "check_prompt", blind_check)
+    try:
+        outcome = activate_protection("d_ready", memory, repo_root=root)
+        assert outcome.result == "validation_failed"
+        assert outcome.rule_installed is False
+        capsys.readouterr()
+        code = main([
+            "protect", "activate", "d_ready", "--memory", str(memory),
+        ])
+    finally:
+        monkeypatch.undo()
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "VALIDATION FAILED" in out
+    assert "Nothing was written" in out
+    assert memory.read_text(encoding="utf-8") == before
+    assert _audit_summary(memory) == baseline
+
+
+# ── G4: explicit activation installs real enforcement ────────────────────────
+
+
+def test_explicit_activation_installs_rule_and_verifies(tmp_path):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    before = json.loads(memory.read_text(encoding="utf-8"))
+
+    outcome = activate_protection("d_ready", memory, repo_root=root)
+    assert outcome.result == "verified"
+    assert outcome.rule_installed is True
+    assert outcome.verification_tier == "protected"
+
+    raw = json.loads(memory.read_text(encoding="utf-8"))
+    ready = next(e for e in raw["decisions"] if e["id"] == "d_ready")
+    assert ready["rules"] == [{"type": "FORBID_LITERAL", "value": "postgres"}]
+    others = [e for e in raw["decisions"] if e["id"] != "d_ready"]
+    assert others == [e for e in before["decisions"] if e["id"] != "d_ready"]
+    assert raw["meta"] == before["meta"]
+
+
+def test_activation_via_cli(tmp_path, capsys):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+
+    capsys.readouterr()
+    code = main([
+        "protect", "activate", "d_single_no", "--memory", str(memory),
+        "--repo-root", str(root),
+    ])
+    out = capsys.readouterr().out
+    assert code == 0, out
+    assert "activated and verified" in out
+    raw = json.loads(memory.read_text(encoding="utf-8"))
+    entry = next(e for e in raw["decisions"] if e["id"] == "d_single_no")
+    assert entry["rules"] == [{"type": "FORBID_LITERAL", "value": "yaml"}]
+
+
+def test_activation_is_idempotent_and_never_duplicates(tmp_path):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+
+    first = activate_protection("d_ready", memory, repo_root=root)
+    assert first.result == "verified" and first.rule_installed is True
+
+    second = activate_protection("d_ready", memory, repo_root=root)
+    assert second.result == "already_protected"
+    assert second.rule_installed is False
+
+    assert activate_protection("d_ready", memory).result == "already_protected"
+
+    raw = json.loads(memory.read_text(encoding="utf-8"))
+    ready = next(e for e in raw["decisions"] if e["id"] == "d_ready")
+    assert ready["rules"] == [{"type": "FORBID_LITERAL", "value": "postgres"}]
+
+
+def test_ineligible_decisions_cannot_be_activated(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    before = memory.read_text(encoding="utf-8")
+
+    assert activate_protection("d_superseded", memory).result == "not_eligible"
+    assert activate_protection("d_multi", memory).result == "not_eligible"
+    assert activate_protection("d_guid", memory).result == "not_eligible"
+    outcome = activate_protection("d_typed", memory)
+    assert outcome.result == "already_protected"
+    assert outcome.rule_installed is False
+    assert memory.read_text(encoding="utf-8") == before
+
+
+def test_activate_unknown_decision_is_usage_error(tmp_path, capsys):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    capsys.readouterr()
+    code = main(["protect", "activate", "nope", "--memory", str(memory)])
+    captured = capsys.readouterr()
+    assert code == 2
+    assert captured.err.startswith("ERROR")
+    assert captured.out == ""
+
+
+def test_activate_refuses_unsupported_activation_record(tmp_path, capsys):
+    _, memory = _write_repo(
+        tmp_path, DECISIONS,
+        activation={"schema": "someone.else/v9", "state": "setup"},
+    )
+    before = memory.read_text(encoding="utf-8")
+    capsys.readouterr()
+    code = main(["protect", "activate", "d_ready", "--memory", str(memory)])
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "refusing" in captured.err
+    assert memory.read_text(encoding="utf-8") == before
+
+
+# ── G5: applicability semantics of the activated rule ────────────────────────
+
+
+def test_activated_protection_enforces_and_exempts_canonical_sources(
+    tmp_path, capsys,
+):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    assert activate_protection("d_ready", memory).result == "verified"
+
+    violating = root / "violating.py"
+    violating.write_text("use postgres here\n", encoding="utf-8")
+    permitted = root / "clean.py"
+    permitted.write_text("use an embedded key-value store here\n", encoding="utf-8")
+
+    capsys.readouterr()
+    code = main([
+        "check", "--memory", str(memory), "--input", str(violating),
+        "--query", "service layer", "--adr-dir", "docs/adr-absent",
+    ])
+    out = capsys.readouterr().out
+    assert code == 2
+    assert 'FORBID_LITERAL "postgres"' in out
+
+    capsys.readouterr()
+    code = main([
+        "check", "--memory", str(memory), "--input", str(permitted),
+        "--query", "service layer", "--adr-dir", "docs/adr-absent",
+    ])
+    assert code == 0
+
+    capsys.readouterr()
+    # The memory file carrying the rule is a canonical policy source: the
+    # activated typed rule must be exempt there (ADR-019 #6 / ADR-020 #8),
+    # even though legacy anti-pattern prose still applies to any text.
+    code = main([
+        "check", "--memory", str(memory), "--input", str(memory),
+        "--query", "service layer", "--adr-dir", "docs/adr-absent",
+        "--json",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    typed = [v for v in payload["violations"] if v["kind"] == "typed_rule"]
+    assert typed == [], typed
+    exempt_traces = [
+        a for a in payload["applicability"]
+        if a["rule_type"] == "FORBID_LITERAL"
+        and a["decision_id"] == "d_ready"
+        and a["outcome"] == "EXCLUDED"
+    ]
+    assert exempt_traces and exempt_traces[0]["selector"] == (
+        "<canonical-policy-source>"
+    ), payload["applicability"]
+
+
+# ── G6: score moves only when canonical evidence exists ──────────────────────
+
+
+def test_activation_without_evidence_does_not_move_score(
+    tmp_path, monkeypatch,
+):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    baseline = _audit_summary(memory)
+    assert baseline["protected"] == 1 and baseline["mneme_ready"] == 2
+    assert baseline["current_protection_pct"] == 25.0
+
+    import mneme.protection as protection
+
+    monkeypatch.setattr(protection, "_install_rule", lambda *a, **k: False)
+    try:
+        outcome = activate_protection("d_ready", memory, repo_root=root)
+    finally:
+        monkeypatch.undo()
+    assert outcome.result == "verification_failed"
+    assert outcome.rule_installed is False
+    assert outcome.verification_tier == "mneme_ready"
+
+    after = _audit_summary(memory)
+    assert after == baseline, (
+        "activation without verifiable enforcement evidence "
+        "must not increase Current Protection"
+    )
+
+
+def test_validate_alone_does_not_change_classification(tmp_path, capsys):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    baseline = _audit_summary(memory)
+    before = memory.read_text(encoding="utf-8")
+
+    assert main(["protect", "validate", "d_ready", "--memory", str(memory)]) == 0
+    capsys.readouterr()
+
+    assert _audit_summary(memory) == baseline
+    assert memory.read_text(encoding="utf-8") == before
+
+
+def test_cli_activate_reports_verification_failure(tmp_path, capsys, monkeypatch):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    import mneme.protection as protection
+
+    monkeypatch.setattr(protection, "_install_rule", lambda *a, **k: False)
+    try:
+        capsys.readouterr()
+        code = main([
+            "protect", "activate", "d_ready", "--memory", str(memory),
+            "--repo-root", str(root),
+        ])
+    finally:
+        monkeypatch.undo()
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "remains NOT Protected" in captured.out
+    assert "activated and verified" not in captured.out
+
+
+# ── G7: re-audit parity after activation ─────────────────────────────────────
+
+
+def test_fresh_audit_and_setup_observe_activated_protection(tmp_path, capsys):
+    root, memory = _write_repo(tmp_path, DECISIONS)
+    baseline = _audit_summary(memory)
+    assert baseline["protected"] == 1 and baseline["mneme_ready"] == 2
+    assert baseline["current_protection_pct"] == 25.0
+
+    assert activate_protection("d_ready", memory, repo_root=root).result == (
+        "verified"
+    )
+
+    after = _audit_summary(memory)
+    assert after["protected"] == 2 and after["mneme_ready"] == 1
+    assert after["current_protection_pct"] == 50.0
+    assert after["requires_modelling"] == baseline["requires_modelling"]
+    assert after["guidance"] == baseline["guidance"]
+
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        capsys.readouterr()
+        assert main(["setup"]) == 0
+        setup_out = capsys.readouterr().out
+    finally:
+        os.chdir(old)
+    setup_counts = {}
+    for key in ("Protected", "Mneme-ready", "Requires modelling", "Guidance"):
+        match = re.search(rf"^\s*{re.escape(key)}: (\d+)$", setup_out, re.M)
+        assert match, f"missing {key} in setup summary: {setup_out}"
+        setup_counts[key] = int(match.group(1))
+    assert setup_counts == {
+        "Protected": 2,
+        "Mneme-ready": 1,
+        "Requires modelling": 1,
+        "Guidance": 1,
+    }
+
+
+def test_activation_performs_the_reserved_setup_to_active_transition(tmp_path):
+    _, memory = _write_repo(
+        tmp_path, DECISIONS, activation=_SETUP_ACTIVATION
+    )
+    assert activate_protection("d_ready", memory).result == "verified"
+
+    record = json.loads(memory.read_text(encoding="utf-8"))["activation"]
+    assert record["state"] == "active"
+    assert record["activated_at"]
+    assert record["setup_completed_at"] == BASE_TS
+    assert record["enforcement"] == "not_enabled"
+
+
+def test_setup_still_refuses_active_projects_after_activation(tmp_path, capsys):
+    """Frozen M1.3 behavior: setup never downgrades an active project."""
+    root, memory = _write_repo(
+        tmp_path, DECISIONS, activation=_SETUP_ACTIVATION
+    )
+    assert activate_protection("d_ready", memory).result == "verified"
+    before = memory.read_text(encoding="utf-8")
+
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        capsys.readouterr()
+        code = main(["setup"])
+        out = capsys.readouterr().out
+    finally:
+        os.chdir(old)
+    assert code == 0
+    assert "active state" in out
+    assert memory.read_text(encoding="utf-8") == before
+
+
+def test_activation_without_activation_record_does_not_invent_one(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    assert activate_protection("d_single_no", memory).result == "verified"
+    raw = json.loads(memory.read_text(encoding="utf-8"))
+    assert "activation" not in raw
+
+
+# ── Status surface ───────────────────────────────────────────────────────────
+
+
+def test_status_reflects_each_lifecycle_stage(tmp_path, capsys):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+
+    status = protection_status("d_ready", memory)
+    assert status.tier == "mneme_ready" and status.rule_installed is False
+    assert status.proposal is not None and status.proposal.value == "postgres"
+
+    capsys.readouterr()
+    assert main(["protect", "status", "d_ready", "--memory", str(memory)]) == 0
+    out = capsys.readouterr().out
+    assert "mneme_ready" in out and "rule installed:   no" in out
+
+    assert activate_protection("d_ready", memory).result == "verified"
+    status = protection_status("d_ready", memory)
+    assert status.tier == "protected" and status.rule_installed is True
+    assert status.proposal is None
+
+    capsys.readouterr()
+    assert main(["protect", "status", "d_ready", "--memory", str(memory)]) == 0
+    out = capsys.readouterr().out
+    assert "protected" in out and "rule installed:   yes" in out
+
+    capsys.readouterr()
+    code = main(["protect", "status", "nope", "--memory", str(memory)])
+    captured = capsys.readouterr()
+    assert code == 2 and captured.err.startswith("ERROR")
+
+
+def test_errors_raise_before_any_write(tmp_path):
+    _, memory = _write_repo(tmp_path, DECISIONS)
+    before = memory.read_text(encoding="utf-8")
+    with pytest.raises(ProtectionError):
+        activate_protection("ghost", memory)
+    with pytest.raises(ProtectionError):
+        protection_status("ghost", memory)
+    assert memory.read_text(encoding="utf-8") == before
+
+
+# ── Full product loop (realistic end-to-end fixture) ─────────────────────────
+
+
+def test_full_loop_audit_validate_activate_verify_audit(tmp_path, capsys):
+    """ADR/decision → audit (Mneme-ready) → validate → activate → evidence →
+    fresh canonical audit → Protected; setup parity throughout; score moves
+    only with canonical evidence."""
+    root, memory = _write_repo(tmp_path, DECISIONS)
+
+    # 1+2 — the candidate starts Mneme-ready / Protectable, unprotected.
+    initial = _audit_summary(memory)
+    assert initial["mneme_ready"] == 2 and initial["protected"] == 1
+    assert initial["current_protection_pct"] == 25.0
+
+    # 2 — validation alone does not make it Protected.
+    capsys.readouterr()
+    assert main([
+        "protect", "validate", "d_ready", "--memory", str(memory),
+        "--repo-root", str(root),
+    ]) == 0
+    assert "Result: VALID" in capsys.readouterr().out
+    assert _audit_summary(memory) == initial
+
+    # 3 — explicit activation.
+    capsys.readouterr()
+    assert main([
+        "protect", "activate", "d_ready", "--memory", str(memory),
+        "--repo-root", str(root),
+    ]) == 0
+    assert "activated and verified" in capsys.readouterr().out
+
+    # 4 — real mechanical enforcement evidence exists and works both ways.
+    raw = json.loads(memory.read_text(encoding="utf-8"))
+    entry = next(e for e in raw["decisions"] if e["id"] == "d_ready")
+    assert entry["rules"] == [{"type": "FORBID_LITERAL", "value": "postgres"}]
+
+    violating = root / "src"
+    violating.mkdir()
+    violating_file = violating / "service.py"
+    violating_file.write_text("import postgres\n", encoding="utf-8")
+    permitted_file = violating / "service_ok.py"
+    permitted_file.write_text("import sqlite3\n", encoding="utf-8")
+
+    capsys.readouterr()
+    assert main([
+        "check", "--memory", str(memory), "--input", str(violating_file),
+        "--query", "service layer", "--adr-dir", "docs/adr-absent",
+    ]) == 2
+    assert "FORBID_LITERAL \"postgres\"" in capsys.readouterr().out
+    capsys.readouterr()
+    assert main([
+        "check", "--memory", str(memory), "--input", str(permitted_file),
+        "--query", "service layer", "--adr-dir", "docs/adr-absent",
+    ]) == 0
+
+    # 5+6 — a fresh canonical audit independently observes Protected, and
+    # Current Protection moved only because canonical evidence changed.
+    final = _audit_summary(memory)
+    assert final["protected"] == 2 and final["mneme_ready"] == 1
+    assert final["current_protection_pct"] == 50.0
+
+    # 7 — setup/readiness sees the same classification.
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        capsys.readouterr()
+        assert main(["setup"]) == 0
+        setup_out = capsys.readouterr().out
+    finally:
+        os.chdir(old)
+    counts = {}
+    for key in ("Protected", "Mneme-ready", "Requires modelling", "Guidance"):
+        match = re.search(rf"^\s*{re.escape(key)}: (\d+)$", setup_out, re.M)
+        counts[key] = int(match.group(1))
+    assert counts == {
+        "Protected": 2,
+        "Mneme-ready": 1,
+        "Requires modelling": 1,
+        "Guidance": 1,
+    }

--- a/tests/test_protection_activation.py
+++ b/tests/test_protection_activation.py
@@ -36,6 +36,7 @@ from mneme.protection import (
     validate_proposal,
 )
 from mneme.schemas import Rule
+from mneme.setup_state import derive_activation_state, read_activation
 
 MEMORY_REL = Path(".mneme") / "project_memory.json"
 
@@ -621,11 +622,50 @@ def test_setup_still_refuses_active_projects_after_activation(tmp_path, capsys):
     assert memory.read_text(encoding="utf-8") == before
 
 
-def test_activation_without_activation_record_does_not_invent_one(tmp_path):
-    _, memory = _write_repo(tmp_path, DECISIONS)
-    assert activate_protection("d_single_no", memory).result == "verified"
-    raw = json.loads(memory.read_text(encoding="utf-8"))
-    assert "activation" not in raw
+def test_activation_persists_active_record_for_pre_m13_memory(
+    tmp_path, capsys,
+):
+    """Frozen M1.3 invariant: verified protection implies state ``active``.
+
+    A pre-M1.3 memory file with no activation record is de-facto ``setup``
+    (``derive_activation_state``). Explicit activation of the first
+    protection must leave a valid ``active`` record behind — never the
+    invalid "Protected decision + setup project" combination — while
+    reusing the existing M1.3 schema, transition table and persistence.
+    """
+    root, memory = _write_repo(tmp_path, DECISIONS)
+
+    # 1 — before activation the project derives as setup.
+    assert derive_activation_state(memory) == "setup"
+    assert read_activation(memory) is None
+
+    # 2 — explicit activation succeeds and canonical verification passes.
+    outcome = activate_protection("d_single_no", memory, repo_root=root)
+    assert outcome.result == "verified"
+    assert outcome.verification_tier == "protected"
+
+    # 3+4+5 — the project is now active with a valid, populated record.
+    assert derive_activation_state(memory) == "active"
+    record = read_activation(memory)
+    assert record is not None
+    assert record.state == "active"
+    assert record.activated_at
+    assert record.to_dict()["schema"] == "mneme.setup/v1"
+
+    # 6 — setup cannot subsequently downgrade the project.
+    before = memory.read_text(encoding="utf-8")
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        capsys.readouterr()
+        code = main(["setup"])
+        out = capsys.readouterr().out
+    finally:
+        os.chdir(old)
+    assert code == 0
+    assert "active state" in out
+    assert memory.read_text(encoding="utf-8") == before
+    assert read_activation(memory).state == "active"
 
 
 # ── Status surface ───────────────────────────────────────────────────────────
@@ -667,6 +707,67 @@ def test_errors_raise_before_any_write(tmp_path):
     with pytest.raises(ProtectionError):
         protection_status("ghost", memory)
     assert memory.read_text(encoding="utf-8") == before
+
+
+# ── CLI error paths: clean exit 2, never a traceback ─────────────────────────
+
+
+_PROTECT_SUBCOMMANDS = [
+    ("list",),
+    ("status", "d_ready"),
+    ("validate", "d_ready"),
+    ("activate", "d_ready"),
+]
+
+
+def test_protect_cli_missing_memory_is_clean_usage_error(
+    tmp_path, capsys,
+):
+    missing = tmp_path / "absent" / "project_memory.json"
+    for subcommand in _PROTECT_SUBCOMMANDS:
+        capsys.readouterr()
+        code = main([
+            "protect", *subcommand, "--memory", str(missing),
+        ])
+        captured = capsys.readouterr()
+        assert code == 2, (subcommand, captured.out, captured.err)
+        assert captured.out == ""
+        assert captured.err.startswith("ERROR: memory file"), captured.err
+        assert "Traceback" not in captured.err
+        assert not missing.exists(), "a failed protect command wrote memory"
+
+
+def test_protect_cli_invalid_memory_is_clean_usage_error(
+    tmp_path, capsys,
+):
+    malformed = tmp_path / "broken.json"
+    malformed.write_text("{ not valid json ]", encoding="utf-8")
+    invalid_schema = tmp_path / "badrule.json"
+    invalid_schema.write_text(json.dumps({
+        "meta": {"name": "x", "description": "x"},
+        "items": [],
+        "examples": [],
+        "decisions": [{
+            "id": "d_ready",
+            "decision": "No postgres in the service layer",
+            "anti_patterns": ["postgres"],
+            "rules": [{"type": "NOT_A_TYPE", "value": "postgres"}],
+        }],
+    }, indent=2) + "\n", encoding="utf-8")
+
+    for memory in (malformed, invalid_schema):
+        before = memory.read_text(encoding="utf-8")
+        for subcommand in _PROTECT_SUBCOMMANDS:
+            capsys.readouterr()
+            code = main([
+                "protect", *subcommand, "--memory", str(memory),
+            ])
+            captured = capsys.readouterr()
+            assert code == 2, (subcommand, captured.out, captured.err)
+            assert captured.out == ""
+            assert captured.err.startswith("ERROR:"), captured.err
+            assert "Traceback" not in captured.err
+            assert memory.read_text(encoding="utf-8") == before
 
 
 # ── Full product loop (realistic end-to-end fixture) ─────────────────────────


### PR DESCRIPTION
## Summary

Implements **M1.4 — Protection Activation P0**: closes the first complete product loop

```text
Audit → Setup → candidate → validate → activate → canonical verify → Protected
```

by turning an already-classified Mneme-ready decision into a real, verifiable deterministic protection. No redesign of the Audit, readiness semantics, or protection classification.

### Architecture

Reuses (canonical, untouched semantics):
- `assess_protection` / `generate_protection_report` (`mneme/enforcer.py`) — single source of truth for Protected / Mneme-ready / Requires modelling / Guidance; readiness remains a thin view, Audit/Setup parity intact.
- Typed `FORBID_LITERAL` rule schema (`mneme/schemas.py`, ADR-019) and ADR-020 path applicability (`mneme/path_selectors.py`).
- Existing enforcement engine `check_prompt` (used by validation *and* by hooks/`mneme check`).
- `atomic_write_json` / activation record (`mneme/setup_state.py`) — no parallel persistence.

Added:
- `mneme/enforcer.py`: `propose_literal_rule()` — rule-materialization helper built from the *same* primitives `assess_protection` uses (shared `_proposed_literal_tokens`), so proposal and classification cannot diverge; callers gate eligibility through the canonical assessment.
- `mneme/protection.py` (new): candidate discovery, frozen-eligibility precheck, deterministic validation (4 engine-backed checks, no writes, no model), explicit idempotent activation (appends the rule to the decision record via raw read-modify-write; refuses unsafe records; completes the M1.3 activation-state model — `setup` record → `active`, and pre-M1.3 no-record files gain one valid `active` record), and verification that re-runs the canonical assessment against the repository from disk.
- `mneme/cli.py`: `mneme protect list|status|validate|activate` (exit codes: 0 desired state, 1 actionable failure, 2 usage error; clean usage errors, never tracebacks).

No second protection semantics were introduced: eligibility, classification, verification and scoring all flow through the frozen P1.2 functions; activation only installs the enforcement artifact, and only verification by independent canonical re-assessment reports success.

Core invariants (regression-tested): `activation requested + no observable enforcement evidence = decision remains NOT Protected` and Current Protection does not move; `verified protection ⇒ project activation state active`; `invalid/missing memory ⇒ clean exit 2, never traceback`.

## Validation

- New: `python -m pytest tests/test_protection_activation.py` — 27 passed (G1–G8, applicability, idempotency, failed verification, activation-state invariant, CLI error paths, e2e loop).
- Audit/readiness/setup parity: `tests/test_setup_audit_parity.py tests/test_cli_audit.py tests/test_cli_setup.py tests/test_setup_state.py` — 81 passed.
- Rules/enforcement/frozen benchmarks: `tests/test_enforcer.py tests/test_path_selectors.py tests/test_schemas.py tests/test_enforcement_scope.py tests/test_enforcement_quality_benchmark.py tests/test_benchmark.py tests/test_adr_precedence.py` — 178 passed.
- Full suite: `python -m pytest` — 1239 passed, 6 skipped (baseline 1212+6 before this PR).
- Repo governance gate: `mneme check --mode warn` over the new/changed docs and source files — PASS.
- No lint/type tooling is configured in this repository (CI runs pytest only).

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823