### PR TITLE
docs: record P0.7 published-package smoke run for v0.7.0

### DIFF
--- a/docs/releases/v0.7.0-validation.md
+++ b/docs/releases/v0.7.0-validation.md
@@ -87,6 +87,16 @@ Before/after production verification:
 | Enforcement | — | `not_enabled` locally, nothing activated | ✅ unchanged |
 | Audit count | 1 | 1 | ✅ no duplicate audit |
 
+## Post-release smoke CI (P0.7, completed after G1–G4)
+
+The published-package smoke workflow (`.github/workflows/release-smoke.yml`,
+PR #354) ran against the live release: run
+[34136632812](https://github.com/MnemeHQ/mneme/actions/runs/34136632812)
+dispatched for `0.7.0` — PyPI served the version, pipx install, CLI
+surface, and the disposable-repo clean-setup check all passed
+(state `setup`, enforcement `not_enabled`). It now runs automatically
+after every successful "Publish to PyPI" run for a `v*` tag.
+
 ## Outcome
 
 - Only blocking item before the design partner: **cleared** — `v0.7.0` is
@@ -94,5 +104,5 @@ Before/after production verification:
   Audit reference.
 - Audit → Setup → Protect is externally ready via
   `pipx install "mneme-hq==0.7.0"`.
-- Non-blocking follow-ups: `upload:tmp…` issue (separate ticket) and a
-  published-package release-smoke CI job (P0.7).
+- Remaining non-blocking follow-up: the `upload:tmp…` issue (separate
+  ticket).


### PR DESCRIPTION
## Summary

Appends the post-release smoke CI evidence to `docs/releases/v0.7.0-validation.md`: the release-smoke workflow (PR #354) dispatched for `0.7.0` passed against the live PyPI artifact — run [34136632812](https://github.com/MnemeHQ/mneme/actions/runs/34136632812): PyPI served the version, pipx install, CLI surface, and the disposable-repo clean-setup check all passed (state `setup`, enforcement `not_enabled`). The remaining non-blocking follow-up list now contains only the `upload:tmp…` issue.

Docs-only change.

## Validation

- No code changes; evidence addendum only.

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: claude
- Human owner: @TheoV823
