### PR TITLE
docs: highlight Architecture Audit callout in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Mneme turns architectural decisions and ADRs into deterministic guardrails for t
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://pypi.org/project/mneme-hq/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
+> **Where is your architecture actually enforced?** Run the [Architecture Audit](#architecture-audit) to see which decisions are protected, which can become deterministic guardrails, and which still depend on someone remembering the rules. [Try it →](https://mnemehq.com/audit/)
+
 Mneme is the architectural governance layer behind that drift-prevention mechanism. It keeps recorded engineering decisions active as AI coding systems propose and modify code, instead of leaving ADRs as passive documentation.
 
 > **Current phase:** Layer 1 validation. Retrieval, enforcement, and benchmark semantics are governed by the accepted architecture and freeze record. See [Current Phase](docs/architecture/current-phase.md) before changing core behavior.


### PR DESCRIPTION
## Summary

Adds a highlighted Architecture Audit callout as a blockquote directly after the README badges: one-line pitch, jump link to the Architecture Audit section, and the mnemehq.com/audit/ CTA. Matches the existing "Current phase" blockquote style. Docs-only change; no behavior or governance surface touched.

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: glm-5.3-flash
- Agent session: not-exposed
- Task origin: local
- Human owner: @TheoV823
