### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,75 @@
 
 ---
 
+## v0.7.0 — 2026-09-07
+
+**Architecture Audit, Audit→Setup activation, and per-decision protection — first PyPI release of the full loop**
+
+This is the first published package release containing the complete
+`Audit → Setup → Protect` journey: the P1.2 Architecture Protection Audit,
+`mneme setup` with activation state, Audit-reference setup pairing, and
+per-decision protection activation. No retrieval, enforcement-engine, or
+frozen-benchmark semantics change.
+
+### Added
+
+- `mneme audit` — P1.2 Architecture Protection Audit. Classifies every
+  decision in `project_memory.json` into Protected / Mneme-ready /
+  Requires modelling / Guidance, optionally scans the repository for
+  verified CI enforcement evidence (`--repo-root`), and writes a
+  versioned `mneme.audit/v1` JSON report via `--json`. Findings are
+  deterministic and reproducible.
+- `mneme setup` — installs Mneme in **setup mode** (M1.3a): context
+  injection and non-blocking checks only, never enforcement. Persists
+  activation state (`mneme.setup/v1`) in `project_memory.json`, records
+  git context, detects installed coding-agent integrations read-only
+  (detects, never configures), and prints a readiness view that is a
+  thin view over the canonical P1.2 protection assessment. Idempotent;
+  existing projects are preserved; enforcement stays `not_enabled`.
+- Audit-reference setup support (M1.3b) — `mneme setup --audit-ref
+  <reference>` resolves an opaque, scoped, expiring Architecture Audit
+  setup reference **before any local write** (fail-closed on invalid,
+  expired, mismatched, or unreachable references), records baseline
+  provenance, and reports setup completion back to the Audit service
+  (idempotent, with automatic retry on the next setup run).
+- `mneme protect list|status|validate|activate` — per-decision
+  protection activation (M1.4): lists Mneme-ready candidates,
+  deterministically validates a proposed protection against the existing
+  enforcement engine (no writes, no model), explicitly activates it for
+  one decision, and verifies via independent canonical re-assessment.
+  Activation is explicit and idempotent; requesting activation without
+  observable enforcement evidence never reports Protected and never
+  moves Current Protection by itself.
+- EventCatalog ADR ingestion (retrieval-only) — EventCatalog documents
+  can feed the decision corpus.
+
+### Fixed
+
+- Strict `Pipeline` verdict precedence: UNKNOWN applicability now takes
+  precedence over conflicts, so an out-of-scope conflict can no longer
+  mask an unknown-applicability failure.
+- Static PyPI Python badge replaces the broken dynamic badge.
+
+### Validation / Research
+
+- Enforcement-quality benchmark results recorded in-repo.
+- Claude Managed Agents M0 capability study remains evidence only.
+
+### Maintenance
+
+- CI: pull-request + squash-only enforcement on `main` (GitHub ruleset
+  plus local pre-push guard).
+- Docs: five-minute quickstart; README Architecture Audit section.
+
+### Compatibility
+
+- No changes to retrieval ranking, `DecisionRetriever`,
+  `ConflictDetector`, existing typed-rule semantics, or the frozen
+  enforcement benchmark. `mneme setup` and `mneme protect` are additive
+  CLI surface over the existing engine.
+
+---
+
 ## v0.6.0 — 2026-08-28
 
 **Governability API, Kiro CLI v3, LangChain/LangGraph, and ADR lifecycle analysis**

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,44 @@
+# mneme-hq 0.7.0
+
+**First PyPI release of the complete `Audit → Setup → Protect` journey.**
+
+## Added
+
+- **`mneme audit`** — P1.2 Architecture Protection Audit. Deterministic
+  classification of every decision (Protected / Mneme-ready / Requires
+  modelling / Guidance), optional verified CI-evidence scan
+  (`--repo-root`), versioned `mneme.audit/v1` JSON report.
+- **`mneme setup`** — installs Mneme in **setup mode** (M1.3a): context
+  injection and non-blocking checks only, never enforcement. Persists
+  activation state, records git context, detects installed integrations
+  read-only, prints a readiness view over the canonical protection
+  assessment. Idempotent; enforcement stays `not_enabled`.
+- **Audit-reference setup support** (M1.3b) — `mneme setup --audit-ref
+  <reference>` resolves an opaque, scoped, expiring Audit setup
+  reference before any local write (fail-closed), records baseline
+  provenance, and reports setup completion back to the Audit service.
+- **`mneme protect list|status|validate|activate`** — per-decision
+  protection activation (M1.4): list candidates, deterministically
+  validate a proposed protection against the enforcement engine,
+  explicitly activate one decision, and verify via canonical
+  re-assessment. Protection is explicit, never implicit, and Current
+  Protection never moves by itself.
+- EventCatalog ADR ingestion (retrieval-only).
+
+## Fixed
+
+- Strict `Pipeline` verdict precedence: UNKNOWN applicability now takes
+  precedence over conflicts.
+
+## Compatibility
+
+- No changes to retrieval ranking, `DecisionRetriever`,
+  `ConflictDetector`, existing typed-rule semantics, or the frozen
+  enforcement benchmark. `setup` and `protect` are additive CLI surface
+  over the existing engine.
+
+## Install
+
+```bash
+pipx install "mneme-hq==0.7.0"
+```

--- a/mneme/__init__.py
+++ b/mneme/__init__.py
@@ -16,4 +16,4 @@ Typical usage::
 See demo.py in the repo root for a full end-to-end example.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mneme-hq"
-version = "0.6.0"
+version = "0.7.0"
 description = "Architectural drift prevention for the agentic AI SDLC. Deterministic ADR guardrails across coding agents and CI."
 keywords = ["architectural-drift-prevention", "architectural-drift", "agentic-ai-sdlc", "agentic-ai", "ai-coding-agents", "adr", "architectural-governance", "ci", "codex", "claude-code"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepares Mneme HQ 0.7.0 for release — the first published package release of the complete **Audit → Setup → Protect** journey.

- Bumps the package version `0.6.0` → `0.7.0` (`pyproject.toml`, `mneme/__init__.py`).
- CHANGELOG: documents the P1.2 Architecture Protection Audit (`mneme audit`), `mneme setup` with activation state (M1.3a), audit-reference setup pairing (`mneme setup --audit-ref`, M1.3b), and per-decision protection activation (`mneme protect list|status|validate|activate`, M1.4).
- Adds `docs/releases/v0.7.0.md` as the GitHub release notes source.

No new Setup/Protection functionality, no audit-scoring changes, no lifecycle model changes — packaging and release metadata only. Publishing happens via the existing Trusted Publishing workflow when the GitHub release for `v0.7.0` is published.

## Validation

- `python -m pytest -q` — **1238 passed, 7 skipped**.
- `python -m build` — built the 0.7.0 sdist and wheel; `twine check dist/*` — both PASSED.
- `tests/test_packaging_contract.py -q` — 8 passed against the built artifacts.

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823