### PR TITLE
docs: add Architecture Audit section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,39 @@ cd mneme
 pip install -e ".[dev]"
 ```
 
+## Architecture Audit
+
+See where your architecture is actually protected — and where it still depends on people remembering the rules.
+
+Mneme audits your repository and shows which architectural decisions are:
+
+- **Protected** — already enforced mechanically
+- **Mneme-ready** — can be turned into a deterministic guardrail
+- **Requires modelling** — important, but not yet safe to automate
+- **Guidance** — useful context, but not something that should be enforced
+
+Run an audit:
+
+```bash
+mneme audit --memory .mneme/project_memory.json --repo-root .
+```
+
+For a Mneme-ready decision, validate the proposed protection before enabling it:
+
+```bash
+mneme protect validate <decision-id> --memory .mneme/project_memory.json
+```
+
+Then explicitly activate it:
+
+```bash
+mneme protect activate <decision-id> --memory .mneme/project_memory.json
+```
+
+Mneme only reports a decision as **Protected** after it can verify that real enforcement is in place. The full activation contract is documented in [Protection Activation](docs/protect-activation.md).
+
+[Try the Architecture Audit →](https://mnemehq.com/audit/)
+
 ## 60-second enforcement example
 
 Initialize a project-local decision corpus:


### PR DESCRIPTION
## Summary

Adds a compact **Architecture Audit** section to the README (docs-only change).

The README is the first thing GitHub visitors and Wave 1 prospects see, so the audit story should not live only behind the site. The new section sits right after **Install** and walks the user journey:

**Audit → identify protection gaps → activate protection → verify**

- Classified tiers: Protected / Mneme-ready / Requires modelling / Guidance
- Commands: `mneme audit`, `mneme protect validate`, `mneme protect activate`
- Links to the public [Architecture Audit page](https://mnemehq.com/audit/) and `docs/protect-activation.md`

Kept out of the `mnemehq-site` PR intentionally: different repo, different review surface.

## Verification

- All CLI commands and flags checked against `mneme/cli.py` (`audit --memory --repo-root`, `protect validate <id> --memory`, `protect activate <id> --memory`).
- `docs/protect-activation.md` exists; public audit page confirmed live at https://mnemehq.com/audit/.
- Docs-only change; no code, ADR, or memory semantics touched.

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823
