### PR TITLE
fix: replace broken PyPI python badge with static 3.11+ badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mneme turns architectural decisions and ADRs into deterministic guardrails for t
 
 [![Tests](https://github.com/MnemeHQ/mneme/actions/workflows/tests.yml/badge.svg)](https://github.com/MnemeHQ/mneme/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/mneme-hq.svg)](https://pypi.org/project/mneme-hq/)
-[![Python](https://img.shields.io/pypi/pyversions/mneme-hq.svg)](https://pypi.org/project/mneme-hq/)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://pypi.org/project/mneme-hq/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Mneme is the architectural governance layer behind that drift-prevention mechanism. It keeps recorded engineering decisions active as AI coding systems propose and modify code, instead of leaving ADRs as passive documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ description = "Architectural drift prevention for the agentic AI SDLC. Determini
 keywords = ["architectural-drift-prevention", "architectural-drift", "agentic-ai-sdlc", "agentic-ai", "ai-coding-agents", "adr", "architectural-governance", "ci", "codex", "claude-code"]
 readme = "README.md"
 requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+]
 dependencies = [
     "anthropic>=0.25.0",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
## Summary

- Replaces the Shields `pypi/pyversions` badge (rendering **missing**) with a static `Python 3.11+` badge matching `requires-python = >=3.11` in `pyproject.toml`.
- Adds `Programming Language :: Python :: 3` and `:: 3.11` classifiers so the next PyPI release populates the pyversions endpoint correctly.

Deliberately does **not** claim 3.12/3.13: the test suite (`tests.yml`) runs on 3.11 only. Some auxiliary workflows run 3.12, but no 3.12 classifier is added until the test suite covers it.

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823