### PR TITLE
docs: record v0.7.0 release validation evidence

### DIFF
--- a/docs/releases/v0.7.0-validation.md
+++ b/docs/releases/v0.7.0-validation.md
@@ -1,0 +1,98 @@
+# v0.7.0 — Release Validation Evidence
+
+Recorded 2026-09-07. This document captures the release-readiness evidence
+for `mneme-hq==0.7.0` (release-readiness P0): version bump, publish, and
+clean-machine acceptance of the Audit → Setup → Protect journey from the
+published package.
+
+Precondition (unchanged in this release): M1.3 Audit → Setup backend
+promotion and production UI, M1.4 protection activation core, audit/site
+messaging, and CLI docs for `audit` / `setup` / `protect` were already
+merged and verified on core `main` (PRs #345, #347, #349; site #104–#109,
+site deployed at `932c88d`). This release publishes that work; it adds no
+new Setup or Protection functionality.
+
+## Release identity
+
+| Item | Value |
+| --- | --- |
+| Release commit | `2356422170e7e7094320c2df4e72624b6af799de` (`chore: prepare 0.7.0 release (#352)`) |
+| Tag | `v0.7.0` (points at the release commit) |
+| GitHub release | https://github.com/MnemeHQ/mneme/releases/tag/v0.7.0 (published 2026-09-07T12:49:36Z) |
+| Publish workflow | "Publish to PyPI" run [34123986089](https://github.com/MnemeHQ/mneme/actions/runs/34123986089) — `build` success, `publish` success |
+| PyPI environment approval | Required reviewer `TheoV823` approved the pending deployment |
+| PyPI version | `mneme-hq==0.7.0` (`requires-python >=3.11`) |
+| Wheel | `mneme_hq-0.7.0-py3-none-any.whl` sha256 `64ec2489885992869b8373c2d73d97f9129ed76c053f93da92c1b9abbd7ef280` |
+| Sdist | `mneme_hq-0.7.0.tar.gz` sha256 `95af1c7b644db5e96597bfafe1304f07494d5fb9aa4dabd5f8b86f271ad5d4cf` |
+
+## Pre-publish validation (source worktree, release commit content)
+
+- `python -m pytest -q` — **1238 passed, 7 skipped**.
+- `python -m build` — built the 0.7.0 sdist and wheel.
+- `python -m twine check dist/*` — both artifacts **PASSED**.
+- `tests/test_packaging_contract.py -q` — **8 passed** against the built
+  artifacts (name/version/entry points verified from the artifacts).
+- PR CI (#352): pytest, pytest (langchain extra), encoding check,
+  provenance check, install-command check, `mneme check --mode warn` — all
+  green before merge.
+
+## G1 — Published artifact
+
+`pipx install mneme-hq==0.7.0` (pipx 1.17.2, isolated venv on Python
+3.14.3) installed successfully from public PyPI. A stale `uv tool` install
+of mneme-hq 0.5.1 was uninstalled first so the pipx-managed shims in
+`%USERPROFILE%\.local\bin` were authoritative for every later check.
+
+## G2 — Published CLI surface
+
+All from the pipx-installed package, run outside any source checkout:
+
+- `mneme --help` — exit 0; `setup`, `audit`, `protect` present.
+- `mneme setup --help` — exit 0; exposes `--audit-ref`.
+- `mneme protect --help` — exit 0; exposes `list`, `status`, `validate`,
+  `activate`.
+
+## G3 — Clean local setup
+
+Disposable Git repository (`%TEMP%\mneme-g3-clean-repo`):
+
+- `mneme setup` — exit 0, reported `Enforcement / Not enabled` and
+  "Mneme is installed in setup mode."
+- Created only `.mneme/project_memory.json` (verified via `git status`).
+- Persisted activation state: `state: setup`, `enforcement: not_enabled`,
+  `activated_at: null`, `protection: None` — no protection activated
+  implicitly.
+
+## G4 — Production Audit → Setup (design-partner gate)
+
+Fresh production Audit created and consumed from the **PyPI-installed**
+CLI, exactly the journey a design partner runs.
+
+| Item | Value |
+| --- | --- |
+| Project | `ea075714-a7fb-452b-8738-25681d7c323f` (slug `v0-7-0-release-validation`) |
+| Audit | `096c3893-e6e8-44db-94bf-a88ec2ddab49` (trigger `initial`, status `completed`) |
+| Audited commit | `2356422170e7e7094320c2df4e72624b6af799de` (the release commit) |
+| Setup reference | `VxjbTJAezD620mfpMzLA40e1w9WM8Dc5` (expiring 2026-09-21, redeemed by this validation) |
+| Setup run | `mneme setup --audit-ref <ref>` from the PyPI install, in a disposable repo whose `origin` is the audited repository — exit 0, baseline connected, "Setup recorded with the Audit service" |
+
+Before/after production verification:
+
+| Check | Before | After | Result |
+| --- | --- | --- | --- |
+| Audit activation state | `not_installed` | `setup` (`setup_completed_at` 2026-09-07T14:19:59Z, `setup_audit_id` = the audit) | ✅ "Mneme installed — Setup mode" |
+| Audit lifecycle | `saved` | `saved` | ✅ unchanged |
+| Audit record (hash/decision baseline) | SHA256 `A1F1F516…F775CF` | byte-identical | ✅ unchanged |
+| Protection score | `current_protection` 0.333 (42 decisions: 1 protected, 0 ready, 2 requires modelling, 39 guidance) | identical payload | ✅ unchanged |
+| Enforcement | — | `not_enabled` locally, nothing activated | ✅ unchanged |
+| Audit count | 1 | 1 | ✅ no duplicate audit |
+
+## Outcome
+
+- Only blocking item before the design partner: **cleared** — `v0.7.0` is
+  published, clean-installable, and validated against a real production
+  Audit reference.
+- Audit → Setup → Protect is externally ready via
+  `pipx install "mneme-hq==0.7.0"`.
+- Non-blocking follow-ups: `upload:tmp…` issue (separate ticket) and a
+  published-package release-smoke CI job (P0.7).


### PR DESCRIPTION
## Summary

Records the v0.7.0 release-readiness P0 evidence in `docs/releases/v0.7.0-validation.md`:

- Release identity: release commit `23564221`, tag `v0.7.0`, GitHub release, Trusted Publishing run 34123986089 (build + publish success), PyPI artifact SHA256s.
- Pre-publish validation: 1238 passed / 7 skipped, `twine check` PASSED, packaging contract green, PR CI green.
- G1: `pipx install mneme-hq==0.7.0` from public PyPI.
- G2: `mneme --help` / `mneme setup --help` / `mneme protect --help` exit 0 with the expected surface.
- G3: disposable-repo `mneme setup` — setup mode, enforcement `not_enabled`, nothing activated implicitly.
- G4 (design-partner gate): fresh production Audit `096c3893…` at the release commit → `mneme setup --audit-ref …` from the PyPI install → activation state `setup`, audit record byte-identical, lifecycle unchanged, protection score unchanged, enforcement `not_enabled`, no duplicate audit.

Docs-only change; no runtime code touched.

## Validation

- No code changes; release evidence only.

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823