### PR TITLE
feat(audit): semantic tiers + declared/CI-claim test evidence (ADR-023/024/025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- P1.2 Architecture Audit tier semantics (ADR-023): intent is now judged
+  from the decision text (prescriptive vs advisory language) instead of
+  record shape, so byte-identical decision text no longer changes tier
+  when an unrelated structured constraint is added, and deterministic
+  architectural requirements without structured fields no longer fall to
+  Guidance. `Identified Mneme Potential` is now
+  (Mneme-ready + Requires modelling) / protection-relevant — decisions
+  deterministically enforceable in principle, not only records
+  immediately expressible by existing rule types. `mneme.audit/v1`,
+  CLI, Protect behavior, and enforcement/refusal semantics are unchanged.
+
 ---
 
 ## v0.7.0 — 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- Declared test-evidence ingestion for the Architecture Audit (ADR-024,
+  passive): a decision record may declare explicit `test_evidence` entries
+  linking it to a test that enforces it. Ordinary `mneme audit` is
+  PASSIVE — it executes no repository-controlled code (no pytest, no
+  conftest, no plugins) — and validates declared linkages passively
+  (well-formed unambiguous pytest selector, exact repository HEAD SHA
+  pin, existing test file). A declared linkage annotates evidence
+  sources as `test:declared:<selector>` but never protects: the VERIFIED
+  state requires a trusted verification producer (CI-produced exact-SHA +
+  exact-selector ingestion — next task). Guidance is never upgraded; every
+  failure mode (missing selector, stale or unavailable SHA, ambiguous
+  mapping, malformed declaration) fails closed with a deterministic
+  diagnostic. `mneme.audit/v1` unchanged.
+
 ### Fixed
 
 - P1.2 Architecture Audit tier semantics (ADR-023): intent is now judged

--- a/docs/adr/ADR-023-audit-tier-semantics-and-mneme-potential.md
+++ b/docs/adr/ADR-023-audit-tier-semantics-and-mneme-potential.md
@@ -1,0 +1,172 @@
+---
+id: ADR-023
+title: "Audit Tier Semantics and Mneme Potential"
+status: accepted
+priority: foundational
+date: 2026-09-11
+scope: audit.tier_semantics
+---
+
+# ADR-023: Audit Tier Semantics and Mneme Potential
+
+**Status:** Accepted
+**Date:** 2026-09-11
+**Deciders:** Theo Valmis
+
+---
+
+## Context
+
+The P1.2 Architecture Protection Audit (ADR-017 lineage, frozen in
+`docs/plans/p1-2-architecture-audit-redesign.md`) classified each decision
+into Protected / Mneme-ready / Requires modelling / Guidance from the
+*shape* of the record: a decision was protection-relevant only when its
+`anti_patterns` or `no X`-shaped `constraints` fields were populated. The
+decision text itself was never consulted for intent.
+
+The first real Design Partner diagnostic (sagarika29/ai-system-architect,
+"PASS WITH ISSUES") demonstrated two P0 defects:
+
+1. **Tier classification was overly dependent on record shape.**
+   Byte-identical architectural decision text changed tier from Guidance
+   to Requires Modelling when a structured constraint ("no empty
+   descriptions") was added. The tier therefore reflected which fields
+   happened to be populated rather than what the architectural decision
+   means.
+
+2. **"Identified Mneme Potential" was biased toward what the current rule
+   engine can trivially encode.** A low-value single-token anti-pattern
+   (`seamless`) became Mneme-ready via `FORBID_LITERAL`, while higher-value
+   architectural boundaries (reject invalid output contracts, reject blank
+   input, fail closed on invalid architecture output) could not become
+   Mneme-ready under the same narrow rule model and were excluded from the
+   metric entirely. The percentage could read as "architectural value
+   Mneme can protect" while actually meaning "records compatible with
+   current rule types".
+
+The enforcement loop itself (Audit → candidate rule → Protect → Validate →
+strict-mode refusal) worked correctly and must not be weakened.
+
+## Decision
+
+### Tier semantics
+
+The four tiers are redefined semantically (the audited unit is the
+*documented statement* — the decision text — plus its compiled
+enforcement material):
+
+- **PROTECTED** — a documented architectural decision for which Mneme has
+  deterministically linked evidence that the decision is currently
+  enforced: a typed `FORBID_LITERAL` rule, or external CI evidence whose
+  failure is deterministically linked to detecting the forbidden token.
+
+- **MNEME_READY** — a documented architectural decision that can be
+  represented faithfully by an existing Mneme rule type, with sufficient
+  scope/applicability information to activate it without inventing missing
+  architectural intent: an explicit literal prohibition (single-term
+  anti-pattern, single-term "no X" constraint, or an equivalently explicit
+  quoted term ban stated by the decision text).
+
+- **REQUIRES_MODELLING** — a documented architectural decision that
+  appears deterministically enforceable in principle, but Mneme does not
+  yet have an adequate rule type, sufficient structured scope, or another
+  required representation mechanism.
+
+- **GUIDANCE** — a documented statement that is primarily advisory,
+  explanatory, aspirational, preference-based, or inherently
+  judgment-dependent and should not currently be represented as
+  deterministic enforcement.
+
+### Intent classification (structure invariance)
+
+Intent (deterministic vs guidance) is judged from the decision text:
+
+- prescriptive language (obligation, requirement, prohibition — `must`,
+  `never`, `reject`, `fail closed`, `forbidden`, `enforce`, `validate`,
+  leading `No X` headlines) makes a decision protection-relevant
+  regardless of which structured fields are populated;
+- advisory language (`prefer`, `consider`, `should`, `can`, `where
+  practical`, `judgment`, `tradeoffs`) marks the statement guidance, and
+  no structured field can upgrade it;
+- structured prohibition fields remain documented enforcement material
+  for decisions whose text is not advisory, preserving the frozen
+  Mneme-ready guardrail derivation for every pre-existing record shape.
+
+**Invariant:** adding syntactic structure or a constraint field MUST NOT,
+by itself, change a decision from Guidance to Requires Modelling or
+Mneme-ready. Classification derives from the meaning/capability
+relationship, not record shape. Both classifiers are conservative:
+prescriptive markers never fire on advisory wording, absent markers
+default to guidance, and prose prohibitions that need interpretation are
+never literalized from text alone (no repository- or partner-specific
+vocabulary is special-cased).
+
+### Identified Mneme Potential
+
+```
+Identified Mneme Potential = (M + R) / PR × 100%
+```
+
+- **Numerator:** active decisions classified Mneme-ready (M) or Requires
+  Modelling (R) — decisions whose documented meaning is deterministically
+  enforceable in principle and not yet enforced.
+- **Denominator:** PR = Protected (P) + Mneme-ready (M) + Requires
+  Modelling (R) — active, protection-relevant decisions only. Guidance is
+  excluded from numerator and denominator.
+
+**Reading of the metric.** Under these definitions Identified Mneme
+Potential is the **unprotected deterministic opportunity**: it is
+numerically identical to the Protection Gap (`(M + R) / PR`) by
+construction, and the exact complement of Current Protection
+(`Potential = 100 − Current Protection`). It is NOT an independent second
+metric, and user-facing output must not present Current Protection and
+Identified Mneme Potential as two separate findings. The
+`identified_mneme_potential_pct` field is retained in `mneme.audit/v1`
+for compatibility. A future, genuinely distinct metric may express
+immediately protectable coverage as `(P + M) / PR`, with
+Requires-modelling reported as the product gap. No subjective
+"importance" weights are introduced.
+
+### Compatibility
+
+`mneme.audit/v1` is unchanged: same schema string, same summary fields,
+same per-decision fields. CLI, Protect behavior, enforcement/refusal
+semantics, and runtime enforcement (`assess_governability`, `check_prompt`)
+are unchanged. Classification remains deterministic for identical inputs.
+
+## Consequences
+
+- Deterministic architectural requirements with no structured fields no
+  longer fall to Guidance; they surface as Requires Modelling and enter
+  the protection-relevant denominator, so the audit honestly distinguishes
+  "deterministic but already protected" vs "deterministic and
+  representable now" vs "deterministic but requiring richer modelling" vs
+  "actual guidance".
+- A text-stated quoted term ban ("must not use the term `seamless`") is
+  now Mneme-ready and activatable without a structured field; the
+  proposed guardrail and the classification share the same derivation
+  (`_proposed_literal_tokens`).
+- Mneme's own audit summary changes for decisions whose text is
+  prescriptive but previously shape-classified as Guidance (for example
+  encoding enforcement); those records now report Requires Modelling.
+  Historical release-validation records (v0.7.0) are snapshots and are
+  not recomputed.
+- The Mneme Potential percentage rises on corpora containing
+  deterministic boundaries that today's rule model cannot yet encode;
+  that is the intended honest reading, with the M/R split and Current
+  Protection showing what is immediately actionable.
+- Known limitations remain: intent classification is a conservative
+  lexical model, not full semantic parsing; constraint-level decomposition
+  (one decision → multiple constraints) is still deferred; test-evidence
+  ingestion as a verified enforcement channel is the next planned P1 task
+  and is intentionally out of scope here.
+
+## Related
+
+- ADR-017: Enforcement Scope Is Independent of Retrieval Scope
+- ADR-019: Typed Literal Rule Contract
+- ADR-020: Explicit Path Applicability for Typed Rules
+- P1.2 redesign plan (original freeze):
+  `docs/plans/p1-2-architecture-audit-redesign.md`
+- Design Partner diagnostic repository (read-only fixture):
+  `sagarika29/ai-system-architect`

--- a/docs/adr/ADR-024-declared-test-evidence-ingestion.md
+++ b/docs/adr/ADR-024-declared-test-evidence-ingestion.md
@@ -43,6 +43,27 @@ scope: audit.test_evidence
 > figure (60%) is intentionally not preserved; under the corrected passive
 > model it reverts to 0% until trusted verification arrives. Safety is
 > more important than that number.
+>
+> **CI-evidence parsing/matching (2026-09-11, follow-up).** The parsing and
+> matching half of trusted verification is implemented as a library in
+> `mneme/evidence.py`: `parse_ci_evidence_document()` parses and validates a
+> machine-produced evidence document (schema `mneme.test-evidence/v1`
+> carrying `repository_sha`, a `producer` provenance object, and a list of
+> `{selector, outcome}` results), and `match_ci_evidence()` computes which
+> declared selectors a document **claims** to match when its SHA exactly
+> equals the audited repository HEAD, the selector is string-equal to an
+> unambiguous declaration, and the outcome is `passed`.
+>
+> **The document is an evidence carrier, not a trust root.** A matching
+> document yields the `matched_unverified` state (annotated
+> `test:ci-claim:<selector>@<sha>`), never `verified`. Producer metadata
+> contained inside the document is descriptive until Mneme authenticates it
+> against the external CI provider. The `verified` state is reserved for a
+> future authenticated CI-retrieval producer and is unreachable from the raw
+> document parameter, which is UNTRUSTED evidence material. Ordinary
+> `mneme audit` never supplies a document and never auto-discovers or
+> auto-trusts any repository file. The default Audit remains DECLARED-only;
+> no caller input can manufacture Protected.
 
 ## Context
 

--- a/docs/adr/ADR-024-declared-test-evidence-ingestion.md
+++ b/docs/adr/ADR-024-declared-test-evidence-ingestion.md
@@ -1,0 +1,215 @@
+---
+id: ADR-024
+title: "Declared Test-Evidence Ingestion for the Architecture Audit"
+status: accepted
+priority: normal
+date: 2026-09-11
+scope: audit.test_evidence
+---
+
+# ADR-024: Declared Test-Evidence Ingestion for the Architecture Audit
+
+**Status:** Accepted
+**Date:** 2026-09-11
+**Deciders:** Theo Valmis
+
+---
+
+> **Security amendment (2026-09-11, pre-commit review).** The first draft of
+> this ADR had `mneme audit` execute the linked test itself
+> (`python -m pytest <selector>` inside the audited repository). Pytest
+> invocation is **arbitrary repository-code execution**: conftest.py files,
+> collection hooks, plugins, fixtures, imports, and test bodies all run
+> inside the audit's subprocess, so an audited repository could execute
+> attacker- or author-controlled code during a routine read-only audit.
+> The mitigations in that draft (`PYTHONDONTWRITEBYTECODE`,
+> `no:cacheprovider`, selector validation, SHA pinning, `cwd` pinning,
+> timeout) contain side effects but do NOT contain execution.
+>
+> This amendment makes **default Architecture Audit passive**:
+>
+> **Architecture Audit does not execute code from the audited repository
+> unless the user explicitly requests an execution-capable verification
+> mode.**
+>
+> Ordinary `mneme audit` never invokes pytest or any other repository-code
+> runner. The decision→test declaration model, SHA pinning, deterministic
+> linkage, ambiguity handling, and tier semantics are preserved unchanged;
+> what changed is that a merely **declared** linkage annotates but never
+> protects, and the VERIFIED state now requires a trusted verification
+> producer (CI-produced exact-SHA + exact-selector ingestion — the next
+> task). Local test execution is an explicit, separately opt-in future
+> capability, not part of Audit. The draft's Sagarika Current-Protection
+> figure (60%) is intentionally not preserved; under the corrected passive
+> model it reverts to 0% until trusted verification arrives. Safety is
+> more important than that number.
+
+## Context
+
+The first real Design Partner diagnostic (sagarika29/ai-system-architect)
+revealed that the target repository already contains deterministic tests
+enforcing several of its documented architectural boundaries — blank-input
+rejection, invalid-output rejection, API call-parameter assertions,
+invalid-enum rejection, approved-stack cleanup — yet Mneme classified the
+corresponding decisions as Requires Modelling. There was no deterministic
+channel linking test evidence to architectural intent, so the Audit asked
+only "what can Mneme itself enforce?" instead of the more valuable
+question: "which architectural decisions are actually protected in this
+system, regardless of which deterministic mechanism provides that
+protection?"
+
+ADR-023 fixed tier semantics (intent from decision text, not record
+shape) but left the protection-evidence channels at exactly two: typed
+`FORBID_LITERAL` rules and verified CI linkage on literalizable tokens.
+
+## Decision
+
+### Declaration home
+
+Test-evidence declarations live on the **decision record** in
+`project_memory.json`, as an optional per-decision field:
+
+```json
+"test_evidence": [
+  {"selector": "tests/test_validation.py::test_empty_input_rejected",
+   "sha": "<40-char repository SHA>"}
+]
+```
+
+`sha` is optional; when present it pins the repository SHA the evidence
+was established for. This is the smallest clean extension consistent with
+Mneme's architecture: decisions already carry `rules` on the same record,
+protection activation mutates that same file, and declarations follow the
+ADR-019 trust model — **explicit, human-authored directives, never
+inferred**. Alternatives rejected: ADR frontmatter (covers only ADR-sourced
+decisions; Design Partner boundary decisions are not ADRs — documented
+follow-up), and a separate evidence-manifest file (a new file format and
+discovery path for no additional determinism). No CLI command is added in
+M0; declarations are policy, authored deliberately.
+
+### Evidence contract
+
+The audited chain is exactly:
+
+```
+Decision → stable decision identifier → declared test evidence
+        → test selector / assertion target → verified execution result
+        → protection evidence
+```
+
+A test MUST NOT count as protection merely because its filename resembles
+a decision, test text contains similar words, an LLM believes it
+corresponds, the suite passes globally, or code coverage includes
+relevant code. Mneme performs no fuzzy semantic matching: the linkage is
+the declaration; verification establishes that the declared test passed
+against the exact repository SHA, from a trusted provenance source.
+
+**Declaration is not verification.** Declaring a linkage (the decision
+record asserting "this test enforces this decision") is one act;
+supplying verification evidence ("this exact selector passed at this
+exact SHA, established by a trusted source") is a different one. Only the
+second can establish protection.
+
+### Verification (M0) — passive
+
+Ordinary `mneme audit` executes **no repository-controlled code** — no
+pytest, no conftest, no plugins, no test bodies. Declared evidence is
+validated passively, in order —
+
+1. the selector is well-formed (repository-relative pytest node id, no
+   whitespace, at least one `::` separator, no drive letter, no leading
+   slash, no `..` escape);
+2. the mapping is unambiguous (the same selector declared by two or more
+   decisions protects neither);
+3. the repository HEAD SHA is available, the declared SHA pin (if any)
+   matches HEAD exactly, and the selector's file exists inside the
+   repository.
+
+A linkage that passes all passive checks reaches the **DECLARED** state:
+it is recorded as `test:declared:<selector>` in the decision's evidence
+sources and never moves a decision out of Requires Modelling or Guidance.
+
+The **VERIFIED** state — "the exact selector passed against the exact
+repository SHA, and the provenance of that result is trusted" — has **no
+producer in M0**. Introducing it requires a trustworthy verification
+source; the intended one is CI-produced evidence (test results already
+generated by the organization's own CI for the exact SHA + selector),
+which is the next task. Local execution of the linked test is an explicit,
+separately opt-in future capability and is never performed implicitly.
+
+### Protection semantics
+
+- A **deterministic** decision (ADR-023: prescriptive text, or documented
+  enforcement fields with non-advisory text) with **trusted verified**
+  test evidence is **Protected**: `evidence_confidence: "verified"`,
+  evidence sources `test:verified:<selector>@<sha>`. M0 has no trusted
+  verification producer, so no decision reaches Protected through test
+  evidence in this commit.
+- A **declared** linkage annotates `evidence_sources` as
+  `test:declared:<selector>` but classification keeps Requires Modelling
+  (deterministic intent) or Guidance (advisory intent).
+- A **Guidance** decision is never upgraded — declared evidence or not
+  (intent classification is evidence-independent).
+- A Requires-modelling decision with declared but unverified evidence
+  remains Requires Modelling.
+
+### Failure behaviour (fail closed)
+
+| Condition | Result |
+|---|---|
+| Declared selector malformed | diagnostic `malformed-selector`; no protection |
+| Selector declared by multiple decisions | diagnostic `ambiguous-mapping`; neither protected |
+| Repository SHA unavailable | diagnostic `sha-unavailable`; no protection |
+| Declared SHA ≠ HEAD | diagnostic `stale` (`sha-mismatch`); no protection |
+| Selector file missing | diagnostic `selector-not-found`; no protection |
+| Declared linkage without trusted verification | state `declared`; never protects |
+| Advisory decision + declared evidence | remains Guidance |
+| Declared but unverified evidence | tier unchanged |
+
+Evidence failure never silently upgrades protection, and passive Audit
+never executes audited-repository code.
+
+### Audit output
+
+`mneme.audit/v1` is unchanged. Declared test evidence appears in the
+existing per-decision `evidence_sources` list as
+`test:declared:<selector>` (with the pinned SHA when present), and the
+CLI prints it under `evidence:` — selector and pin with no runner noise
+and no execution. Failure and staleness diagnostics appear as
+`test:<state>:<selector>@<code-or-sha>` so the audit always answers why a
+declared linkage did not establish protection.
+
+## Consequences
+
+- Mneme now has a deterministic representation for test-backed
+  protection: a decision can declare which test enforces it, and Audit
+  reports that linkage with its validation state.
+- Under the corrected passive model, a **declared** linkage annotates but
+  never protects: the Sagarika corpus reverts to Requires Modelling for
+  its deterministic boundaries (Current Protection 0%) until trusted
+  verification arrives. Reported honestly; safety outranks the number.
+- The **VERIFIED** state requires a trusted provenance source. The
+  intended producer is CI-produced test results for the exact SHA +
+  selector (the next task): it avoids executing untrusted code inside
+  Audit and reuses tests organizations already run. Local execution of
+  the linked test is an explicit, separately opt-in future capability
+  and is never performed implicitly by Audit.
+- False protection is guarded on all sides: linkage is never inferred
+  (no fuzzy matching, no filename/name similarity, no LLM judgment), the
+  suite passing globally or coverage counting proves nothing, and the
+  declaration alone is never protection.
+- Declaring evidence is deliberate repository-governance work; an audit
+  without repository context (`--repo-root` omitted) validates nothing.
+- Passive Audit validates declarations without executing anything:
+  declaration validation scales linearly with declared evidence entries;
+  no repository test execution occurs.
+- CI-produced verification ingestion, ADR-frontmatter declarations,
+  sandboxed local verification, and additional runner ecosystems are
+  documented follow-up work.
+
+## Related
+
+- ADR-019: Typed Literal Rule Contract (explicit-directive trust model)
+- ADR-023: Audit Tier Semantics and Mneme Potential
+- Design Partner diagnostic repository (read-only fixture):
+  `sagarika29/ai-system-architect`

--- a/docs/adr/ADR-024-declared-test-evidence-ingestion.md
+++ b/docs/adr/ADR-024-declared-test-evidence-ingestion.md
@@ -64,6 +64,42 @@ scope: audit.test_evidence
 > `mneme audit` never supplies a document and never auto-discovers or
 > auto-trusts any repository file. The default Audit remains DECLARED-only;
 > no caller input can manufacture Protected.
+>
+> **Authenticated GitHub Actions CI claim (2026-09-11, follow-up).** The
+> authenticated retrieval path is implemented in `mneme/github_evidence.py`.
+> `verify_github_run()` authenticates a workflow run and its evidence
+> artifact through the GitHub REST API (trust root = `Authorization: Bearer
+> <GITHUB_TOKEN>`; external to `project_memory.json`, the carrier, repository
+> files, and caller-authored producer metadata).
+>
+> The authenticated chain validates, fail-closed, that (1) a token is
+> present; (2) the audited repository identity resolves from the origin
+> remote; (3) the run exists and belongs to exactly that repository; (4) the
+> run's `head_sha` equals the audited HEAD exactly; (5) a non-expired
+> artifact named `mneme-test-results` exists; (6) the artifact downloads
+> (with the bearer token never forwarded to the signed redirect host), parses
+> as `mneme.test-evidence/v1`, and its `repository_sha` equals the run
+> `head_sha`. Selector results are matched exactly (`outcome == passed`).
+>
+> **Authenticated artifact provenance is not execution proof.** The artifact
+> content is still produced by repository-controlled workflow code, so a
+> workflow could upload `{"outcome": "passed"}` without running the test.
+> Therefore the authenticated result is the `authenticated_ci_claim` state
+> (annotated `test:ci-authenticated:<selector>@<sha>`), NOT `verified`, and it
+> never reaches Protected. `verified` remains reserved for a future trusted
+> producer — a Mneme-controlled verifier pinned to an approved immutable
+> version whose output the repository cannot forge.
+>
+> **Trust boundary.** No public API accepts a trust-bearing parameter:
+> `assess_protection` and `generate_protection_report` take only the
+> declaration/carrier inputs and never construct `verified`. The
+> authenticated result flows only through the internal, private
+> `_verify_test_evidence(..., authenticated_claim=...)` seam, reached solely
+> by `audit_with_github_claim()`, which is the one supported public
+> authenticated operation and stops at `authenticated_ci_claim`. Default
+> `mneme audit` remains offline and never calls GitHub. (Python code in the
+> same process can always monkeypatch internals; the guarantee is that the
+> supported public API cannot self-certify protection.)
 
 ## Context
 

--- a/docs/adr/ADR-025-trusted-test-execution-attestation.md
+++ b/docs/adr/ADR-025-trusted-test-execution-attestation.md
@@ -1,0 +1,151 @@
+---
+id: ADR-025
+title: "Trusted Test-Execution Attestation (Deferred)"
+status: proposed
+priority: normal
+date: 2026-09-11
+scope: audit.test_evidence
+---
+
+# ADR-025: Trusted Test-Execution Attestation (Deferred)
+
+**Status:** Proposed
+**Date:** 2026-09-11
+**Deciders:** Theo Valmis
+
+---
+
+## Context
+
+ADR-024 established four test-evidence states: `declared`, `matched_unverified`,
+`authenticated_ci_claim`, and a reserved `verified`. The `authenticated_ci_claim`
+state — reached through the authenticated GitHub API — proves the repository,
+the workflow run, the exact run SHA, and that the evidence artifact belongs to
+that run. It deliberately does **not** prove that a test executed: the artifact
+*content* is still produced by repository-controlled workflow code, which can
+upload `{"outcome": "passed"}` without running the test. Therefore
+`authenticated_ci_claim` never reaches Protected, and `verified` remains
+unreachable.
+
+This ADR records the design for the first **trusted execution-attestation
+producer** — the step that would take an authenticated CI claim to `verified`
+and thereby to Protected — and records the decision to **defer** it.
+
+## Threat model
+
+An adversarial or mistaken repository (its workflow code is fully
+repository-controlled) can attempt:
+
+| # | Attack | Boundary required |
+|---|---|---|
+| 1 | Upload a fake `mneme-test-results` JSON claiming "passed" | evidence must be signed by a key the repository does not hold |
+| 2 | Invoke the trusted verifier, then replace/modify its artifact | artifact content must be digest-bound to the signed evidence |
+| 3 | Run a different test but claim the declared selector | the signed evidence must bind the exact selector |
+| 4 | Fabricate "passed" after pytest actually failed | the outcome must derive from the verifier's own test-process exit code, not a workflow input |
+| 5 | Copy valid evidence from another SHA | evidence must bind the exact repository SHA |
+| 6 | Copy valid evidence from another repository | evidence must bind the repository identity |
+| 7 | Copy valid evidence for another selector | evidence must bind the exact selector |
+| 8 | A compromised workflow step forges verifier output | the signing identity must be one the workflow cannot impersonate |
+
+The common requirement: evidence whose **authenticity and integrity cannot be
+manufactured by ordinary repository workflow code**.
+
+## Evaluated trust options
+
+1. **GitHub Artifact Attestations (Sigstore/SLSA provenance)** — `actions/attest-build-provenance`
+   (or the `attest` command) produces a signed DSSE attestation bundle. The
+   signing identity is a GitHub Sigstore certificate whose SAN encodes the
+   workflow OIDC identity; the statement subject is the artifact SHA-256 digest.
+   Fetchable via `GET /repos/{owner}/{repo}/attestations/{digest}`. Verifying the
+   signature requires `sigstore-python` (or `gh attestation verify`).
+2. **GitHub OIDC tokens** — a workflow can mint a JWT (`id-token: write`) whose
+   `sub`/`sha`/`workflow_ref` claims are GitHub-authoritative, verifiable against
+   GitHub's OIDC JWKS. This proves *which repository's workflow ran*, but not
+   *that a trusted verifier executed the test*: the repository's own workflow is
+   the subject.
+3. **Mneme-hosted signing service** — a backend the audited repository cannot
+   reach/impersonate, holding a Mneme signing key. Correct but not GitHub-native;
+   deferred as it requires a Mneme backend.
+4. **Trusted reusable workflow identity** — a Mneme-controlled reusable workflow
+   (e.g. `mnemehq/verify-tests`), pinned to an immutable tag/SHA, invoked by the
+   audited repository via `uses:`. Its OIDC identity (`https://github.com/mnemehq/verify-tests/.github/workflows/verify.yml@refs/tags/v1`)
+   is minted by GitHub for the *reusable workflow's* job — an identity the
+   calling repository cannot impersonate or modify (the workflow code is Mneme's,
+   pinned immutable).
+
+**Selected mechanism (M0, deferred):** GitHub Artifact Attestations **over a
+Mneme-controlled reusable workflow** (options 1 + 4). The audited repository can
+invoke the verifier but cannot forge its OIDC identity, cannot obtain its signing
+identity, and cannot modify the pinned immutable workflow code. This is the same
+trust model used by `slsa-github-generator` and trusted-publisher workflows.
+
+## Why repository workflow code cannot forge it
+
+- The repository cannot mint an attestation with the verifier's OIDC identity:
+  the OIDC token for the reusable workflow's job is issued by GitHub for
+  `mnemehq/verify-tests`, not for the caller.
+- The repository cannot alter an attested artifact's content without invalidating
+  the digest-bound signature (subject = SHA-256 of the artifact; any byte change
+  breaks the signature).
+- The repository cannot inject `outcome: passed`: the verifier derives the
+  outcome from the test process's actual exit status, and the attestation binds
+  that outcome; the workflow has no input channel that writes the outcome.
+- Replay (attacks 5–7) is blocked because the predicate/subject binds the exact
+  repository, SHA, and selector.
+
+## Verification procedure (future)
+
+```
+explicit verification operation
+  → authenticated run + artifact (existing authenticated_ci_claim chain)
+  → download artifact, compute SHA-256 digest
+  → GET /repos/{owner}/{repo}/attestations/{digest}
+  → verify DSSE/Sigstore signature (sigstore-python or gh attestation verify)
+  → verify certificate SAN == pinned verifier workflow identity
+  → verify subject digest == downloaded artifact digest
+  → verify predicate binds repository == audited remote, SHA == audited HEAD,
+    selector == exact declared selector, outcome == passed (from test exit)
+  → private trusted internal result → STATE_VERIFIED → Protected
+```
+
+The verifier identity and its pinned immutable version are **configuration**,
+not derived from the audited repository. Without a configured trusted verifier
+(and a real cryptographic verifier), the `verified` state is unreachable.
+
+## Decision
+
+**Deferred until a real pilot/customer requirement justifies it.** The trusted
+execution-attestation producer is not implemented in M0 and is not scheduled as
+the next milestone. It requires two capabilities that do not exist in the
+repository and cannot be fabricated here: (1) a published Mneme-controlled
+reusable workflow (the trusted issuer identity), and (2) a cryptographic
+attestation verifier (`sigstore-python` or `gh attestation verify`).
+Implementing the structural checks alone — without the cryptographic signature
+verification — would create a forgeable "verified" path, which is worse than
+leaving `verified` unreachable.
+
+Until then:
+
+- `verified` remains unreachable through test evidence;
+- `authenticated_ci_claim` remains the strongest reachable test-evidence state
+  and never reaches Protected;
+- `mneme audit` remains offline and passive;
+- no public API accepts a trust-bearing parameter, and no repository JSON field
+  can create trust.
+
+## Consequences
+
+- Protected via test evidence is intentionally not yet achievable; that is
+  honest and correct.
+- This design is **deferred until a real pilot/customer requirement justifies
+  it** — it is not scheduled work and not a next milestone. If and when it is
+  needed, the shape is a GitHub-native trusted verifier (a Mneme-controlled
+  reusable workflow) plus `gh attestation verify`/`sigstore-python` verification
+  gated behind a configured trusted-workflow identity, producing `verified`
+  only on successful cryptographic verification.
+
+## Related
+
+- ADR-024: Declared Test-Evidence Ingestion for the Architecture Audit
+- GitHub Artifact Attestations / SLSA provenance (`actions/attest-build-provenance`)
+- GitHub OIDC identity for reusable workflows

--- a/docs/plans/p1-2-architecture-audit-redesign.md
+++ b/docs/plans/p1-2-architecture-audit-redesign.md
@@ -1,5 +1,16 @@
 # P1.2 Architecture Audit Redesign — Design Document
 
+> **Amendment (2026-09-11, ADR-023):** after the first Design Partner
+> diagnostic exposed that tier classification depended on record shape
+> (byte-identical decision text changed tier when a structured constraint
+> was added) and that Identified Mneme Potential counted only records
+> immediately expressible by existing rule types, the tier semantics and
+> the Potential formula were amended. Tier intent is now judged from the
+> decision text (prescriptive vs advisory); Potential =
+> (Mneme-ready + Requires modelling) / protection-relevant. See
+> `docs/adr/ADR-023-audit-tier-semantics-and-mneme-potential.md`. The
+> sections below record the original P1.2 freeze.
+
 ## Executive Summary
 
 The current Architecture Audit reports a single "Coverage" percentage (~5% on Mneme repo) that counts all ADRs, agent instructions, and config evidence in one denominator but only credits directly compilable Mneme rules. This makes well-governed repositories appear almost completely ungoverned.

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -845,10 +845,27 @@ def propose_literal_rule(decision: "Decision") -> "Rule | None":
 def assess_protection(
     decision: "Decision",
     repo_root: str | Path | None = None,
-    test_evidence_results: "dict[str, list] | None" = None,
-    ci_evidence_document: str | None = None,
 ) -> ProtectionDecisionReport:
     """Assess one Decision's P1.2 protection state.
+
+    Public entry point. It accepts NO trust-bearing parameter: it classifies
+    from the decision's typed rules, the existing CI-enforcement evidence
+    scan, and the passively validated (declared) test evidence only. No
+    caller can inject a value that reaches the ``verified`` test-evidence
+    state through this API.
+    """
+    return _assess_protection(decision, repo_root, None)
+
+
+def _assess_protection(
+    decision: "Decision",
+    repo_root: str | Path | None,
+    test_evidence_results: "dict[str, list] | None",
+) -> ProtectionDecisionReport:
+    """Internal assessment. ``test_evidence_results`` carries pre-computed
+    corpus-level validation records and must never be exposed publicly: it is
+    the only seam that can carry the ``verified`` state, and only the
+    authenticated GitHub component supplies it.
 
     Tier resolution order (highest wins):
 
@@ -874,14 +891,10 @@ def assess_protection(
     validated inline for this decision when a repository root is given.
     Ordinary Audit never executes repository-controlled code: a merely
     declared entry annotates ``evidence_sources`` as
-    ``test:declared:<selector>`` and never upgrades a tier.
-
-    ``ci_evidence_document``, when supplied, is UNTRUSTED evidence material:
-    it may at most produce a matching CI *claim* (annotated as
-    ``test:ci-claim:<selector>@<sha>``), never the ``verified`` state. Only
-    an authenticated verification producer (not yet present in M0) may
-    produce ``verified`` and thereby upgrade a deterministic decision to
-    Protected; advisory decisions are never upgraded by any channel.
+    ``test:declared:<selector>`` and never upgrades a tier. Only an
+    authenticated verification producer (not yet present in M0) may produce
+    ``verified`` and thereby upgrade a deterministic decision to Protected;
+    advisory decisions are never upgraded by any channel.
     """
     literal_rules = [
         rule for rule in decision.rules if rule.type == "FORBID_LITERAL"
@@ -927,17 +940,14 @@ def assess_protection(
     # Declared test evidence (ADR-024), passively validated once per corpus
     # by the aggregate report; single-decision callers validate inline.
     # PASSIVE-AUDIT INVARIANT: no repository-controlled code is executed —
-    # no pytest, no conftest, no plugins. A caller-supplied
-    # ``ci_evidence_document`` is UNTRUSTED material and yields at most a
-    # matching claim (state "matched_unverified"); only an authenticated
-    # producer (none exists in M0) may carry the "verified" state, which is
-    # the only test-evidence state this function upgrades to protected.
+    # no pytest, no conftest, no plugins. The public path can only produce
+    # "declared"/"matched_unverified"/"authenticated_ci_claim"; only the
+    # authenticated producer (none in M0) may carry "verified", which is the
+    # only test-evidence state upgraded to protected.
     if repo_root is not None and test_evidence_results is None:
         from mneme.evidence import verify_test_evidence
 
-        test_evidence_results = verify_test_evidence(
-            [decision], repo_root, ci_evidence_document=ci_evidence_document,
-        )
+        test_evidence_results = verify_test_evidence([decision], repo_root)
     test_sources: list[str] = []
     verified_by_test = False
     if test_evidence_results:
@@ -984,16 +994,14 @@ def generate_protection_report(
 ) -> ArchitectureProtectionReport:
     """Assess a corpus and aggregate the P1.2 summary.
 
+    Public entry point. It accepts NO trust-bearing parameter: test evidence
+    is passively validated (declared / matched claim only); the ``verified``
+    state is unreachable here. ``ci_evidence_document``, when supplied, is
+    UNTRUSTED material and can at most produce a matching CI claim.
+
     Only active decisions count toward any tier or the protection-relevant
     denominator; superseded and deprecated decisions appear in ``decisions``
     for provenance but are excluded from all counts.
-
-    Declared test evidence (ADR-024) is validated once for the whole corpus
-    — enabling cross-decision ambiguity checks — and passed into every
-    per-decision assessment. ``ci_evidence_document``, when supplied by an
-    explicit caller, is UNTRUSTED evidence material: it yields at most a
-    matching CI claim (never the ``verified`` state), so it can never
-    upgrade a tier. Ordinary ``mneme audit`` never supplies it.
     """
     test_evidence_results = None
     if repo_root is not None:
@@ -1002,12 +1010,22 @@ def generate_protection_report(
         test_evidence_results = verify_test_evidence(
             decisions, repo_root, ci_evidence_document=ci_evidence_document,
         )
+    return _build_report(decisions, repo_root, test_evidence_results)
+
+
+def _build_report(
+    decisions: list["Decision"],
+    repo_root: str | Path | None,
+    test_evidence_results: "dict[str, list] | None",
+) -> ArchitectureProtectionReport:
+    """Internal aggregation over pre-computed verification results.
+
+    ``test_evidence_results`` may carry the ``verified`` state and is only
+    ever supplied by the authenticated GitHub component; it must never be
+    exposed on a public API.
+    """
     reports = [
-        assess_protection(
-            decision,
-            repo_root=repo_root,
-            test_evidence_results=test_evidence_results,
-        )
+        _assess_protection(decision, repo_root, test_evidence_results)
         for decision in decisions
     ]
     active = [r for r in reports if r.status == "active"]

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -846,6 +846,7 @@ def assess_protection(
     decision: "Decision",
     repo_root: str | Path | None = None,
     test_evidence_results: "dict[str, list] | None" = None,
+    ci_evidence_document: str | None = None,
 ) -> ProtectionDecisionReport:
     """Assess one Decision's P1.2 protection state.
 
@@ -855,7 +856,7 @@ def assess_protection(
       2. verified external CI evidence on a literalizable token -> protected
       3. trusted verified test evidence on a deterministic decision
          -> protected (ADR-024; no trusted verification producer exists
-         in M0, so declared evidence annotates only)
+         in M0, so a merely declared or merely matched claim never protects)
       4. remaining deterministic intent -> mneme_ready or
          requires_modelling
       5. advisory or otherwise non-deterministic statement -> guidance
@@ -873,9 +874,14 @@ def assess_protection(
     validated inline for this decision when a repository root is given.
     Ordinary Audit never executes repository-controlled code: a merely
     declared entry annotates ``evidence_sources`` as
-    ``test:declared:<selector>`` and never upgrades a tier; only a trusted
-    verification producer (CI-produced exact-SHA + exact-selector result)
-    may establish protection, and advisory decisions are never upgraded.
+    ``test:declared:<selector>`` and never upgrades a tier.
+
+    ``ci_evidence_document``, when supplied, is UNTRUSTED evidence material:
+    it may at most produce a matching CI *claim* (annotated as
+    ``test:ci-claim:<selector>@<sha>``), never the ``verified`` state. Only
+    an authenticated verification producer (not yet present in M0) may
+    produce ``verified`` and thereby upgrade a deterministic decision to
+    Protected; advisory decisions are never upgraded by any channel.
     """
     literal_rules = [
         rule for rule in decision.rules if rule.type == "FORBID_LITERAL"
@@ -921,12 +927,17 @@ def assess_protection(
     # Declared test evidence (ADR-024), passively validated once per corpus
     # by the aggregate report; single-decision callers validate inline.
     # PASSIVE-AUDIT INVARIANT: no repository-controlled code is executed —
-    # no pytest, no conftest, no plugins. Only a trusted verification
-    # producer (none exists in M0) may carry the VERIFIED state.
+    # no pytest, no conftest, no plugins. A caller-supplied
+    # ``ci_evidence_document`` is UNTRUSTED material and yields at most a
+    # matching claim (state "matched_unverified"); only an authenticated
+    # producer (none exists in M0) may carry the "verified" state, which is
+    # the only test-evidence state this function upgrades to protected.
     if repo_root is not None and test_evidence_results is None:
         from mneme.evidence import verify_test_evidence
 
-        test_evidence_results = verify_test_evidence([decision], repo_root)
+        test_evidence_results = verify_test_evidence(
+            [decision], repo_root, ci_evidence_document=ci_evidence_document,
+        )
     test_sources: list[str] = []
     verified_by_test = False
     if test_evidence_results:
@@ -969,6 +980,7 @@ def assess_protection(
 def generate_protection_report(
     decisions: list["Decision"],
     repo_root: str | Path | None = None,
+    ci_evidence_document: str | None = None,
 ) -> ArchitectureProtectionReport:
     """Assess a corpus and aggregate the P1.2 summary.
 
@@ -976,15 +988,20 @@ def generate_protection_report(
     denominator; superseded and deprecated decisions appear in ``decisions``
     for provenance but are excluded from all counts.
 
-    Declared test evidence (ADR-024) is verified once for the whole corpus
+    Declared test evidence (ADR-024) is validated once for the whole corpus
     — enabling cross-decision ambiguity checks — and passed into every
-    per-decision assessment.
+    per-decision assessment. ``ci_evidence_document``, when supplied by an
+    explicit caller, is UNTRUSTED evidence material: it yields at most a
+    matching CI claim (never the ``verified`` state), so it can never
+    upgrade a tier. Ordinary ``mneme audit`` never supplies it.
     """
     test_evidence_results = None
     if repo_root is not None:
         from mneme.evidence import verify_test_evidence
 
-        test_evidence_results = verify_test_evidence(decisions, repo_root)
+        test_evidence_results = verify_test_evidence(
+            decisions, repo_root, ci_evidence_document=ci_evidence_document,
+        )
     reports = [
         assess_protection(
             decision,

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -469,21 +469,42 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
 #                      currently be represented as deterministic
 #                      enforcement.
 #
-# Semantic invariants (ADR-023):
+# Protection-evidence channels (deterministically linked evidence that the
+# decision is currently enforced):
+#   1. typed FORBID_LITERAL rule on the decision record;
+#   2. verified external CI evidence on a literalizable token
+#      (failure deterministically linked to detecting the token);
+#   3. declared test evidence (ADR-024, PASSIVE): an explicit, human-
+#      authored ``test_evidence`` declaration on the decision record.
+#      Ordinary Audit validates declarations passively — selector
+#      well-formedness, cross-decision ambiguity, SHA-pin staleness, and
+#      test-file existence — and annotates them as
+#      ``test:declared:<selector>``. A merely declared entry NEVER
+#      protects: pytest invocation is arbitrary repository-code execution,
+#      so Audit executes no repository-controlled code. The VERIFIED
+#      state requires a trusted producer (CI-produced exact-SHA +
+#      exact-selector ingestion — the next task).
+#
+# Semantic invariants (ADR-023, extended by ADR-024):
 #   - Structure invariance: adding syntactic structure or a constraint
 #     field MUST NOT, by itself, move a decision out of guidance. Intent is
 #     judged from the decision text (prescriptive vs advisory language);
 #     structured prohibition fields carry documented enforcement material
 #     only for decisions whose text is not advisory.
-#   - Guidance is evidence-independent: external enforcement-like evidence
-#     never upgrades a guidance decision.
+#   - Guidance is evidence-independent: no enforcement-like evidence —
+#     CI, test, or otherwise — ever upgrades a guidance decision.
 #   - Guidance decisions never enter the protection-relevant denominator.
 #   - mneme_ready always carries an explicit FORBID_LITERAL guardrail
 #     description; a decision cannot be mneme_ready without one.
 #   - Candidate external evidence (token mentioned in CI without failure
 #     semantics) annotates but never upgrades a tier by itself.
+#   - Test evidence protects only through a trusted verification producer
+#     (ADR-024): declared evidence annotates but never protects, and
+#     ordinary Audit executes no repository-controlled code — no pytest,
+#     no conftest, no plugins, no test bodies (passive-Audit invariant).
 #   - Deterministic output for identical inputs: classification is a pure
-#     function of the decision record and repository files.
+#     function of the decision record, the declared evidence, and
+#     repository files.
 
 AUDIT_SCHEMA = "mneme.audit/v1"
 
@@ -824,6 +845,7 @@ def propose_literal_rule(decision: "Decision") -> "Rule | None":
 def assess_protection(
     decision: "Decision",
     repo_root: str | Path | None = None,
+    test_evidence_results: "dict[str, list] | None" = None,
 ) -> ProtectionDecisionReport:
     """Assess one Decision's P1.2 protection state.
 
@@ -831,10 +853,11 @@ def assess_protection(
 
       1. typed FORBID_LITERAL rule  -> protected (verified enforcement)
       2. verified external CI evidence on a literalizable token -> protected
-      3. deterministic intent representable by an existing rule type
-         with sufficient scope -> mneme_ready with an explicit
-         FORBID_LITERAL guardrail
-      4. remaining deterministic intent -> requires_modelling
+      3. trusted verified test evidence on a deterministic decision
+         -> protected (ADR-024; no trusted verification producer exists
+         in M0, so declared evidence annotates only)
+      4. remaining deterministic intent -> mneme_ready or
+         requires_modelling
       5. advisory or otherwise non-deterministic statement -> guidance
          (evidence-independent)
 
@@ -844,6 +867,15 @@ def assess_protection(
     invariant). Structured prohibition fields still supply the concrete
     guardrail derivation, and they keep non-advisory decisions
     protection-relevant exactly as in the frozen P1.2 model.
+
+    Test evidence (ADR-024) arrives passively validated in
+    ``test_evidence_results`` (decision id -> verification records) or is
+    validated inline for this decision when a repository root is given.
+    Ordinary Audit never executes repository-controlled code: a merely
+    declared entry annotates ``evidence_sources`` as
+    ``test:declared:<selector>`` and never upgrades a tier; only a trusted
+    verification producer (CI-produced exact-SHA + exact-selector result)
+    may establish protection, and advisory decisions are never upgraded.
     """
     literal_rules = [
         rule for rule in decision.rules if rule.type == "FORBID_LITERAL"
@@ -886,6 +918,26 @@ def assess_protection(
             evidence_sources=[],
         )
 
+    # Declared test evidence (ADR-024), passively validated once per corpus
+    # by the aggregate report; single-decision callers validate inline.
+    # PASSIVE-AUDIT INVARIANT: no repository-controlled code is executed —
+    # no pytest, no conftest, no plugins. Only a trusted verification
+    # producer (none exists in M0) may carry the VERIFIED state.
+    if repo_root is not None and test_evidence_results is None:
+        from mneme.evidence import verify_test_evidence
+
+        test_evidence_results = verify_test_evidence([decision], repo_root)
+    test_sources: list[str] = []
+    verified_by_test = False
+    if test_evidence_results:
+        from mneme.evidence import evidence_source_strings
+
+        verifications = test_evidence_results.get(decision.id, [])
+        test_sources = evidence_source_strings(verifications)
+        verified_by_test = any(
+            v.state == "verified" for v in verifications
+        )
+
     tokens = _proposed_literal_tokens(decision)
     tier: ProtectionTier = "mneme_ready" if tokens else "requires_modelling"
     proposed_guardrail = f"FORBID_LITERAL: {tokens[0]}" if tokens else None
@@ -898,6 +950,10 @@ def assess_protection(
         if evidence_confidence == "verified":
             tier = "protected"
 
+    if verified_by_test:
+        tier = "protected"
+        evidence_confidence = "verified"
+
     return ProtectionDecisionReport(
         id=decision.id,
         decision=decision.decision,
@@ -906,7 +962,7 @@ def assess_protection(
         protection_tier=tier,
         mneme_guardrail=proposed_guardrail,
         evidence_confidence=evidence_confidence,
-        evidence_sources=evidence_sources,
+        evidence_sources=[*test_sources, *evidence_sources],
     )
 
 
@@ -919,9 +975,22 @@ def generate_protection_report(
     Only active decisions count toward any tier or the protection-relevant
     denominator; superseded and deprecated decisions appear in ``decisions``
     for provenance but are excluded from all counts.
+
+    Declared test evidence (ADR-024) is verified once for the whole corpus
+    — enabling cross-decision ambiguity checks — and passed into every
+    per-decision assessment.
     """
+    test_evidence_results = None
+    if repo_root is not None:
+        from mneme.evidence import verify_test_evidence
+
+        test_evidence_results = verify_test_evidence(decisions, repo_root)
     reports = [
-        assess_protection(decision, repo_root=repo_root)
+        assess_protection(
+            decision,
+            repo_root=repo_root,
+            test_evidence_results=test_evidence_results,
+        )
         for decision in decisions
     ]
     active = [r for r in reports if r.status == "active"]

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -441,20 +441,40 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
 # enforce this today?"; the P1.2 audit asks "how much of this repository's
 # deterministic architectural intent is already protected, and what remains?".
 #
-# Frozen tier contract (docs/plans/p1-2-architecture-audit-redesign.md):
-#   protected          deterministic intent WITH verified enforcement — a
-#                      typed FORBID_LITERAL rule, or external CI evidence
-#                      whose failure is deterministically linked to
-#                      detecting the forbidden token.
-#   mneme_ready        deterministic intent with a concrete safe Mneme
-#                      guardrail identified today (single-term anti-pattern
-#                      or single-term "no X" constraint).
-#   requires_modelling deterministic intent that exists but has no safe
-#                      concrete guardrail (multi-term anti-patterns, multi-
-#                      term "no X" constraints needing interpretation).
-#   guidance           intent not appropriate for deterministic enforcement.
+# Tier semantics (ADR-023; amends the P1.2 freeze in
+# docs/plans/p1-2-architecture-audit-redesign.md after the first Design
+# Partner diagnostic, sagarika29/ai-system-architect):
+#   protected          a documented architectural decision for which Mneme
+#                      has deterministically linked evidence that the
+#                      decision is currently enforced — a typed
+#                      FORBID_LITERAL rule, or external CI evidence whose
+#                      failure is deterministically linked to detecting the
+#                      forbidden token.
+#   mneme_ready        a documented architectural decision that can be
+#                      represented faithfully by an existing Mneme rule
+#                      type, with sufficient scope/applicability
+#                      information to activate it without inventing missing
+#                      architectural intent (an explicit literal
+#                      prohibition — single-term anti-pattern, single-term
+#                      "no X" constraint, or an equivalently explicit
+#                      quoted term ban stated by the decision text).
+#   requires_modelling a documented architectural decision that appears
+#                      deterministically enforceable in principle, but
+#                      Mneme does not yet have an adequate rule type,
+#                      sufficient structured scope, or another required
+#                      representation mechanism.
+#   guidance           a documented statement that is primarily advisory,
+#                      explanatory, aspirational, preference-based, or
+#                      inherently judgment-dependent and should not
+#                      currently be represented as deterministic
+#                      enforcement.
 #
-# Semantic invariants:
+# Semantic invariants (ADR-023):
+#   - Structure invariance: adding syntactic structure or a constraint
+#     field MUST NOT, by itself, move a decision out of guidance. Intent is
+#     judged from the decision text (prescriptive vs advisory language);
+#     structured prohibition fields carry documented enforcement material
+#     only for decisions whose text is not advisory.
 #   - Guidance is evidence-independent: external enforcement-like evidence
 #     never upgrades a guidance decision.
 #   - Guidance decisions never enter the protection-relevant denominator.
@@ -462,6 +482,8 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
 #     description; a decision cannot be mneme_ready without one.
 #   - Candidate external evidence (token mentioned in CI without failure
 #     semantics) annotates but never upgrades a tier by itself.
+#   - Deterministic output for identical inputs: classification is a pure
+#     function of the decision record and repository files.
 
 AUDIT_SCHEMA = "mneme.audit/v1"
 
@@ -500,6 +522,9 @@ class ArchitectureProtectionReport:
     requires_modelling: int
     guidance: int
     current_protection_pct: float
+    # Compat metric (ADR-023): the unprotected deterministic opportunity —
+    # numerically identical to ``protection_gap_pct`` and the exact
+    # complement of ``current_protection_pct``; not an independent metric.
     identified_mneme_potential_pct: float
     protection_gap_pct: float
 
@@ -592,6 +617,116 @@ def _split_no_constraints(
     return single, multi
 
 
+# ── Semantic intent classification (ADR-023) ─────────────────────────────────
+#
+# The audit tier must track what the documented decision MEANS, not which
+# structured fields happen to be populated (P0 finding #1 of the first
+# Design Partner diagnostic: byte-identical decision text flipped guidance
+# → requires_modelling when an unrelated structured constraint was added).
+#
+# Intent is therefore judged from the decision text itself:
+#   - prescriptive language (obligation, requirement, prohibition — must,
+#     never, reject, fail closed, forbidden, enforce, validate, "No X"
+#     headlines) makes a decision protection-relevant regardless of which
+#     structured fields are populated;
+#   - advisory language (prefer, consider, should, can, where practical,
+#     judgment, tradeoffs) marks the statement guidance, and no structured
+#     field can upgrade it;
+#   - structured prohibition fields (anti_patterns / "no X" constraints)
+#     remain documented enforcement material for decisions whose text is
+#     not advisory, preserving the frozen Mneme-ready guardrail derivation
+#     for every pre-existing record shape.
+#
+# Both classifiers are deliberately conservative: prescriptive markers
+# never fire on advisory wording, and absent markers default to guidance
+# (silent text is never inferred to be deterministic). No repository- or
+# partner-specific vocabulary is special-cased.
+
+_ADVISORY_RE = re.compile(
+    r"\b(?:prefer\w*|consider\w*|recommen\w+|should|ideally|optional|"
+    r"flexible|judg(?:e|ment|ement)\w*|trade[- ]?off\w*|aspirational|"
+    r"where\s+practical|when\s+possible|when\s+appropriate|"
+    r"as\s+appropriate|as\s+needed|in\s+general|generally|typically|"
+    r"usually|nice[- ]to[- ]have|may\b|might\b|can\b|could\b)\b",
+    re.IGNORECASE,
+)
+
+_PRESCRIPTIVE_RE = re.compile(
+    r"\b(?:must(?:\s+not)?|mustn't|shall(?:\s+not)?|required|requires|"
+    r"require\b|mandatory|always|never|reject\w*|forbid\w*|banned|ban\b|"
+    r"enforc\w*|validat\w*|fail\w*\s+closed?|fail-closed|do\s+not|don't|"
+    r"cannot|can't|refuse\w*)\b",
+    re.IGNORECASE,
+)
+
+_NO_HEADLINE_RE = re.compile(r"^\s*no\s+\S", re.IGNORECASE)
+
+_QUOTED_TERM_BAN_RE = re.compile(
+    r"\b(?:must\s+not|must\s+never|never|shall\s+not|do\s+not|don't|"
+    r"forbidden|banned|prohibited|avoid|omit|no)\b"
+    r"[^.;\n]{0,64}?"
+    r"\b(?:terms?|words?|phrases?|literals?|strings?|tokens?|"
+    r"keywords?|identifiers?)\b"
+    r"[^\S\n]*[:\-]?[^\S\n]*"
+    r"[`'\"\u201c\u2018]"
+    r"([A-Za-z][A-Za-z0-9_-]{2,48})"
+    r"[`'\"\u201d\u2019]?",
+    re.IGNORECASE,
+)
+
+
+def _is_advisory_text(text: str) -> bool:
+    """True when the decision text reads as advisory/preference wording."""
+    return bool(_ADVISORY_RE.search(text))
+
+
+def _is_prescriptive_text(text: str) -> bool:
+    """True when the decision text states an obligation or prohibition."""
+    return bool(_PRESCRIPTIVE_RE.search(text)) or bool(_NO_HEADLINE_RE.match(text))
+
+
+def _headline_no_tokens(text: str) -> list[str]:
+    """Tokens proposed by a leading "No <single term>" prohibition headline.
+
+    The same derivation ``_split_no_constraints`` applies to a "no X"
+    constraint, applied to the decision text's headline.
+    """
+    m = _NO_CONSTRAINT_RE.match(text.strip())
+    if not m:
+        return []
+    phrase = m.group(1).strip()
+    if _is_literal_rule(phrase):
+        terms = _rule_terms(phrase)
+        if terms:
+            return [terms[0]]
+    return []
+
+
+def _text_literal_tokens(text: str) -> list[str]:
+    """Literalizable tokens stated by the decision text itself.
+
+    Two conservative, deterministic shapes are recognised:
+
+    1. a leading ``No <single term>`` prohibition headline — exactly the
+       derivation ``_split_no_constraints`` applies to a "no X" constraint;
+    2. an explicitly quoted term prohibition ("must not use the term
+       ``seamless``") — the quotes make the banned literal explicit, so a
+       FORBID_LITERAL guardrail is faithful rather than invented.
+
+    Anything else stays Requires-modelling: prose prohibitions that need
+    interpretation are never literalized from text alone.
+    """
+    tokens: list[str] = []
+    for match in _QUOTED_TERM_BAN_RE.finditer(text):
+        token = match.group(1).lower()
+        if token not in tokens:
+            tokens.append(token)
+    for token in _headline_no_tokens(text):
+        if token not in tokens:
+            tokens.append(token)
+    return tokens
+
+
 def _scan_ci_evidence(
     tokens: list[str],
     repo_root: str | Path | None,
@@ -646,13 +781,19 @@ def _proposed_literal_tokens(decision: "Decision") -> list[str]:
 
     Exactly the derivation ``assess_protection`` uses to classify a decision
     ``mneme_ready``: the terms of each single-term anti-pattern, then the
-    forbidden terms of single-term "no X" constraints. Kept beside the
-    assessment so the proposal below and the classification above are the
-    same computation, not two interpretations of it.
+    forbidden terms of single-term "no X" constraints, then tokens stated by
+    the decision text itself (``_text_literal_tokens``), deduplicated in
+    order. Kept beside the assessment so the proposal below and the
+    classification above are the same computation, not two interpretations
+    of it.
     """
     single_aps = [ap for ap in decision.anti_patterns if _is_literal_rule(ap)]
     single_nos, _ = _split_no_constraints(decision.constraints)
-    return [t for ap in single_aps for t in _rule_terms(ap)] + single_nos
+    tokens = [t for ap in single_aps for t in _rule_terms(ap)] + single_nos
+    for token in _text_literal_tokens(decision.decision):
+        if token not in tokens:
+            tokens.append(token)
+    return tokens
 
 
 def propose_literal_rule(decision: "Decision") -> "Rule | None":
@@ -687,12 +828,22 @@ def assess_protection(
     """Assess one Decision's P1.2 protection state.
 
     Tier resolution order (highest wins):
+
       1. typed FORBID_LITERAL rule  -> protected (verified enforcement)
       2. verified external CI evidence on a literalizable token -> protected
-      3. single-term anti-pattern or single-term "no X" constraint
-         -> mneme_ready with an explicit FORBID_LITERAL guardrail
+      3. deterministic intent representable by an existing rule type
+         with sufficient scope -> mneme_ready with an explicit
+         FORBID_LITERAL guardrail
       4. remaining deterministic intent -> requires_modelling
-      5. no deterministic intent -> guidance (evidence-independent)
+      5. advisory or otherwise non-deterministic statement -> guidance
+         (evidence-independent)
+
+    Intent (deterministic vs guidance) is judged from the decision text
+    (``_is_prescriptive_text`` / ``_is_advisory_text``), never from which
+    structured fields happen to be populated (ADR-023 structure-invariance
+    invariant). Structured prohibition fields still supply the concrete
+    guardrail derivation, and they keep non-advisory decisions
+    protection-relevant exactly as in the frozen P1.2 model.
     """
     literal_rules = [
         rule for rule in decision.rules if rule.type == "FORBID_LITERAL"
@@ -701,8 +852,26 @@ def assess_protection(
     multi_aps = [ap for ap in decision.anti_patterns if not _is_literal_rule(ap)]
     single_nos, multi_nos = _split_no_constraints(decision.constraints)
 
-    has_deterministic_intent = bool(
-        literal_rules or single_aps or multi_aps or single_nos or multi_nos
+    if literal_rules:
+        return ProtectionDecisionReport(
+            id=decision.id,
+            decision=decision.decision,
+            status=decision.status,
+            intent="deterministic",
+            protection_tier="protected",
+            mneme_guardrail=f"FORBID_LITERAL: {literal_rules[0].value}",
+            evidence_confidence="verified",
+            evidence_sources=[],
+        )
+
+    documented_enforcement = bool(
+        single_aps or multi_aps or single_nos or multi_nos
+    )
+    advisory = _is_advisory_text(decision.decision)
+    prescriptive = _is_prescriptive_text(decision.decision)
+
+    has_deterministic_intent = prescriptive or (
+        documented_enforcement and not advisory
     )
 
     if not has_deterministic_intent:
@@ -714,18 +883,6 @@ def assess_protection(
             protection_tier="guidance",
             mneme_guardrail=None,
             evidence_confidence="none",
-            evidence_sources=[],
-        )
-
-    if literal_rules:
-        return ProtectionDecisionReport(
-            id=decision.id,
-            decision=decision.decision,
-            status=decision.status,
-            intent="deterministic",
-            protection_tier="protected",
-            mneme_guardrail=f"FORBID_LITERAL: {literal_rules[0].value}",
-            evidence_confidence="verified",
             evidence_sources=[],
         )
 
@@ -776,9 +933,32 @@ def generate_protection_report(
     guidance = sum(1 for r in active if r.protection_tier == "guidance")
     protection_relevant = protected + mneme_ready + requires_modelling
 
+    # Metric formulas (ADR-023, exact numerator/denominator):
+    #
+    #   Current Protection          = P / PR × 100
+    #       fraction of protection-relevant decisions with verified
+    #       deterministic enforcement.
+    #   Identified Mneme Potential  = (M + R) / PR × 100
+    #       the UNPROTECTED DETERMINISTIC OPPORTUNITY: fraction of
+    #       protection-relevant decisions whose documented meaning is
+    #       deterministically enforceable in principle and not yet
+    #       enforced — representable by an existing rule type today
+    #       (Mneme-ready) or requiring richer modelling (Requires
+    #       modelling). Guidance never enters the numerator or the
+    #       denominator. This is numerically identical to the Protection
+    #       Gap by construction and is the exact complement of Current
+    #       Protection (Potential = 100 − Current Protection); it is NOT
+    #       an independent second metric and user-facing output must not
+    #       present the two as separate findings. A future, genuinely
+    #       distinct metric may express immediately protectable coverage
+    #       as (P + M) / PR, with Requires-modelling as the product gap.
+    #   Protection Gap              = (M + R) / PR × 100
+    #       the actionable shortfall — numerically identical to Potential
+    #       by construction, framed as what remains rather than what
+    #       Mneme could protect.
     current_protection = round(protected / protection_relevant * 100, 1) if protection_relevant else 0.0
     identified_potential = (
-        round((protected + mneme_ready) / protection_relevant * 100, 1)
+        round((mneme_ready + requires_modelling) / protection_relevant * 100, 1)
         if protection_relevant
         else 0.0
     )

--- a/mneme/evidence.py
+++ b/mneme/evidence.py
@@ -1,0 +1,365 @@
+"""
+evidence.py — Declared test-evidence ingestion for the P1.2 audit (ADR-024).
+
+Security invariant (ADR-024 amendment):
+
+    Architecture Audit does not execute code from the audited repository
+    unless the user explicitly requests an execution-capable verification
+    mode.
+
+Ordinary ``mneme audit`` is PASSIVE. This module performs no subprocess
+execution of any repository-controlled code — no pytest, no conftest, no
+plugins, no test bodies. Pytest invocation is arbitrary code execution
+(repository-controlled imports, collection hooks, fixtures and test
+bodies run inside the audit process's child), so it must never happen
+implicitly. Local execution is an explicitly opt-in, documented future
+capability, not part of Audit.
+
+Contract (the audited chain):
+
+    Decision
+      ↓
+    stable decision identifier          (the decision record's own ``id``;
+                                         the declaration lives ON the
+                                         decision record in
+                                         ``project_memory.json``)
+      ↓
+    declared test evidence              (``test_evidence`` entries —
+                                         explicit, human-authored policy,
+                                         never inferred)
+      ↓
+    passive validation                  (selector well-formedness,
+                                         cross-decision ambiguity, SHA-pin
+                                         staleness, test-file existence —
+                                         all pure checks)
+      ↓
+    evidence state                      (DECLARED / STALE / INVALID /
+                                         AMBIGUOUS; VERIFIED is defined
+                                         but has no producer in M0)
+      ↓
+    evidence_sources / diagnostics      (annotation only — a merely
+                                         DECLARED entry never protects)
+
+Evidence states:
+
+    DECLARED    an explicit decision→test-selector mapping exists and
+                passes passive validation. It annotates evidence_sources
+                as ``test:declared:<selector>`` but classification keeps
+                Requires Modelling (deterministic intent) or Guidance
+                (advisory intent).
+    VERIFIED    a deterministic trusted result establishes that the exact
+                selector passed against the exact repository SHA. No such
+                trusted producer exists in M0 — verified evidence arrives
+                with the CI-evidence ingestion task.
+    STALE       the declared SHA pin does not match repository HEAD:
+                ``test:stale:<selector>@<sha>``.
+    INVALID     the selector is malformed or its file does not exist:
+                ``test:invalid:<selector>@<code>``.
+    AMBIGUOUS   the same selector is declared by more than one decision:
+                ``test:invalid:<selector>@ambiguous-mapping`` — neither
+                decision is protected.
+
+A passing test is evidence only when the provenance of the passing result
+is trusted; declaring it is not verifying it. Trusted verification is the
+next task (CI-produced exact-SHA + exact-selector ingestion).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_GIT_TIMEOUT_S = 30
+
+# Fixed, deterministic reason codes used in evidence-source strings.
+REASON_MALFORMED_SELECTOR = "malformed-selector"
+REASON_AMBIGUOUS_MAPPING = "ambiguous-mapping"
+REASON_SHA_UNAVAILABLE = "sha-unavailable"
+REASON_SHA_MISMATCH = "sha-mismatch"
+REASON_SELECTOR_NOT_FOUND = "selector-not-found"
+REASON_NO_VERIFICATION = "no-verification"
+
+# Evidence states.
+STATE_DECLARED = "declared"
+STATE_VERIFIED = "verified"
+STATE_STALE = "stale"
+STATE_INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class TestEvidenceVerification:
+    """Passive verification outcome for one declared test-evidence entry.
+
+    ``code`` is a fixed, deterministic reason code (no spaces, safe for
+    evidence-source strings); ``detail`` is the human-facing explanation.
+    """
+
+    decision_id: str
+    selector: str
+    state: str  # "declared" | "verified" | "stale" | "invalid"
+    sha: str  # exact repository HEAD SHA the validation ran against ("" if none)
+    code: str
+    detail: str
+
+
+def _declared_entries(decision) -> list[dict]:
+    """Declared test-evidence entries for one decision, conservatively read.
+
+    The field is optional and additive: anything that is not a list of
+    mappings is ignored and can never contribute evidence. The audit
+    reports diagnostics for unusable entries.
+    """
+    entries = getattr(decision, "test_evidence", None)
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _selector_file_part(selector) -> str | None:
+    """Validated repository-relative file path of a pytest node id.
+
+    Returns the normalized file part when ``selector`` is a non-empty string
+    without whitespace, carrying at least one ``::`` separator whose first
+    segment is a relative path (no drive letter, no leading slash, no ``..``
+    escape); ``None`` otherwise.
+    """
+    if not isinstance(selector, str) or not selector:
+        return None
+    if any(ch.isspace() for ch in selector):
+        return None
+    normalized = selector.replace("\\", "/")
+    head = normalized.split("::")[0]
+    if not head or not normalized[len(head) :].startswith("::"):
+        return None
+    if head.startswith("/") or (len(head) > 1 and head[1] == ":"):
+        return None
+    parts = [part for part in head.split("/") if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        return None
+    return "/".join(parts)
+
+
+def _declared_sha(entry: dict) -> str | None:
+    """Optional pinned repository SHA from one declaration, or ``None``."""
+    sha = entry.get("sha")
+    if not isinstance(sha, str) or not sha.strip():
+        return None
+    return sha.strip()
+
+
+def _current_repo_sha(repo_root: Path) -> str | None:
+    """Exact HEAD SHA of the audited repository, or ``None`` (fail closed).
+
+    Runs the ``git`` binary only — never any repository-controlled code.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    sha = result.stdout.strip()
+    if result.returncode != 0 or not sha:
+        return None
+    return sha
+
+
+def verify_test_evidence(
+    decisions: list,
+    repo_root: str | os.PathLike[str] | None,
+) -> dict[str, list[TestEvidenceVerification]]:
+    """Passively validate every declared test-evidence entry. Fail closed.
+
+    No repository-controlled code is ever executed. For each decision
+    record carrying ``test_evidence`` declarations, every selector is
+    checked in order:
+
+    1. well-formed (repository-relative pytest node id);
+    2. unambiguous (not declared by any other decision);
+    3. resolvable: the repository HEAD SHA is available, the declared SHA
+       pin (if any) matches HEAD exactly, and the selector's file exists
+       inside the repository.
+
+    The resulting state is ``declared`` (annotates, never protects),
+    ``stale`` (SHA pin mismatch), or ``invalid`` (malformed selector,
+    missing file, or ambiguous mapping). No ``verified`` state is produced
+    in M0 — a merely declared test never moves a decision to Protected.
+    """
+    results: dict[str, list[TestEvidenceVerification]] = {}
+
+    if repo_root is None:
+        for decision in decisions:
+            declared = _declared_entries(decision)
+            if not declared:
+                continue
+            results[decision.id] = [
+                TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=(
+                        entry.get("selector")
+                        if isinstance(entry.get("selector"), str)
+                        else ""
+                    ),
+                    state=STATE_INVALID,
+                    sha="",
+                    code=REASON_NO_VERIFICATION,
+                    detail=(
+                        "no repository context available; declared evidence "
+                        "cannot be validated"
+                    ),
+                )
+                for entry in declared
+            ]
+        return results
+
+    root = Path(repo_root)
+
+    # Cross-decision ambiguity: the same selector declared by two or more
+    # decisions is an ambiguous mapping and protects neither.
+    by_selector: dict[str, set[str]] = {}
+    for decision in decisions:
+        for entry in _declared_entries(decision):
+            selector = entry.get("selector")
+            if isinstance(selector, str) and selector:
+                by_selector.setdefault(selector, set()).add(decision.id)
+    ambiguous = {
+        selector
+        for selector, owners in by_selector.items()
+        if len(owners) > 1
+    }
+
+    # One deterministic SHA snapshot per validation run.
+    sha = _current_repo_sha(root)
+
+    for decision in decisions:
+        declared = _declared_entries(decision)
+        if not declared:
+            continue
+        entries: list[TestEvidenceVerification] = []
+        for entry in declared:
+            selector = entry.get("selector")
+            file_part = _selector_file_part(selector)
+            if file_part is None:
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector if isinstance(selector, str) else "",
+                    state=STATE_INVALID,
+                    sha="",
+                    code=REASON_MALFORMED_SELECTOR,
+                    detail="declared test selector is malformed",
+                ))
+                continue
+            if sha is None:
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_INVALID,
+                    sha="",
+                    code=REASON_SHA_UNAVAILABLE,
+                    detail="repository SHA could not be determined",
+                ))
+                continue
+            if selector in ambiguous:
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_INVALID,
+                    sha=sha,
+                    code=REASON_AMBIGUOUS_MAPPING,
+                    detail=(
+                        "selector is declared by more than one decision; "
+                        "ambiguous mapping protects neither"
+                    ),
+                ))
+                continue
+            declared_sha = _declared_sha(entry)
+            if declared_sha is not None and declared_sha != sha:
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_STALE,
+                    sha=sha,
+                    code=REASON_SHA_MISMATCH,
+                    detail=(
+                        f"declared SHA {declared_sha} does not match "
+                        f"repository HEAD {sha}"
+                    ),
+                ))
+                continue
+            selector_path = root.joinpath(*file_part.split("/"))
+            if not selector_path.is_file():
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_INVALID,
+                    sha=sha,
+                    code=REASON_SELECTOR_NOT_FOUND,
+                    detail="declared test file does not exist in the repository",
+                ))
+                continue
+            entries.append(TestEvidenceVerification(
+                decision_id=decision.id,
+                selector=selector,
+                state=STATE_DECLARED,
+                sha=sha,
+                code=REASON_NO_VERIFICATION,
+                detail=(
+                    "declared linkage passes passive validation; no trusted "
+                    "verification producer is available yet, so this never "
+                    "establishes protection on its own"
+                ),
+            ))
+        results[decision.id] = entries
+    return results
+
+
+def evidence_source_strings(
+    verifications: list[TestEvidenceVerification],
+) -> list[str]:
+    """Deterministic evidence-source strings for the audit report.
+
+    Declared entries read ``test:declared:<selector>`` (with the pinned
+    SHA when present); stale entries read ``test:stale:<selector>@<code>``;
+    invalid entries read ``test:invalid:<selector>@<code>``. The audit
+    always answers why a declared linkage did not establish protection —
+    with no runner noise and no execution.
+    """
+    sources: list[str] = []
+    for verification in verifications:
+        selector = verification.selector
+        if verification.state == STATE_DECLARED:
+            sources.append(f"test:declared:{selector}")
+        elif verification.state == STATE_STALE:
+            sources.append(f"test:stale:{selector}@{verification.code}")
+        elif verification.state == STATE_VERIFIED:
+            sources.append(f"test:verified:{selector}@{verification.sha}")
+        else:
+            sources.append(
+                f"test:invalid:{selector}@{verification.code}"
+            )
+    return sources
+
+
+__all__ = [
+    "TestEvidenceVerification",
+    "verify_test_evidence",
+    "evidence_source_strings",
+    "STATE_DECLARED",
+    "STATE_VERIFIED",
+    "STATE_STALE",
+    "STATE_INVALID",
+    "REASON_MALFORMED_SELECTOR",
+    "REASON_AMBIGUOUS_MAPPING",
+    "REASON_SHA_UNAVAILABLE",
+    "REASON_SHA_MISMATCH",
+    "REASON_SELECTOR_NOT_FOUND",
+    "REASON_NO_VERIFICATION",
+]

--- a/mneme/evidence.py
+++ b/mneme/evidence.py
@@ -53,10 +53,19 @@ Evidence states:
                         its CI provenance has NOT been independently
                         authenticated by Mneme. Annotated as
                         ``test:ci-claim:<selector>@<sha>``; never protects.
-    VERIFIED            reserved for evidence whose provenance was
-                        authenticated through a trusted verification source.
-                        No such producer exists in M0, so the raw document
-                        parameter can never produce this state.
+    AUTHENTICATED_CLAIM an ``mneme.test-evidence/v1`` document whose CI run
+                        and artifact Mneme authenticated via the GitHub API,
+                        whose SHA matches the audited HEAD, and whose selector
+                        says ``passed``. The artifact *content* is still
+                        repository-controlled workflow output — authentication
+                        proves the artifact's provenance, not that a trusted
+                        verifier executed the test — so this is a stronger
+                        claim, annotated ``test:ci-authenticated:<selector>@<sha>``,
+                        and never protects on its own.
+    VERIFIED            reserved for evidence produced by a trusted
+                        verification producer (a Mneme-controlled verifier,
+                        pinned and attested). No such producer exists in M0;
+                        nothing reaches this state.
     STALE               the declared SHA pin does not match repository HEAD:
                         ``test:stale:<selector>@<sha>``.
     INVALID             the selector is malformed or its file does not exist:
@@ -66,9 +75,10 @@ Evidence states:
                         — neither decision is protected.
 
 A passing test is evidence only when the provenance of the passing result is
-authenticated; declaring it is not verifying it, and a matching CI document
-is a claim, not a trust root. Authenticated verification arrives with a
-future trusted CI retrieval producer, not this module.
+authenticated *and* the result was produced by a trusted verifier. Declaring
+is not verifying; a matching CI document is a claim; an authenticated CI
+artifact is still a claim whose content is repository-controlled. The
+``verified`` state arrives with a future trusted producer, not this module.
 """
 
 from __future__ import annotations
@@ -98,6 +108,7 @@ CI_EVIDENCE_SCHEMA = "mneme.test-evidence/v1"
 # Evidence states.
 STATE_DECLARED = "declared"
 STATE_MATCHED = "matched_unverified"
+STATE_AUTHENTICATED_CLAIM = "authenticated_ci_claim"
 STATE_VERIFIED = "verified"
 STATE_STALE = "stale"
 STATE_INVALID = "invalid"
@@ -113,7 +124,7 @@ class TestEvidenceVerification:
 
     decision_id: str
     selector: str
-    state: str  # "declared" | "matched_unverified" | "verified" | "stale" | "invalid"
+    state: str  # "declared" | "matched_unverified" | "authenticated_ci_claim" | "verified" | "stale" | "invalid"
     sha: str  # exact repository HEAD SHA the validation ran against ("" if none)
     code: str
     detail: str
@@ -326,29 +337,38 @@ def verify_test_evidence(
 ) -> dict[str, list[TestEvidenceVerification]]:
     """Passively validate every declared test-evidence entry. Fail closed.
 
-    No repository-controlled code is ever executed. For each decision
-    record carrying ``test_evidence`` declarations, every selector is
-    checked in order:
+    Public entry point. It NEVER produces the ``verified`` state: declared
+    linkages reach ``declared``, and an externally supplied document can at
+    most reach ``matched_unverified`` (an unauthenticated claim). See
+    :func:`_verify_test_evidence` for the internal, authenticated path.
+    """
+    return _verify_test_evidence(decisions, repo_root, ci_evidence_document, None)
+
+
+def _verify_test_evidence(
+    decisions: list,
+    repo_root: str | os.PathLike[str] | None,
+    ci_evidence_document: str | None,
+    authenticated_claim: "object | None",
+) -> dict[str, list[TestEvidenceVerification]]:
+    """Passively validate every declared test-evidence entry. Fail closed.
+
+    Internal implementation. ``authenticated_claim`` is a value produced by
+    ``mneme.github_evidence.verify_github_run`` (an authenticated CI run and
+    artifact whose content is still repository-controlled); it may reach the
+    ``authenticated_ci_claim`` state, never ``verified``. This parameter is
+    private and must never be exposed on a public assessment/report API —
+    no caller-supplied value may reach ``verified``/Protected.
+
+    No repository-controlled code is ever executed. For each decision record
+    carrying ``test_evidence`` declarations, every selector is checked in
+    order:
 
     1. well-formed (repository-relative pytest node id);
     2. unambiguous (not declared by any other decision);
-    3. resolvable: the repository HEAD SHA is available, the declared SHA
-       pin (if any) matches HEAD exactly, and the selector's file exists
-       inside the repository.
-
-    A linkage that passes all passive checks reaches ``declared`` and never
-    protects on its own.
-
-    When the caller supplies an external evidence document
-    (``ci_evidence_document``) whose exact SHA matches the audited HEAD and
-    whose results include the exact selector with outcome ``passed``, the
-    linkage is recorded as ``matched_unverified`` — a matching CI *claim*,
-    never ``verified``. The document is UNTRUSTED evidence material: its
-    provenance is recorded, not authenticated, and no such authentication
-    producer exists in M0, so the raw parameter can never reach the
-    ``verified`` state that ``assess_protection`` upgrades to Protected.
-    Ordinary ``mneme audit`` never supplies a document and never
-    auto-discovers or auto-trusts any repository file.
+    3. resolvable: the repository HEAD SHA is available, the declared SHA pin
+       (if any) matches HEAD exactly, and the selector's file exists inside
+       the repository.
     """
     results: dict[str, list[TestEvidenceVerification]] = {}
 
@@ -404,6 +424,16 @@ def verify_test_evidence(
         document, _reason = parse_ci_evidence_document(ci_evidence_document)
         if document is not None:
             matched = match_ci_evidence(decisions, sha, document)
+
+    # Authenticated CI claim (stronger than matched, still a claim): only
+    # from the authenticated GitHub evidence component. Never the verified
+    # state, because the artifact content is repository-controlled.
+    authenticated: dict[str, list[str]] = {}
+    if authenticated_claim is not None and sha is not None:
+        claim_document = getattr(authenticated_claim, "document", None)
+        claim_sha = getattr(authenticated_claim, "head_sha", None)
+        if claim_document is not None and claim_sha == sha:
+            authenticated = match_ci_evidence(decisions, sha, claim_document)
 
     for decision in decisions:
         declared = _declared_entries(decision)
@@ -471,7 +501,21 @@ def verify_test_evidence(
                     detail="declared test file does not exist in the repository",
                 ))
                 continue
-            if selector in matched.get(decision.id, []):
+            if selector in authenticated.get(decision.id, []):
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_AUTHENTICATED_CLAIM,
+                    sha=sha,
+                    code=REASON_NO_VERIFICATION,
+                    detail=(
+                        "authenticated CI run/artifact claims the selector "
+                        "passed at this repository SHA; the artifact content "
+                        "is repository-controlled, so this is a claim, not "
+                        "proof of execution"
+                    ),
+                ))
+            elif selector in matched.get(decision.id, []):
                 entries.append(TestEvidenceVerification(
                     decision_id=decision.id,
                     selector=selector,
@@ -507,12 +551,14 @@ def evidence_source_strings(
     """Deterministic evidence-source strings for the audit report.
 
     Declared entries read ``test:declared:<selector>``; a matching but
-    unauthenticated CI claim reads ``test:ci-claim:<selector>@<sha>``;
-    stale entries read ``test:stale:<selector>@<code>``; invalid entries
-    read ``test:invalid:<selector>@<code>``. The reserved authenticated
-    state reads ``test:verified:<selector>@<sha>`` and has no producer in
-    M0. The audit always answers why a declared linkage did not establish
-    protection — with no runner noise and no execution.
+    unauthenticated CI claim reads ``test:ci-claim:<selector>@<sha>``; an
+    authenticated (but still repository-controlled) CI claim reads
+    ``test:ci-authenticated:<selector>@<sha>``; stale entries read
+    ``test:stale:<selector>@<code>``; invalid entries read
+    ``test:invalid:<selector>@<code>``. The reserved authenticated state
+    reads ``test:verified:<selector>@<sha>`` and has no producer in M0. The
+    audit always answers why a declared linkage did not establish protection —
+    with no runner noise and no execution.
     """
     sources: list[str] = []
     for verification in verifications:
@@ -521,6 +567,8 @@ def evidence_source_strings(
             sources.append(f"test:declared:{selector}")
         elif verification.state == STATE_MATCHED:
             sources.append(f"test:ci-claim:{selector}@{verification.sha}")
+        elif verification.state == STATE_AUTHENTICATED_CLAIM:
+            sources.append(f"test:ci-authenticated:{selector}@{verification.sha}")
         elif verification.state == STATE_STALE:
             sources.append(f"test:stale:{selector}@{verification.code}")
         elif verification.state == STATE_VERIFIED:
@@ -542,6 +590,7 @@ __all__ = [
     "CI_EVIDENCE_SCHEMA",
     "STATE_DECLARED",
     "STATE_MATCHED",
+    "STATE_AUTHENTICATED_CLAIM",
     "STATE_VERIFIED",
     "STATE_STALE",
     "STATE_INVALID",

--- a/mneme/evidence.py
+++ b/mneme/evidence.py
@@ -42,30 +42,38 @@ Contract (the audited chain):
 
 Evidence states:
 
-    DECLARED    an explicit decision→test-selector mapping exists and
-                passes passive validation. It annotates evidence_sources
-                as ``test:declared:<selector>`` but classification keeps
-                Requires Modelling (deterministic intent) or Guidance
-                (advisory intent).
-    VERIFIED    a deterministic trusted result establishes that the exact
-                selector passed against the exact repository SHA. No such
-                trusted producer exists in M0 — verified evidence arrives
-                with the CI-evidence ingestion task.
-    STALE       the declared SHA pin does not match repository HEAD:
-                ``test:stale:<selector>@<sha>``.
-    INVALID     the selector is malformed or its file does not exist:
-                ``test:invalid:<selector>@<code>``.
-    AMBIGUOUS   the same selector is declared by more than one decision:
-                ``test:invalid:<selector>@ambiguous-mapping`` — neither
-                decision is protected.
+    DECLARED            an explicit decision→test-selector mapping exists and
+                        passes passive validation. It annotates
+                        evidence_sources as ``test:declared:<selector>`` but
+                        classification keeps Requires Modelling (deterministic
+                        intent) or Guidance (advisory intent).
+    MATCHED_UNVERIFIED  an externally supplied ``mneme.test-evidence/v1``
+                        document parses, matches the exact audited SHA, the
+                        exact declared selector, and says ``passed`` — but
+                        its CI provenance has NOT been independently
+                        authenticated by Mneme. Annotated as
+                        ``test:ci-claim:<selector>@<sha>``; never protects.
+    VERIFIED            reserved for evidence whose provenance was
+                        authenticated through a trusted verification source.
+                        No such producer exists in M0, so the raw document
+                        parameter can never produce this state.
+    STALE               the declared SHA pin does not match repository HEAD:
+                        ``test:stale:<selector>@<sha>``.
+    INVALID             the selector is malformed or its file does not exist:
+                        ``test:invalid:<selector>@<code>``.
+    AMBIGUOUS           the same selector is declared by more than one
+                        decision: ``test:invalid:<selector>@ambiguous-mapping``
+                        — neither decision is protected.
 
-A passing test is evidence only when the provenance of the passing result
-is trusted; declaring it is not verifying it. Trusted verification is the
-next task (CI-produced exact-SHA + exact-selector ingestion).
+A passing test is evidence only when the provenance of the passing result is
+authenticated; declaring it is not verifying it, and a matching CI document
+is a claim, not a trust root. Authenticated verification arrives with a
+future trusted CI retrieval producer, not this module.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from dataclasses import dataclass
@@ -80,9 +88,16 @@ REASON_SHA_UNAVAILABLE = "sha-unavailable"
 REASON_SHA_MISMATCH = "sha-mismatch"
 REASON_SELECTOR_NOT_FOUND = "selector-not-found"
 REASON_NO_VERIFICATION = "no-verification"
+REASON_MALFORMED_EVIDENCE = "malformed-evidence"
+REASON_UNKNOWN_SCHEMA = "unknown-schema"
+REASON_MISSING_PROVENANCE = "missing-provenance"
+
+# The CI-produced test-evidence document schema Mneme consumes.
+CI_EVIDENCE_SCHEMA = "mneme.test-evidence/v1"
 
 # Evidence states.
 STATE_DECLARED = "declared"
+STATE_MATCHED = "matched_unverified"
 STATE_VERIFIED = "verified"
 STATE_STALE = "stale"
 STATE_INVALID = "invalid"
@@ -90,7 +105,7 @@ STATE_INVALID = "invalid"
 
 @dataclass(frozen=True)
 class TestEvidenceVerification:
-    """Passive verification outcome for one declared test-evidence entry.
+    """Passive validation outcome for one declared test-evidence entry.
 
     ``code`` is a fixed, deterministic reason code (no spaces, safe for
     evidence-source strings); ``detail`` is the human-facing explanation.
@@ -98,10 +113,142 @@ class TestEvidenceVerification:
 
     decision_id: str
     selector: str
-    state: str  # "declared" | "verified" | "stale" | "invalid"
+    state: str  # "declared" | "matched_unverified" | "verified" | "stale" | "invalid"
     sha: str  # exact repository HEAD SHA the validation ran against ("" if none)
     code: str
     detail: str
+
+
+@dataclass(frozen=True)
+class CiEvidenceDocument:
+    """A parsed CI-produced test-evidence document (``mneme.test-evidence/v1``).
+
+    This is a pure data record produced by ``parse_ci_evidence_document``.
+    It carries no trust of its own: the provenance fields are recorded but
+    Mneme does not authenticate who produced the document. The trust
+    boundary is external (CI retrieval), not this record.
+    """
+
+    repository_sha: str
+    producer_type: str
+    producer_run_id: str
+    results: tuple[tuple[str, str], ...]  # (selector, outcome), in file order
+
+
+def parse_ci_evidence_document(
+    text: str,
+) -> tuple[CiEvidenceDocument | None, str | None]:
+    """Parse and validate a CI-produced test-evidence document. Fail closed.
+
+    Returns ``(document, None)`` on success and ``(None, reason)`` on any
+    structural or schema failure. Reasons are fixed, deterministic codes:
+    ``malformed-evidence``, ``unknown-schema``, ``missing-provenance``.
+
+    Validation is strictly structural — no execution, no fuzzy matching.
+    """
+    if not isinstance(text, str):
+        return None, REASON_MALFORMED_EVIDENCE
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None, REASON_MALFORMED_EVIDENCE
+    if not isinstance(data, dict):
+        return None, REASON_MALFORMED_EVIDENCE
+
+    if data.get("schema") != CI_EVIDENCE_SCHEMA:
+        return None, REASON_UNKNOWN_SCHEMA
+
+    sha = data.get("repository_sha")
+    if not isinstance(sha, str) or not sha.strip():
+        return None, REASON_MALFORMED_EVIDENCE
+
+    producer = data.get("producer")
+    if not isinstance(producer, dict):
+        return None, REASON_MISSING_PROVENANCE
+    producer_type = producer.get("type")
+    if not isinstance(producer_type, str) or not producer_type.strip():
+        return None, REASON_MISSING_PROVENANCE
+    run_id = producer.get("run_id") or producer.get("job_id") or ""
+    if not isinstance(run_id, str) or not run_id.strip():
+        return None, REASON_MISSING_PROVENANCE
+
+    results = data.get("results")
+    if not isinstance(results, list):
+        return None, REASON_MALFORMED_EVIDENCE
+    parsed: list[tuple[str, str]] = []
+    for item in results:
+        if not isinstance(item, dict):
+            return None, REASON_MALFORMED_EVIDENCE
+        selector = item.get("selector")
+        outcome = item.get("outcome")
+        if not isinstance(selector, str) or not selector.strip():
+            return None, REASON_MALFORMED_EVIDENCE
+        if not isinstance(outcome, str) or not outcome.strip():
+            return None, REASON_MALFORMED_EVIDENCE
+        parsed.append((selector, outcome))
+
+    return (
+        CiEvidenceDocument(
+            repository_sha=sha.strip(),
+            producer_type=producer_type.strip(),
+            producer_run_id=run_id.strip(),
+            results=tuple(parsed),
+        ),
+        None,
+    )
+
+
+def match_ci_evidence(
+    decisions: list,
+    repo_head_sha: str,
+    document: CiEvidenceDocument | None,
+) -> dict[str, list[str]]:
+    """Compute which declared selectors a CI evidence document claims to match.
+
+    Returns a mapping ``decision_id -> [matched selectors]`` (sorted, for
+    determinism). A selector matches only when ALL of the following hold:
+
+    - the document's ``repository_sha`` equals ``repo_head_sha``;
+    - the selector is string-equal to a selector declared by exactly one
+      active decision (unambiguous);
+    - the document's ``outcome`` for that selector is exactly ``passed``.
+
+    This is a pure matching function: the result is a **claim**, not a
+    verification. The document's provenance is recorded, not authenticated —
+    a caller cannot reach VERIFIED through this function, only a matching
+    (MATCHED_UNVERIFIED) claim. Global suite success, coverage,
+    filename/test-name similarity, fuzzy or substring matching, and
+    skipped/xfailed/error outcomes never match anything.
+    """
+    if document is None:
+        return {}
+    if document.repository_sha != repo_head_sha:
+        return {}
+
+    declared: dict[str, set[str]] = {}
+    for decision in decisions:
+        if decision.status != "active":
+            continue
+        for entry in _declared_entries(decision):
+            selector = entry.get("selector")
+            if isinstance(selector, str) and selector:
+                declared.setdefault(selector, set()).add(decision.id)
+
+    ambiguous = {sel for sel, owners in declared.items() if len(owners) > 1}
+
+    matched: dict[str, list[str]] = {}
+    for selector, outcome in document.results:
+        if outcome != "passed":
+            continue
+        owners = declared.get(selector)
+        if owners is None or len(owners) != 1 or selector in ambiguous:
+            continue
+        decision_id = next(iter(owners))
+        matched.setdefault(decision_id, []).append(selector)
+
+    for selectors in matched.values():
+        selectors.sort()
+    return matched
 
 
 def _declared_entries(decision) -> list[dict]:
@@ -175,6 +322,7 @@ def _current_repo_sha(repo_root: Path) -> str | None:
 def verify_test_evidence(
     decisions: list,
     repo_root: str | os.PathLike[str] | None,
+    ci_evidence_document: str | None = None,
 ) -> dict[str, list[TestEvidenceVerification]]:
     """Passively validate every declared test-evidence entry. Fail closed.
 
@@ -188,10 +336,19 @@ def verify_test_evidence(
        pin (if any) matches HEAD exactly, and the selector's file exists
        inside the repository.
 
-    The resulting state is ``declared`` (annotates, never protects),
-    ``stale`` (SHA pin mismatch), or ``invalid`` (malformed selector,
-    missing file, or ambiguous mapping). No ``verified`` state is produced
-    in M0 — a merely declared test never moves a decision to Protected.
+    A linkage that passes all passive checks reaches ``declared`` and never
+    protects on its own.
+
+    When the caller supplies an external evidence document
+    (``ci_evidence_document``) whose exact SHA matches the audited HEAD and
+    whose results include the exact selector with outcome ``passed``, the
+    linkage is recorded as ``matched_unverified`` — a matching CI *claim*,
+    never ``verified``. The document is UNTRUSTED evidence material: its
+    provenance is recorded, not authenticated, and no such authentication
+    producer exists in M0, so the raw parameter can never reach the
+    ``verified`` state that ``assess_protection`` upgrades to Protected.
+    Ordinary ``mneme audit`` never supplies a document and never
+    auto-discovers or auto-trusts any repository file.
     """
     results: dict[str, list[TestEvidenceVerification]] = {}
 
@@ -238,6 +395,15 @@ def verify_test_evidence(
 
     # One deterministic SHA snapshot per validation run.
     sha = _current_repo_sha(root)
+
+    # External evidence claim (UNTRUSTED), only when the caller supplied a
+    # document and the repository SHA is available. Never auto-discovered.
+    # The result is a matching claim, not verification.
+    matched: dict[str, list[str]] = {}
+    if ci_evidence_document is not None and sha is not None:
+        document, _reason = parse_ci_evidence_document(ci_evidence_document)
+        if document is not None:
+            matched = match_ci_evidence(decisions, sha, document)
 
     for decision in decisions:
         declared = _declared_entries(decision)
@@ -305,18 +471,32 @@ def verify_test_evidence(
                     detail="declared test file does not exist in the repository",
                 ))
                 continue
-            entries.append(TestEvidenceVerification(
-                decision_id=decision.id,
-                selector=selector,
-                state=STATE_DECLARED,
-                sha=sha,
-                code=REASON_NO_VERIFICATION,
-                detail=(
-                    "declared linkage passes passive validation; no trusted "
-                    "verification producer is available yet, so this never "
-                    "establishes protection on its own"
-                ),
-            ))
+            if selector in matched.get(decision.id, []):
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_MATCHED,
+                    sha=sha,
+                    code=REASON_NO_VERIFICATION,
+                    detail=(
+                        "external CI document claims the selector passed "
+                        "against this repository SHA; provenance is not "
+                        "authenticated, so this never establishes protection"
+                    ),
+                ))
+            else:
+                entries.append(TestEvidenceVerification(
+                    decision_id=decision.id,
+                    selector=selector,
+                    state=STATE_DECLARED,
+                    sha=sha,
+                    code=REASON_NO_VERIFICATION,
+                    detail=(
+                        "declared linkage passes passive validation; no trusted "
+                        "verification producer is available yet, so this never "
+                        "establishes protection on its own"
+                    ),
+                ))
         results[decision.id] = entries
     return results
 
@@ -326,17 +506,21 @@ def evidence_source_strings(
 ) -> list[str]:
     """Deterministic evidence-source strings for the audit report.
 
-    Declared entries read ``test:declared:<selector>`` (with the pinned
-    SHA when present); stale entries read ``test:stale:<selector>@<code>``;
-    invalid entries read ``test:invalid:<selector>@<code>``. The audit
-    always answers why a declared linkage did not establish protection —
-    with no runner noise and no execution.
+    Declared entries read ``test:declared:<selector>``; a matching but
+    unauthenticated CI claim reads ``test:ci-claim:<selector>@<sha>``;
+    stale entries read ``test:stale:<selector>@<code>``; invalid entries
+    read ``test:invalid:<selector>@<code>``. The reserved authenticated
+    state reads ``test:verified:<selector>@<sha>`` and has no producer in
+    M0. The audit always answers why a declared linkage did not establish
+    protection — with no runner noise and no execution.
     """
     sources: list[str] = []
     for verification in verifications:
         selector = verification.selector
         if verification.state == STATE_DECLARED:
             sources.append(f"test:declared:{selector}")
+        elif verification.state == STATE_MATCHED:
+            sources.append(f"test:ci-claim:{selector}@{verification.sha}")
         elif verification.state == STATE_STALE:
             sources.append(f"test:stale:{selector}@{verification.code}")
         elif verification.state == STATE_VERIFIED:
@@ -350,9 +534,14 @@ def evidence_source_strings(
 
 __all__ = [
     "TestEvidenceVerification",
+    "CiEvidenceDocument",
     "verify_test_evidence",
+    "parse_ci_evidence_document",
+    "match_ci_evidence",
     "evidence_source_strings",
+    "CI_EVIDENCE_SCHEMA",
     "STATE_DECLARED",
+    "STATE_MATCHED",
     "STATE_VERIFIED",
     "STATE_STALE",
     "STATE_INVALID",
@@ -362,4 +551,7 @@ __all__ = [
     "REASON_SHA_MISMATCH",
     "REASON_SELECTOR_NOT_FOUND",
     "REASON_NO_VERIFICATION",
+    "REASON_MALFORMED_EVIDENCE",
+    "REASON_UNKNOWN_SCHEMA",
+    "REASON_MISSING_PROVENANCE",
 ]

--- a/mneme/github_evidence.py
+++ b/mneme/github_evidence.py
@@ -1,0 +1,446 @@
+"""
+github_evidence.py — Authenticated GitHub Actions CI *claim* (ADR-024).
+
+Authenticates a GitHub Actions workflow run and its evidence artifact through
+the GitHub REST API, producing an authenticated CI **claim** — not a
+verification. The distinction matters: GitHub proves the run, repository,
+SHA, and artifact association, but the artifact *content* is still produced
+by repository-controlled workflow code. A malicious or mistaken workflow can
+upload ``{"outcome": "passed"}`` without executing the test. Therefore
+authenticated artifact provenance is a stronger claim
+(``authenticated_ci_claim``), never the ``verified`` state that Mneme maps to
+Protected.
+
+Trust chain (each step independently validated, fail-closed):
+
+    authenticated GitHub API (Bearer token)
+        → repository identity (owner/repo == audited remote)
+        → workflow run (exists, belongs to that repository)
+        → exact run head SHA (== audited repository HEAD)
+        → run artifact (exists, not expired, named ``mneme-test-results``)
+        → authenticated artifact download (signed blob, token NOT forwarded)
+        → evidence document (parses as ``mneme.test-evidence/v1`` and its
+          ``repository_sha`` equals the run head SHA)
+        → authenticated CI claim
+
+Only :func:`audit_with_github_claim` — the single supported public operation —
+runs this chain and folds the resulting ``authenticated_ci_claim`` state into
+an assessment report. It cannot reach ``verified``/Protected. The
+``verified`` state is reserved for a future trusted producer (a
+Mneme-controlled verifier, pinned and attested); no such producer exists in
+M0.
+
+Security boundary (honest): Python code in the same process can always
+monkeypatch or private-call internals. The guarantee here is that Mneme's
+SUPPORTED PUBLIC API (``mneme.enforcer.assess_protection`` /
+``generate_protection_report`` and the ``mneme audit`` CLI) accepts no
+trust-bearing parameter, so no supported caller can self-certify protection.
+
+Default ``mneme audit`` never calls GitHub: this is a library/service entry
+point, not part of the offline audit path.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mneme.evidence import CiEvidenceDocument, parse_ci_evidence_document
+
+if TYPE_CHECKING:  # pragma: no cover - avoid import cycle at runtime
+    from mneme.enforcer import ArchitectureProtectionReport
+
+DEFAULT_GITHUB_API_URL = "https://api.github.com"
+DEFAULT_ARTIFACT_NAME = "mneme-test-results"
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+
+# Remote URL forms we resolve to (owner, repo):
+#   https://github.com/owner/repo(.git)
+#   git@github.com:owner/repo(.git)
+#   ssh://git@github.com/owner/repo(.git)
+_REMOTE_RE = re.compile(
+    r"(?:https?://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+    r"([^/]+)/([^/]+?)(?:\.git)?/?$"
+)
+
+
+class GitHubVerificationError(Exception):
+    """Authenticated CI verification failed; no trusted evidence produced."""
+
+    def __init__(self, message: str, status: int | None = None):
+        self.status = status
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class _AuthenticatedCiClaim:
+    """An authenticated CI claim, produced only by :func:`verify_github_run`.
+
+    Private: it is not a trust root (the artifact content is
+    repository-controlled), and it is never exposed as a parameter on any
+    public assessment/report API.
+    """
+
+    repository: str  # "owner/repo", authenticated via the API
+    run_id: int
+    head_sha: str  # == audited repository HEAD, validated
+    document: CiEvidenceDocument  # the authenticated, parsed evidence carrier
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Never follow a redirect automatically; the caller handles it safely."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _http_open(
+    url: str,
+    headers: dict[str, str],
+    timeout: float,
+) -> tuple[int, dict[str, str], bytes]:
+    """Perform ONE request with NO automatic redirect following.
+
+    Returns ``(status, headers, body)``. This is the single HTTP seam so that
+    the redirect behaviour — in particular, never forwarding the Authorization
+    header to a different host — is deterministic and testable.
+    """
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with _NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
+            status = getattr(response, "status", 200)
+            response_headers = {
+                k.lower(): v for k, v in response.headers.items()
+            }
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        response_headers = {
+            k.lower(): v for k, v in (exc.headers.items() if exc.headers else [])
+        }
+        body = exc.read() if hasattr(exc, "read") else b""
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise GitHubVerificationError(f"could not reach {url}: {exc}") from exc
+    return status, response_headers, body
+
+
+def _api_get_json(
+    path: str,
+    token: str,
+    base_url: str,
+    timeout: float,
+) -> dict:
+    """Authenticated GitHub REST API GET returning parsed JSON."""
+    url = f"{base_url}{path}"
+    status, _headers, body = _http_open(url, _auth_headers(token), timeout)
+    if status >= 400:
+        raise GitHubVerificationError(
+            f"GitHub API {path} returned HTTP {status}", status=status
+        )
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitHubVerificationError(
+            f"GitHub API {path} returned a non-JSON response (HTTP {status})"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise GitHubVerificationError(
+            f"GitHub API {path} returned an unexpected payload (HTTP {status})"
+        )
+    return payload
+
+
+def _download_artifact(
+    path: str,
+    token: str,
+    base_url: str,
+    timeout: float,
+) -> bytes:
+    """Authenticated artifact download with safe redirect handling.
+
+    The first request carries the bearer token. If GitHub redirects to a
+    signed blob URL (a different host), the follow-up request is issued
+    WITHOUT any Authorization header, so the token is never forwarded to a
+    non-API host.
+    """
+    url = f"{base_url}{path}"
+    status, headers, body = _http_open(url, _auth_headers(token), timeout)
+    if status in _REDIRECT_STATUSES:
+        location = headers.get("location")
+        if not location:
+            raise GitHubVerificationError(
+                f"artifact download {path} redirected without a Location header"
+            )
+        status, _headers, body = _http_open(location, {}, timeout)
+        if status >= 400:
+            raise GitHubVerificationError(
+                f"artifact download returned HTTP {status}", status=status
+            )
+        return body
+    if status >= 400:
+        raise GitHubVerificationError(
+            f"artifact download {path} returned HTTP {status}", status=status
+        )
+    return body
+
+
+def _repo_head(repo_root: str | os.PathLike[str]) -> str:
+    """Exact HEAD SHA of the audited repository via the git binary."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise GitHubVerificationError(
+            f"could not determine the repository HEAD SHA: {exc}"
+        ) from exc
+    sha = (result.stdout or "").strip()
+    if result.returncode != 0 or not sha:
+        raise GitHubVerificationError("could not determine the repository HEAD SHA")
+    return sha
+
+
+def _resolve_remote_identity(repo_root: str | os.PathLike[str]) -> str:
+    """Resolve the audited repository's canonical ``owner/repo`` identity.
+
+    Reads ``git remote get-url origin`` (the git binary — never repository
+    code) and parses the canonical owner/repo from the URL.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise GitHubVerificationError(
+            f"could not determine the repository remote: {exc}"
+        ) from exc
+    if result.returncode != 0:
+        raise GitHubVerificationError(
+            "could not determine the repository remote (git remote get-url origin)"
+        )
+    remote = (result.stdout or "").strip()
+    match = _REMOTE_RE.search(remote)
+    if match is None:
+        raise GitHubVerificationError(
+            f"unrecognized origin remote URL {remote!r}; cannot prove repository identity"
+        )
+    owner, repo = match.group(1), match.group(2)
+    if not owner or not repo:
+        raise GitHubVerificationError(
+            f"could not parse owner/repo from origin remote {remote!r}"
+        )
+    return f"{owner}/{repo}"
+
+
+def _read_evidence_document(data: bytes) -> str:
+    """Extract the evidence document text from the downloaded artifact zip."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            members = [name for name in archive.namelist() if name.endswith(".json")]
+    except (zipfile.BadZipFile, OSError) as exc:
+        raise GitHubVerificationError(
+            f"artifact is not a valid zip archive: {exc}"
+        ) from exc
+    if len(members) != 1:
+        raise GitHubVerificationError(
+            "artifact must contain exactly one evidence document (.json); "
+            f"found {len(members)}"
+        )
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            return archive.read(members[0]).decode("utf-8")
+    except (UnicodeDecodeError, zipfile.BadZipFile, KeyError, OSError) as exc:
+        raise GitHubVerificationError(
+            f"could not read the evidence document from the artifact: {exc}"
+        ) from exc
+
+
+def verify_github_run(
+    repo_root: str | os.PathLike[str],
+    run_id: int,
+    audited_sha: str,
+    token: str | None = None,
+    owner: str | None = None,
+    repo: str | None = None,
+    artifact_name: str = DEFAULT_ARTIFACT_NAME,
+    base_url: str = DEFAULT_GITHUB_API_URL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> _AuthenticatedCiClaim:
+    """Authenticate a GitHub Actions run and return its evidence claim.
+
+    Validates, in order, that:
+
+    1. a GitHub token is available (``GITHUB_TOKEN`` / ``MNEME_GITHUB_TOKEN``
+       or an explicit ``token``);
+    2. the audited repository identity resolves from the origin remote (or is
+       supplied as ``owner``/``repo``);
+    3. the referenced workflow run exists and belongs to exactly that
+       repository;
+    4. the run's ``head_sha`` equals ``audited_sha`` exactly;
+    5. an artifact named ``artifact_name`` exists for that run and is not
+       expired;
+    6. the artifact downloads and parses as ``mneme.test-evidence/v1``, and
+       its ``repository_sha`` equals the run ``head_sha``.
+
+    Any failure raises :class:`GitHubVerificationError`. The returned value is
+    an authenticated CI **claim** — the artifact content is repository-
+    controlled, so this is not execution proof and never reaches the
+    ``verified`` state. Only this function constructs ``_AuthenticatedCiClaim``.
+    """
+    token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get(
+        "MNEME_GITHUB_TOKEN"
+    )
+    if not token:
+        raise GitHubVerificationError(
+            "no GitHub token available (set GITHUB_TOKEN or MNEME_GITHUB_TOKEN)"
+        )
+
+    identity = f"{owner}/{repo}" if owner and repo else _resolve_remote_identity(
+        repo_root
+    )
+
+    run = _api_get_json(
+        f"/repos/{identity}/actions/runs/{run_id}", token, base_url, timeout
+    )
+    run_repository = run.get("head_repository") or {}
+    run_full_name = run_repository.get("full_name") or ""
+    if run_full_name and run_full_name != identity:
+        raise GitHubVerificationError(
+            f"run {run_id} belongs to {run_full_name!r}, not the audited "
+            f"repository {identity!r}"
+        )
+
+    head_sha = run.get("head_sha")
+    if not isinstance(head_sha, str) or not head_sha:
+        raise GitHubVerificationError(f"run {run_id} reported no head SHA")
+    if head_sha != audited_sha:
+        raise GitHubVerificationError(
+            f"run {run_id} head SHA {head_sha} does not match the audited "
+            f"repository SHA {audited_sha}"
+        )
+
+    artifacts = _api_get_json(
+        f"/repos/{identity}/actions/runs/{run_id}/artifacts",
+        token,
+        base_url,
+        timeout,
+    )
+    artifact = next(
+        (
+            a for a in artifacts.get("artifacts", [])
+            if isinstance(a, dict)
+            and a.get("name") == artifact_name
+            and not a.get("expired", False)
+        ),
+        None,
+    )
+    if artifact is None:
+        raise GitHubVerificationError(
+            f"run {run_id} has no non-expired artifact named {artifact_name!r}"
+        )
+    artifact_id = artifact.get("id")
+    if not isinstance(artifact_id, int):
+        raise GitHubVerificationError(
+            f"run {run_id} artifact {artifact_name!r} has no usable id"
+        )
+
+    raw = _download_artifact(
+        f"/repos/{identity}/actions/artifacts/{artifact_id}/zip",
+        token,
+        base_url,
+        timeout,
+    )
+    document, reason = parse_ci_evidence_document(_read_evidence_document(raw))
+    if document is None:
+        raise GitHubVerificationError(
+            f"artifact {artifact_name!r} is not valid test evidence: {reason}"
+        )
+    if document.repository_sha != head_sha:
+        raise GitHubVerificationError(
+            f"artifact evidence SHA {document.repository_sha} does not match "
+            f"run head SHA {head_sha}"
+        )
+
+    return _AuthenticatedCiClaim(
+        repository=identity,
+        run_id=run_id,
+        head_sha=head_sha,
+        document=document,
+    )
+
+
+def audit_with_github_claim(
+    decisions: list,
+    repo_root: str | os.PathLike[str],
+    run_id: int,
+    token: str | None = None,
+    owner: str | None = None,
+    repo: str | None = None,
+    artifact_name: str = DEFAULT_ARTIFACT_NAME,
+    base_url: str = DEFAULT_GITHUB_API_URL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> "ArchitectureProtectionReport":
+    """Authenticated assessment: run the GitHub chain and fold in the claim.
+
+    This is the ONLY supported public operation that exercises the
+    authenticated path. It authenticates the run (``verify_github_run``) and
+    produces a report whose test-evidence entries reach at most the
+    ``authenticated_ci_claim`` state — never ``verified``/Protected — because
+    the artifact content is repository-controlled and Mneme has no trusted
+    verification producer in M0.
+    """
+    audited_sha = _repo_head(repo_root)
+    claim = verify_github_run(
+        repo_root,
+        run_id,
+        audited_sha,
+        token=token,
+        owner=owner,
+        repo=repo,
+        artifact_name=artifact_name,
+        base_url=base_url,
+        timeout=timeout,
+    )
+    from mneme.enforcer import _build_report
+    from mneme.evidence import _verify_test_evidence
+
+    results = _verify_test_evidence(decisions, repo_root, None, claim)
+    return _build_report(decisions, repo_root, results)
+
+
+__all__ = [
+    "GitHubVerificationError",
+    "verify_github_run",
+    "audit_with_github_claim",
+]

--- a/mneme/memory_store.py
+++ b/mneme/memory_store.py
@@ -148,6 +148,11 @@ class MemoryStore:
                     _load_rule(rule)
                     for rule in d.get("rules", [])
                 ],
+                test_evidence=[
+                    entry
+                    for entry in (d.get("test_evidence") or [])
+                    if isinstance(entry, dict)
+                ],
                 source_path=_resolve_source_path(
                     self.path,
                     d.get("source"),

--- a/mneme/schemas.py
+++ b/mneme/schemas.py
@@ -221,7 +221,14 @@ class Decision:
         anti_patterns: Explicitly forbidden approaches,
                        e.g. ["introduce ORM", "add migration layer"].
         rules:          Mechanically enforceable typed rules. Unlike legacy
-                       constraint prose, each type has exact semantics.
+                        constraint prose, each type has exact semantics.
+        test_evidence:  Declared test-evidence entries (ADR-024). Each entry
+                        is an explicit, human-authored linkage from this
+                        decision to a test that enforces it:
+                        {"selector": <pytest node id>,
+                         "sha": <optional pinned repository SHA>}.
+                        Optional and additive; absent or malformed entries
+                        contribute no protection evidence (fail closed).
         source_path:    Resolved ADR source path when provenance is available.
                        Runtime-only; persisted under the existing ``source``
                        block rather than as a top-level Decision field.
@@ -244,6 +251,7 @@ class Decision:
     created_at: str = ""
     updated_at: str = ""
     rules: list[Rule] = field(default_factory=list)
+    test_evidence: list[dict[str, str]] = field(default_factory=list)
     source_path: str = ""
     memory_path: str = ""
     status: str = "active"

--- a/tests/test_audit_test_evidence.py
+++ b/tests/test_audit_test_evidence.py
@@ -1,0 +1,702 @@
+"""Test-evidence ingestion for the P1.2 audit (ADR-024, passive model).
+
+Regression tests for the declared test-evidence channel under the
+passive-Audit security invariant:
+
+    Architecture Audit does not execute code from the audited repository
+    unless the user explicitly requests an execution-capable verification
+    mode.
+
+Frozen principles pinned here:
+
+- Ordinary `mneme audit` never invokes pytest, conftest, plugins, or any
+  other repository-controlled code — verified by an execution sentinel
+  (a conftest.py that would create a marker file if imported) and by
+  recording every subprocess invocation reachable from the evidence
+  module.
+- DECLARED is not VERIFIED: a merely declared decision→test linkage
+  annotates evidence_sources/diagnostics but never protects. M0 has no
+  trusted verification producer (CI-produced exact-SHA + exact-selector
+  ingestion is the next task).
+- Advisory (Guidance) intent is evidence-independent: declared test
+  evidence never upgrades it.
+- Every failure mode (missing selector, malformed selector, missing file,
+  SHA unavailable, stale SHA pin, ambiguous mapping, declared-but-
+  unverified) fails closed with a deterministic diagnostic.
+- Existing typed-rule / CI protection paths and the Protect / Validate /
+  strict-refusal loop are unchanged.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+from mneme.cli import main
+from mneme.enforcer import generate_protection_report
+from mneme.evidence import (
+    REASON_SELECTOR_NOT_FOUND,
+    REASON_SHA_MISMATCH,
+)
+from mneme.protection import (
+    activate_protection,
+    activation_precheck,
+    find_candidates,
+)
+from mneme.schemas import Decision, Rule
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+BASE_TS = "2026-01-01T00:00:00Z"
+
+PASSING_TEST = "def test_empty_input_rejected():\n    assert True\n"
+UNRELATED_TEST = "def test_markdown_render():\n    assert True\n"
+FAILING_TEST = "def test_empty_input_rejected():\n    assert False\n"
+
+DETERMINISTIC_DECISION = "Reject empty input before calling the model."
+ADVISORY_DECISION = "Prefer simple architectures where practical."
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(
+    tmp_path: Path,
+    test_body: str,
+    test_file: str = "tests/test_boundary.py",
+    decisions: list[dict] | None = None,
+    second_commit: bool = False,
+    extra_files: dict[str, str] | None = None,
+) -> tuple[Path, Path, str]:
+    """Create a real git repository with a test file and fixture memory."""
+    root = tmp_path / "repo"
+    (root / "tests").mkdir(parents=True)
+    (root / test_file).write_text(test_body, encoding="utf-8")
+    for name, content in (extra_files or {}).items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "evidence", "description": "ADR-024 fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": decisions or [],
+    }, indent=2) + "\n", encoding="utf-8")
+    _git(root, "init", "-q")
+    _git(root, "-c", "user.email=test@example.com", "-c",
+         "user.name=tester", "add", "-A")
+    _git(root, "-c", "user.email=test@example.com", "-c",
+         "user.name=tester", "commit", "-q", "-m", "fixture")
+    sha = _git(root, "rev-parse", "HEAD")
+    if second_commit:
+        (root / "OTHER.txt").write_text("later", encoding="utf-8")
+        _git(root, "add", "-A")
+        _git(root, "-c", "user.email=test@example.com", "-c",
+             "user.name=tester", "commit", "-q", "-m", "second")
+    return root, memory, sha
+
+
+def _decision_record(
+    decision_id: str,
+    text: str,
+    selectors: list[dict] | None = None,
+) -> dict:
+    record = {
+        "id": decision_id,
+        "decision": text,
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": [],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    }
+    if selectors is not None:
+        record["test_evidence"] = selectors
+    return record
+
+
+# ── 1+12. Passive audit: declared evidence never executes, never protects ───
+
+
+def test_ordinary_audit_never_executes_repository_code(tmp_path, monkeypatch):
+    """Ordinary `mneme audit` must not execute repository-controlled code.
+
+    Belt: a recorded-subprocess guard inside the evidence module proves no
+    pytest invocation happens. Brace: a conftest.py execution sentinel —
+    a conftest that would create a marker file the moment any pytest run
+    imports it — must never appear."""
+    import mneme.evidence as evidence_module
+
+    executions: list[list[str]] = []
+    real_run = evidence_module.subprocess.run
+
+    def recording_run(command, *args, **kwargs):
+        executions.append([str(part) for part in command])
+        return real_run(command, *args, **kwargs)
+
+    sentinel_conftest = (
+        "from pathlib import Path\n"
+        "Path(__file__).resolve().parent / 'EXECUTED.txt'"
+        ".write_text('repository code ran')\n"
+    )
+    root, memory, _sha = _init_repo(
+        tmp_path,
+        PASSING_TEST,
+        extra_files={"conftest.py": sentinel_conftest},
+        decisions=[
+            _decision_record(
+                "dp-empty-input",
+                DETERMINISTIC_DECISION,
+                [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+            ),
+        ],
+    )
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+
+    monkeypatch.setattr(evidence_module.subprocess, "run", recording_run)
+    exit_code = main([
+        "audit", "--memory", str(memory),
+        "--repo-root", str(root),
+    ])
+    assert exit_code == 0
+
+    # Every subprocess invocation was the passive git SHA read — never pytest.
+    assert executions, "the audit should still pin the repository SHA"
+    for command in executions:
+        assert command[:3] == ["git", "rev-parse", "HEAD"], command
+        assert not any("pytest" in part for part in command), command
+
+    # The conftest execution sentinel was never created: no repository
+    # code ran.
+    assert not (root / "EXECUTED.txt").exists()
+    assert not list(root.rglob("__pycache__"))
+    assert not (root / ".pytest_cache").exists()
+
+    # Declared evidence annotates but never protects.
+    audit_json = tmp_path / "audit.json"
+    exit_code = main([
+        "audit", "--memory", str(memory),
+        "--repo-root", str(root), "--json", str(audit_json),
+    ])
+    assert exit_code == 0
+    data = json.loads(audit_json.read_text(encoding="utf-8"))
+    decision = data["decisions"][0]
+    assert decision["protection_tier"] == "requires_modelling"
+    assert decision["evidence_confidence"] == "none"
+    assert decision["evidence_sources"] == [
+        "test:declared:tests/test_boundary.py::test_empty_input_rejected",
+    ]
+    assert data["summary"]["protected"] == 0
+    assert data["summary"]["current_protection_pct"] == 0.0
+    assert data["summary"]["identified_mneme_potential_pct"] == 100.0
+
+
+def test_declared_selector_alone_does_not_protect(tmp_path):
+    """A merely DECLARED linkage annotates but classification keeps
+    Requires Modelling — declared evidence is not verified evidence."""
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.intent == "deterministic"
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == [
+        "test:declared:tests/test_boundary.py::test_empty_input_rejected",
+    ]
+    assert report.protection_relevant == 1
+    assert report.requires_modelling == 1
+    assert report.protected == 0
+    assert report.current_protection_pct == 0.0
+    assert report.identified_mneme_potential_pct == 100.0
+
+
+# ── 2. Passing unrelated test cannot establish protection ───────────────────
+
+
+def test_unrelated_passing_test_not_credited(tmp_path):
+    """An undeclared passing test is never credited: Mneme performs no
+    scanning, no fuzzy matching, no inference."""
+    root, memory, _sha = _init_repo(tmp_path, UNRELATED_TEST, decisions=[
+        _decision_record("dp-output-contract",
+                         "Validate the output contract before showing the draft."),
+    ])
+    decisions = [
+        Decision(
+            id="dp-output-contract",
+            decision="Validate the output contract before showing the draft.",
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == []
+
+
+def test_wrongly_declared_selector_does_not_protect(tmp_path):
+    """A declared linkage whose selector does not correspond to the
+    decision's boundary still never protects: M0 has no trusted
+    verification producer, so the declaration annotates only."""
+    root, memory, _sha = _init_repo(tmp_path, UNRELATED_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_markdown_render"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_markdown_render"},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_sources == [
+        "test:declared:tests/test_boundary.py::test_markdown_render",
+    ]
+    assert report.protected == 0
+
+
+# ── 3+8. Missing/malformed selector fails closed ────────────────────────────
+
+
+def test_missing_selector_file_is_invalid(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_absent.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_absent.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == [
+        "test:invalid:tests/test_absent.py::test_empty_input_rejected"
+        f"@{REASON_SELECTOR_NOT_FOUND}",
+    ]
+
+
+def test_malformed_selector_is_invalid(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "no separator here"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[{"selector": "no separator here"}],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.protection_tier == "requires_modelling"
+    assert "test:invalid:no separator here@malformed-selector" in (
+        assessment.evidence_sources
+    )
+
+
+# ── 4. Stale SHA pin refuses protection ─────────────────────────────────────
+
+
+def test_declared_sha_mismatch_is_stale(tmp_path):
+    """A declaration pinned to an old SHA is STALE — it annotates but
+    never protects; only a re-pinned, trusted verification could."""
+    root, memory, _first_sha = _init_repo(
+        tmp_path, PASSING_TEST, second_commit=True, decisions=[
+            _decision_record(
+                "dp-empty-input",
+                DETERMINISTIC_DECISION,
+                [{"selector": "tests/test_boundary.py::test_empty_input_rejected",
+                  "sha": "0" * 40}],
+            ),
+        ],
+    )
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected",
+                 "sha": "0" * 40},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_sources == [
+        "test:stale:tests/test_boundary.py::test_empty_input_rejected"
+        f"@{REASON_SHA_MISMATCH}",
+    ]
+    assert report.protected == 0
+
+
+# ── 6+7. Ambiguous mapping and advisory guidance refuse protection ──────────
+
+
+def test_ambiguous_mapping_protects_neither(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+        _decision_record(
+            "dp-other",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+        Decision(
+            id="dp-other",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    by_id = {d.id: d for d in report.decisions}
+
+    for assessment in by_id.values():
+        assert assessment.protection_tier == "requires_modelling"
+        assert assessment.evidence_confidence == "none"
+        assert all(
+            src.startswith("test:invalid:")
+            and src.endswith("@ambiguous-mapping")
+            for src in assessment.evidence_sources
+        ), assessment.evidence_sources
+    assert report.protected == 0
+
+
+def test_guidance_never_upgraded_by_test_evidence(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-guidance",
+            ADVISORY_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-guidance",
+            decision=ADVISORY_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+    report = generate_protection_report(decisions, repo_root=root)
+    assessment = report.decisions[0]
+
+    assert assessment.intent == "guidance"
+    assert assessment.protection_tier == "guidance"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == []
+    assert report.protection_relevant == 0
+    assert report.guidance == 1
+
+
+# ── 7. Declared but unverified evidence never upgrades the tier ─────────────
+
+
+def test_declared_but_unverified_stays_requires_modelling(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+
+    # No repository context: nothing can be validated, nothing protects.
+    report = generate_protection_report(decisions, repo_root=None)
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.decisions[0].evidence_sources == []
+    assert report.protection_relevant == 1
+    assert report.requires_modelling == 1
+
+
+# ── 8. Deterministic output for identical inputs ────────────────────────────
+
+
+def test_identical_declared_evidence_deterministic_output(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+    ])
+    decisions = [
+        Decision(
+            id="dp-empty-input",
+            decision=DETERMINISTIC_DECISION,
+            test_evidence=[
+                {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+            ],
+        ),
+    ]
+    first = generate_protection_report(decisions, repo_root=root)
+    second = generate_protection_report(decisions, repo_root=root)
+
+    def _snapshot(report):
+        return (
+            report.protection_relevant,
+            report.protected,
+            report.mneme_ready,
+            report.requires_modelling,
+            report.guidance,
+            report.current_protection_pct,
+            report.identified_mneme_potential_pct,
+            report.protection_gap_pct,
+            tuple(
+                (d.id, d.intent, d.protection_tier, d.evidence_confidence,
+                 tuple(d.evidence_sources))
+                for d in report.decisions
+            ),
+        )
+
+    assert _snapshot(first) == _snapshot(second)
+
+    audit_one = tmp_path / "audit-one.json"
+    audit_two = tmp_path / "audit-two.json"
+    assert main(["audit", "--memory", str(memory), "--repo-root", str(root),
+                 "--json", str(audit_one)]) == 0
+    assert main(["audit", "--memory", str(memory), "--repo-root", str(root),
+                 "--json", str(audit_two)]) == 0
+    assert audit_one.read_text(encoding="utf-8") == audit_two.read_text(
+        encoding="utf-8"
+    )
+
+
+# ── 9+10. Existing CI / typed-rule paths remain unchanged ───────────────────
+
+
+def test_typed_rule_and_ci_paths_unchanged(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record("dp-typed", "Keep the package namespace distinct"),
+        _decision_record("dp-ci", "No psycopg2 in the service layer"),
+    ])
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(
+        "jobs:\n  guard:\n    steps:\n"
+        "      - run: if grep -rq psycopg2 src/; then exit 1; fi\n",
+        encoding="utf-8",
+    )
+    memory.write_text(json.dumps({
+        "meta": {"name": "evidence", "description": "ADR-024 fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "dp-typed",
+                "decision": "Keep the package namespace distinct",
+                "rationale": "",
+                "scope": [],
+                "constraints": [],
+                "anti_patterns": [],
+                "rules": [{"type": "FORBID_LITERAL", "value": "sqlite"}],
+                "created_at": BASE_TS,
+                "updated_at": BASE_TS,
+            },
+            {
+                "id": "dp-ci",
+                "decision": "No psycopg2 in the service layer",
+                "rationale": "",
+                "scope": [],
+                "constraints": [],
+                "anti_patterns": ["psycopg2"],
+                "created_at": BASE_TS,
+                "updated_at": BASE_TS,
+            },
+        ],
+    }, indent=2) + "\n", encoding="utf-8")
+
+    from mneme.memory_store import MemoryStore
+
+    store = MemoryStore(memory)
+    store.load()
+    report = generate_protection_report(store.decisions(), repo_root=root)
+    by_id = {d.id: d for d in report.decisions}
+
+    assert by_id["dp-typed"].protection_tier == "protected"
+    assert by_id["dp-typed"].evidence_sources == []
+    assert by_id["dp-ci"].protection_tier == "protected"
+    assert any(
+        src.startswith("ci:verified:") for src in by_id["dp-ci"].evidence_sources
+    )
+    assert report.protected == 2
+    assert report.current_protection_pct == 100.0
+
+
+# ── 11. Protect / Validate / strict refusal remain unchanged ────────────────
+
+
+def test_protect_loop_unchanged_with_declared_evidence(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, PASSING_TEST, decisions=[
+        _decision_record(
+            "dp-empty-input",
+            DETERMINISTIC_DECISION,
+            [{"selector": "tests/test_boundary.py::test_empty_input_rejected"}],
+        ),
+        _decision_record("dp-unlinked",
+                         "Validate the output contract before showing the draft."),
+    ])
+
+    from mneme.memory_store import MemoryStore
+
+    store = MemoryStore(memory)
+    store.load()
+    discovered = find_candidates(store.decisions(), repo_root=root)
+
+    # A declared-but-unverified decision is Requires Modelling, never a
+    # candidate; nothing is protected, nothing is activatable.
+    ids = [c.decision_id for c in discovered.candidates]
+    assert ids == [], ids
+    assert discovered.report.protected == 0
+    assert discovered.report.requires_modelling == 2
+
+    declared = Decision(
+        id="dp-empty-input",
+        decision=DETERMINISTIC_DECISION,
+        test_evidence=[
+            {"selector": "tests/test_boundary.py::test_empty_input_rejected"},
+        ],
+    )
+    pre = activation_precheck(declared, repo_root=root)
+    assert pre.eligible is False and pre.tier == "requires_modelling"
+    assert activate_protection(
+        "dp-empty-input", memory, repo_root=root
+    ).result == "not_eligible"
+
+    # The strict-refusal loop itself is untouched: a Mneme-ready decision
+    # whose deterministic validation fails is refused and nothing is written.
+    ready_memory = tmp_path / "ready.json"
+    ready_memory.parent.mkdir(parents=True, exist_ok=True)
+    ready_memory.write_text(json.dumps({
+        "meta": {"name": "e", "description": "e"},
+        "items": [],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "d-ready",
+                "decision": "No postgres in the service layer",
+                "rationale": "",
+                "scope": [],
+                "constraints": [],
+                "anti_patterns": ["postgres"],
+                "created_at": BASE_TS,
+                "updated_at": BASE_TS,
+            },
+        ],
+    }, indent=2) + "\n", encoding="utf-8")
+    ready = Decision(
+        id="d-ready",
+        decision="No postgres in the service layer",
+        anti_patterns=["postgres"],
+        memory_path=str(ready_memory),
+    )
+    ready_pre = activation_precheck(ready)
+    assert ready_pre.eligible is True and ready_pre.tier == "mneme_ready"
+
+    import mneme.protection as protection
+
+    real_check = protection.check_prompt
+
+    def blind_check(text, scored, top=3, input_path=None):
+        result = real_check(text, scored, top=top, input_path=input_path)
+        result.violations = [
+            v for v in result.violations if v.kind != "typed_rule"
+        ]
+        return result
+
+    before = ready_memory.read_text(encoding="utf-8")
+    baseline = generate_protection_report([ready])
+    original_check = protection.check_prompt
+    try:
+        protection.check_prompt = blind_check
+        outcome = activate_protection("d-ready", ready_memory)
+        assert outcome.result == "validation_failed"
+        assert outcome.rule_installed is False
+    finally:
+        protection.check_prompt = original_check
+    assert ready_memory.read_text(encoding="utf-8") == before
+    after = generate_protection_report([ready])
+    assert after.current_protection_pct == baseline.current_protection_pct

--- a/tests/test_audit_tier_semantics.py
+++ b/tests/test_audit_tier_semantics.py
@@ -1,0 +1,468 @@
+"""P1.2 Architecture Audit tier semantics (ADR-023 hardening).
+
+Regression tests for the two P0 defects found by the first real Design
+Partner diagnostic (sagarika29/ai-system-architect):
+
+1. Tier classification must derive from what the architectural decision
+   MEANS (deterministic requirement vs advisory statement), not from which
+   structured fields happen to be populated. Adding a syntactic structure
+   or a constraint field must not, by itself, move a decision out of
+   guidance.
+
+2. "Identified Mneme Potential" must count decisions that are
+   deterministically enforceable in principle (Mneme-ready + Requires
+   modelling), not only decisions immediately expressible by existing rule
+   types. Guidance never enters the numerator or the denominator.
+
+The Design Partner boundaries corpus is used as a regression fixture from
+docs/architecture-boundaries-base.md (sagarika29/ai-system-architect);
+the repository itself is not modified and no partner-specific wording is
+special-cased in the implementation.
+"""
+import json
+from pathlib import Path
+
+from mneme.enforcer import (
+    assess_protection,
+    generate_protection_report,
+    propose_literal_rule,
+)
+from mneme.schemas import Decision, Rule
+
+
+# ── Part C.1: structure invariance ───────────────────────────────────────────
+
+ADVISORY_TEXT = "Prefer simple architectures where practical."
+DETERMINISTIC_TEXT = (
+    "Generated output must contain all required architecture sections; "
+    "otherwise fail closed."
+)
+
+
+def test_structural_constraint_cannot_flip_advisory_text():
+    """Byte-identical guidance text stays Guidance when a structural
+    constraint field is added (P0 finding #1, guidance direction)."""
+    without = assess_protection(Decision(id="d1", decision=ADVISORY_TEXT))
+    with_constraint = assess_protection(Decision(
+        id="d2",
+        decision=ADVISORY_TEXT,
+        constraints=["no empty descriptions"],
+    ))
+
+    for report in (without, with_constraint):
+        assert report.intent == "guidance"
+        assert report.protection_tier == "guidance"
+        assert report.mneme_guardrail is None
+
+    report = generate_protection_report([
+        Decision(id="d1", decision=ADVISORY_TEXT),
+        Decision(id="d2", decision=ADVISORY_TEXT, constraints=["no empty descriptions"]),
+    ])
+    assert report.guidance == 2
+    assert report.protection_relevant == 0
+    assert report.current_protection_pct == 0.0
+    assert report.identified_mneme_potential_pct == 0.0
+
+
+def test_deterministic_text_tier_stable_under_structural_constraint():
+    """Byte-identical deterministic text keeps its tier when a structural
+    constraint field is added — structure alone changes nothing."""
+    without = assess_protection(Decision(id="d1", decision=DETERMINISTIC_TEXT))
+    with_constraint = assess_protection(Decision(
+        id="d2",
+        decision=DETERMINISTIC_TEXT,
+        constraints=["no empty descriptions"],
+    ))
+
+    for report in (without, with_constraint):
+        assert report.intent == "deterministic"
+        assert report.protection_tier == "requires_modelling"
+        assert report.mneme_guardrail is None
+
+
+def test_advisory_statement_remains_guidance():
+    """A truly advisory statement is Guidance (evidence-independent)."""
+    report = assess_protection(Decision(
+        id="d1",
+        decision="Prefer simple architectures where practical.",
+        rationale="Complexity budget",
+    ))
+    assert report.intent == "guidance"
+    assert report.protection_tier == "guidance"
+
+
+def test_deterministic_text_without_rule_type_is_requires_modelling():
+    """A genuinely deterministic architectural requirement is
+    Requires-modelling even when no supported rule type can encode it."""
+    report = assess_protection(Decision(id="d1", decision=DETERMINISTIC_TEXT))
+    assert report.intent == "deterministic"
+    assert report.protection_tier == "requires_modelling"
+    assert report.mneme_guardrail is None
+
+    aggregate = generate_protection_report([report and Decision(
+        id="d1", decision=DETERMINISTIC_TEXT,
+    )])
+    assert aggregate.protection_relevant == 1
+    assert aggregate.requires_modelling == 1
+    assert aggregate.guidance == 0
+
+
+def test_literal_prohibition_is_mneme_ready_from_text_alone():
+    """A supported deterministic literal prohibition is Mneme-ready —
+    derived from the decision text without structured fields."""
+    decision = Decision(
+        id="d1",
+        decision="Generated recommendations must not use the term `seamless`.",
+    )
+    report = assess_protection(decision)
+    assert report.intent == "deterministic"
+    assert report.protection_tier == "mneme_ready"
+    assert report.mneme_guardrail == "FORBID_LITERAL: seamless"
+
+    proposal = propose_literal_rule(decision)
+    assert proposal is not None
+    assert proposal.type == "FORBID_LITERAL"
+    assert proposal.value == "seamless"
+    assert proposal.include_paths is None
+
+
+def test_literal_prohibition_stays_mneme_ready_with_field_backing():
+    """The pre-existing path (single-term anti-pattern field) still yields
+    Mneme-ready with the same guardrail."""
+    decision = Decision(
+        id="d1",
+        decision="Generated recommendations must not use the term `seamless`.",
+        anti_patterns=["seamless"],
+    )
+    report = assess_protection(decision)
+    assert report.protection_tier == "mneme_ready"
+    assert report.mneme_guardrail == "FORBID_LITERAL: seamless"
+    assert propose_literal_rule(decision).value == "seamless"
+
+
+def test_typed_rule_is_protected_regardless_of_text():
+    """Installed deterministic enforcement is Protected — the PROTECTED
+    definition is evidence-linked, independent of prose."""
+    decision = Decision(
+        id="d1",
+        decision=ADVISORY_TEXT,
+        rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+    )
+    report = assess_protection(decision)
+    assert report.protection_tier == "protected"
+    assert report.evidence_confidence == "verified"
+
+
+def test_interpretation_needing_prohibition_stays_requires_modelling():
+    """A deterministic prohibition whose literal is not explicit is never
+    guessed into a Mneme-ready guardrail from text alone."""
+    decision = Decision(
+        id="d1",
+        decision="The service must not depend on external database infrastructure.",
+    )
+    report = assess_protection(decision)
+    assert report.intent == "deterministic"
+    assert report.protection_tier == "requires_modelling"
+    assert report.mneme_guardrail is None
+
+
+# ── Part C.5: Potential calculation ──────────────────────────────────────────
+
+
+def test_potential_covers_ready_and_requires_modelling_not_protected():
+    """Potential = (Mneme-ready + Requires modelling) / protection-relevant.
+
+    Guidance is excluded from numerator and denominator; Protected counts
+    toward the denominator only."""
+    decisions = [
+        Decision(
+            id="p1",
+            decision="Store data in sqlite",
+            rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+        ),
+        Decision(
+            id="m1",
+            decision="Generated recommendations must not use the term `seamless`.",
+        ),
+        Decision(id="r1", decision=DETERMINISTIC_TEXT),
+        Decision(id="g1", decision=ADVISORY_TEXT),
+    ]
+    report = generate_protection_report(decisions)
+
+    active = [d for d in report.decisions if d.status == "active"]
+    p = sum(1 for d in active if d.protection_tier == "protected")
+    m = sum(1 for d in active if d.protection_tier == "mneme_ready")
+    r = sum(1 for d in active if d.protection_tier == "requires_modelling")
+    g = sum(1 for d in active if d.protection_tier == "guidance")
+    assert (p, m, r, g) == (1, 1, 1, 1)
+    assert report.protection_relevant == p + m + r == 3
+
+    assert report.current_protection_pct == round(p / 3 * 100, 1)
+    assert report.identified_mneme_potential_pct == round((m + r) / 3 * 100, 1)
+    assert report.protection_gap_pct == round((m + r) / 3 * 100, 1)
+    assert report.current_protection_pct + report.identified_mneme_potential_pct == 100.0
+
+
+def test_potential_excludes_guidance_even_when_dominant():
+    """A guidance-heavy corpus does not dilute the metric; with no
+    protection-relevant decisions the potential is 0, not inflated."""
+    decisions = [
+        Decision(id=f"g{i}", decision=ADVISORY_TEXT) for i in range(5)
+    ]
+    report = generate_protection_report(decisions)
+    assert report.guidance == 5
+    assert report.protection_relevant == 0
+    assert report.identified_mneme_potential_pct == 0.0
+    assert report.current_protection_pct == 0.0
+
+
+def test_report_deterministic_for_identical_inputs():
+    """Identical inputs produce byte-identical reports."""
+    decisions = [
+        Decision(
+            id="p1",
+            decision="Store data in sqlite",
+            rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+        ),
+        Decision(
+            id="m1",
+            decision="Generated recommendations must not use the term `seamless`.",
+        ),
+        Decision(id="r1", decision=DETERMINISTIC_TEXT),
+        Decision(id="g1", decision=ADVISORY_TEXT),
+    ]
+    first = generate_protection_report(decisions)
+    second = generate_protection_report(decisions)
+
+    def _snapshot(report):
+        return (
+            report.schema,
+            report.total_decisions,
+            report.protection_relevant,
+            report.protected,
+            report.mneme_ready,
+            report.requires_modelling,
+            report.guidance,
+            report.current_protection_pct,
+            report.identified_mneme_potential_pct,
+            report.protection_gap_pct,
+            tuple(
+                (d.id, d.intent, d.protection_tier, d.mneme_guardrail,
+                 d.evidence_confidence, tuple(d.evidence_sources))
+                for d in report.decisions
+            ),
+        )
+
+    assert _snapshot(first) == _snapshot(second)
+
+
+# ── Part D: Design Partner boundaries regression fixture ────────────────────
+
+# Decisions transcribed from docs/architecture-boundaries-base.md in
+# sagarika29/ai-system-architect (the diagnostic corpus). Used read-only as
+# a regression fixture; the repository itself is untouched.
+DP_BOUNDARIES = [
+    Decision(
+        id="dp-empty-input",
+        decision="Reject empty input before calling the model.",
+    ),
+    Decision(
+        id="dp-required-fields",
+        decision="Enforce required fields before calling the model.",
+    ),
+    Decision(
+        id="dp-output-contract",
+        decision=(
+            "Validate the generated output contract and fail closed when "
+            "required sections are missing."
+        ),
+    ),
+    Decision(
+        id="dp-pattern-selection",
+        decision="Architecture pattern selection can remain probabilistic.",
+    ),
+    Decision(
+        id="dp-practical-rule",
+        decision="If a decision can be unit tested, it should be deterministic.",
+    ),
+    Decision(
+        id="dp-banned-term",
+        decision="Generated recommendations must not use the term `seamless`.",
+    ),
+    Decision(
+        id="dp-protected-namespace",
+        decision="Keep the package namespace distinct from the product name",
+        rules=[Rule(type="FORBID_LITERAL", value="pip install ai-system-architect")],
+    ),
+]
+
+
+def test_design_partner_boundaries_distinguish_all_four_tiers():
+    """Audit separates: deterministic+protected vs deterministic and
+    representable now vs deterministic needing richer modelling vs actual
+    guidance — for the Design Partner boundary corpus."""
+    report = generate_protection_report(DP_BOUNDARIES)
+    by_id = {d.id: d for d in report.decisions}
+
+    # Deterministic but already protected.
+    assert by_id["dp-protected-namespace"].protection_tier == "protected"
+    # Deterministic and representable now (existing rule type + scope).
+    assert by_id["dp-banned-term"].protection_tier == "mneme_ready"
+    assert by_id["dp-banned-term"].mneme_guardrail == "FORBID_LITERAL: seamless"
+    # Deterministic but requiring richer modelling.
+    for decision_id in ("dp-empty-input", "dp-required-fields", "dp-output-contract"):
+        assert by_id[decision_id].protection_tier == "requires_modelling"
+        assert by_id[decision_id].intent == "deterministic"
+        assert by_id[decision_id].mneme_guardrail is None
+    # Actual guidance.
+    for decision_id in ("dp-pattern-selection", "dp-practical-rule"):
+        assert by_id[decision_id].protection_tier == "guidance"
+        assert by_id[decision_id].intent == "guidance"
+
+    assert report.protection_relevant == 5
+    assert report.protected == 1
+    assert report.mneme_ready == 1
+    assert report.requires_modelling == 3
+    assert report.guidance == 2
+    assert report.current_protection_pct == round(1 / 5 * 100, 1)
+    assert report.identified_mneme_potential_pct == round(4 / 5 * 100, 1)
+
+
+# ── Part C.6: Protect / Validate / strict refusal unchanged ─────────────────
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+BASE_TS = "2026-01-01T00:00:00Z"
+
+
+def _write_repo(tmp_path: Path, decisions: list[dict]) -> tuple[Path, Path]:
+    """Create a temporary repository with the fixture memory."""
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "adr23", "description": "ADR-023 fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": decisions,
+    }, indent=2) + "\n", encoding="utf-8")
+    return root, memory
+
+
+def _memory_decisions(memory: Path) -> list[dict]:
+    return json.loads(memory.read_text(encoding="utf-8"))["decisions"]
+
+
+def _raw_record(decision: Decision) -> dict:
+    record = {
+        "id": decision.id,
+        "decision": decision.decision,
+        "rationale": "",
+        "scope": [],
+        "constraints": list(decision.constraints),
+        "anti_patterns": list(decision.anti_patterns),
+        "rules": [
+            {
+                "type": r.type,
+                "value": r.value,
+                "exclude_paths": list(r.exclude_paths),
+                **({"include_paths": list(r.include_paths)} if r.include_paths else {}),
+            }
+            for r in decision.rules
+        ],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    }
+    return record
+
+
+def test_protect_loop_and_strict_refusal_unchanged(tmp_path, capsys, monkeypatch):
+    """Validate → activate → verify and strict-mode refusal behave exactly
+    as before under the amended semantics (Part C.6)."""
+    from mneme.protection import (
+        activate_protection,
+        activation_precheck,
+        validate_proposal,
+    )
+
+    root, memory = _write_repo(
+        tmp_path, [_raw_record(d) for d in DP_BOUNDARIES]
+    )
+    before = memory.read_text(encoding="utf-8")
+
+    # Mneme-ready candidate: eligible, validation passes.
+    banned = Decision(
+        id="dp-banned-term",
+        decision="Generated recommendations must not use the term `seamless`.",
+        memory_path=str(memory),
+    )
+    pre = activation_precheck(banned, repo_root=root)
+    assert pre.eligible is True and pre.tier == "mneme_ready"
+    assert pre.proposal.value == "seamless"
+    assert validate_proposal(banned, pre.proposal, memory_path=memory).status == "valid"
+
+    # Requires-modelling and Guidance are never candidates.
+    contract = next(d for d in DP_BOUNDARIES if d.id == "dp-output-contract")
+    assert activation_precheck(contract).eligible is False
+    assert activation_precheck(contract).tier == "requires_modelling"
+    guidance = next(d for d in DP_BOUNDARIES if d.id == "dp-pattern-selection")
+    assert activation_precheck(guidance).eligible is False
+    assert activation_precheck(guidance).tier == "guidance"
+
+    # Strict refusal: a failed deterministic validation writes nothing.
+    import mneme.protection as protection
+
+    real_check = protection.check_prompt
+
+    def blind_check(text, scored, top=3, input_path=None):
+        result = real_check(text, scored, top=top, input_path=input_path)
+        result.violations = [
+            v for v in result.violations if v.kind != "typed_rule"
+        ]
+        return result
+
+    baseline_report = generate_protection_report(
+        [d for d in DP_BOUNDARIES if d.id != "dp-banned-term"]
+    )
+    monkeypatch.setattr(protection, "check_prompt", blind_check)
+    try:
+        outcome = activate_protection("dp-banned-term", memory, repo_root=root)
+    finally:
+        monkeypatch.undo()
+    assert outcome.result == "validation_failed"
+    assert outcome.rule_installed is False
+    assert memory.read_text(encoding="utf-8") == before
+
+    after_refusal = generate_protection_report(
+        [d for d in DP_BOUNDARIES if d.id != "dp-banned-term"]
+    )
+    assert after_refusal.current_protection_pct == baseline_report.current_protection_pct
+    assert after_refusal.identified_mneme_potential_pct == (
+        baseline_report.identified_mneme_potential_pct
+    )
+
+    # Real activation installs the canonical typed rule and verifies.
+    capsys.readouterr()
+    outcome = activate_protection("dp-banned-term", memory, repo_root=root)
+    assert outcome.result == "verified"
+    assert outcome.verification_tier == "protected"
+    entry = next(
+        e for e in _memory_decisions(memory) if e["id"] == "dp-banned-term"
+    )
+    assert entry["rules"] == [{"type": "FORBID_LITERAL", "value": "seamless"}]
+
+    # A fresh canonical audit independently observes Protected.
+    reloaded = [
+        Decision(
+            id=e["id"],
+            decision=e["decision"],
+            anti_patterns=list(e.get("anti_patterns", [])),
+            constraints=list(e.get("constraints", [])),
+            rules=[Rule(type=r["type"], value=r["value"]) for r in e.get("rules", [])],
+        )
+        for e in _memory_decisions(memory)
+    ]
+    fresh = generate_protection_report(reloaded)
+    assert fresh.protected == 2
+    assert fresh.mneme_ready == 0
+    assert fresh.current_protection_pct == round(2 / 5 * 100, 1)

--- a/tests/test_ci_test_evidence.py
+++ b/tests/test_ci_test_evidence.py
@@ -1,0 +1,565 @@
+"""CI-produced test-evidence parsing and matching (ADR-024).
+
+Focused regression tests for the deterministic, fail-closed parsing and
+matching of a CI-produced test-result document against declared test
+evidence. A matching document is an **unauthenticated claim**, never a
+trust root.
+
+The security invariant:
+
+    `mneme audit` is passive and MUST NOT execute code from the audited
+    repository, and MUST NOT auto-trust a JSON file merely present in the
+    repository.
+
+These tests pin:
+
+- DECLARED alone does not protect;
+- an exact-SHA + exact-selector + "passed" document supplied by a caller is
+  at most a MATCHED_UNVERIFIED claim (``test:ci-claim:``), never Protected;
+- no producer/type/run_id value, and no self-asserted "verified"/"trusted"/
+  "authenticated" JSON field, can create the VERIFIED state;
+- an authored "passed": true with no provenance cannot protect;
+- SHA/selector/partial-match/suite-only/failed/skipped/malformed/unknown-
+  schema/ambiguous cases all fail closed;
+- Guidance is never upgraded;
+- existing typed-rule and CI-enforcement protection, the Protect/Validate/
+  refusal loop, and passive Audit are unchanged.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+from mneme.cli import main
+from mneme.enforcer import generate_protection_report
+from mneme.evidence import (
+    CI_EVIDENCE_SCHEMA,
+    REASON_MISSING_PROVENANCE,
+    REASON_UNKNOWN_SCHEMA,
+    match_ci_evidence,
+    parse_ci_evidence_document,
+)
+from mneme.schemas import Decision, Rule
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+BASE_TS = "2026-01-01T00:00:00Z"
+
+PASSING_TEST = "def test_empty_input_rejected():\n    assert True\n"
+DETERMINISTIC_DECISION = "Reject empty input before calling the model."
+ADVISORY_DECISION = "Prefer simple architectures where practical."
+SELECTOR = "tests/test_boundary.py::test_empty_input_rejected"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(
+    tmp_path: Path,
+    decisions: list[dict],
+    extra_files: dict[str, str] | None = None,
+) -> tuple[Path, Path, str]:
+    """A real git repository with a passing test and fixture memory."""
+    root = tmp_path / "repo"
+    (root / "tests").mkdir(parents=True)
+    (root / "tests" / "test_boundary.py").write_text(
+        PASSING_TEST, encoding="utf-8",
+    )
+    for name, content in (extra_files or {}).items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "ci-evidence", "description": "fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": decisions,
+    }, indent=2) + "\n", encoding="utf-8")
+    _git(root, "init", "-q")
+    _git(root, "-c", "user.email=t@e", "-c", "user.name=t", "add", "-A")
+    _git(root, "-c", "user.email=t@e", "-c", "user.name=t", "commit", "-q",
+         "-m", "fixture")
+    sha = _git(root, "rev-parse", "HEAD")
+    return root, memory, sha
+
+
+def _record(decision_id: str, text: str, selectors: list[dict] | None = None) -> dict:
+    record = {
+        "id": decision_id,
+        "decision": text,
+        "rationale": "",
+        "scope": [],
+        "constraints": [],
+        "anti_patterns": [],
+        "created_at": BASE_TS,
+        "updated_at": BASE_TS,
+    }
+    if selectors is not None:
+        record["test_evidence"] = selectors
+    return record
+
+
+def _declared_decision(decision_id: str = "dp-empty-input") -> Decision:
+    return Decision(
+        id=decision_id,
+        decision=DETERMINISTIC_DECISION,
+        test_evidence=[{"selector": SELECTOR}],
+    )
+
+
+def _evidence(sha: str, results: list[dict], schema: str | None = None,
+              producer: dict | None = None) -> str:
+    return json.dumps({
+        "schema": schema if schema is not None else CI_EVIDENCE_SCHEMA,
+        "repository_sha": sha,
+        "producer": producer if producer is not None else {
+            "type": "github-actions", "run_id": "run-123",
+        },
+        "results": results,
+    })
+
+
+# ── 1. DECLARED alone does not protect ──────────────────────────────────────
+
+
+def test_declared_alone_does_not_protect(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    report = generate_protection_report(decisions, repo_root=root)
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.decisions[0].evidence_sources == [f"test:declared:{SELECTOR}"]
+    assert report.protected == 0
+
+
+# ── 2. Valid matching CI document: exact SHA + selector + passed → CLAIM ────
+
+
+def test_valid_ci_evidence_does_not_protect(tmp_path):
+    """A valid, matching caller-supplied CI document is a claim, not proof.
+
+    Exact SHA + exact selector + passed + plausible provenance still only
+    yields MATCHED_UNVERIFIED — never Protected — because provenance is not
+    authenticated."""
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assessment = report.decisions[0]
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == [f"test:ci-claim:{SELECTOR}@{sha}"]
+    assert report.protected == 0
+    assert report.current_protection_pct == 0.0
+
+
+def test_fake_producer_does_not_create_verified(tmp_path):
+    """Arbitrary producer type/run_id cannot manufacture VERIFIED."""
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}],
+                    producer={"type": "totally-fake", "run_id": "not-a-real-run"})
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.decisions[0].evidence_sources == [
+        f"test:ci-claim:{SELECTOR}@{sha}",
+    ]
+    assert report.protected == 0
+
+
+def test_no_self_asserted_trust_field(tmp_path):
+    """No field inside the JSON can declare the document itself trusted."""
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = json.dumps({
+        "schema": CI_EVIDENCE_SCHEMA,
+        "repository_sha": sha,
+        "producer": {"type": "github-actions", "run_id": "r1"},
+        "verified": True,
+        "trusted": True,
+        "authenticated": True,
+        "results": [{"selector": SELECTOR, "outcome": "passed"}],
+    })
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.decisions[0].evidence_sources == [
+        f"test:ci-claim:{SELECTOR}@{sha}",
+    ]
+    assert report.protected == 0
+
+
+# ── 3+4. Authored "passed": true without provenance cannot protect ──────────
+
+
+def test_user_authored_passed_true_does_not_protect(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+
+    # A developer-authored flag with no schema/provenance is rejected.
+    forged = json.dumps({
+        "passed": True,
+        "selector": SELECTOR,
+        "sha": sha,
+    })
+    doc, reason = parse_ci_evidence_document(forged)
+    assert doc is None
+    assert reason == REASON_UNKNOWN_SCHEMA
+
+    # Even a plausible forged document with no provenance is rejected.
+    no_provenance = json.dumps({
+        "schema": CI_EVIDENCE_SCHEMA,
+        "repository_sha": sha,
+        "results": [{"selector": SELECTOR, "outcome": "passed"}],
+    })
+    doc, reason = parse_ci_evidence_document(no_provenance)
+    assert doc is None
+    assert reason == REASON_MISSING_PROVENANCE
+
+
+def test_repository_local_evidence_file_never_auto_trusted(tmp_path):
+    """A JSON file merely present in the repo is not discovered or trusted."""
+    root, memory, sha = _init_repo(
+        tmp_path,
+        [_record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}])],
+    )
+    # A perfectly-formed evidence file, on disk in the repo, for this SHA.
+    (root / ".mneme").mkdir(parents=True, exist_ok=True)
+    (root / ".mneme" / "test_evidence.json").write_text(
+        _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+        encoding="utf-8",
+    )
+    decisions = [_declared_decision()]
+    # No ci_evidence_document supplied: the on-disk file is irrelevant.
+    report = generate_protection_report(decisions, repo_root=root)
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+# ── 5. SHA mismatch fails closed ────────────────────────────────────────────
+
+
+def test_sha_mismatch_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence("0" * 40, [{"selector": SELECTOR, "outcome": "passed"}])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+# ── 6+7. Selector mismatch / partial match fails closed ─────────────────────
+
+
+def test_selector_mismatch_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [
+        {"selector": "tests/test_other.py::test_something_else", "outcome": "passed"},
+    ])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+def test_partial_selector_match_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    # Sub-string / prefix of the declared selector is not an exact match.
+    doc = _evidence(sha, [
+        {"selector": "tests/test_boundary.py::test_empty_input", "outcome": "passed"},
+    ])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+# ── 8. Global suite pass without selector result fails closed ───────────────
+
+
+def test_global_suite_pass_without_selector_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [{"selector": "<whole-suite>", "outcome": "passed"}])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+# ── 9+10. failed / skipped results fail closed ──────────────────────────────
+
+
+def test_failed_and_skipped_results_fail_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    for outcome in ("failed", "skipped", "xfailed", "error"):
+        decisions = [_declared_decision()]
+        doc = _evidence(sha, [{"selector": SELECTOR, "outcome": outcome}])
+        report = generate_protection_report(
+            decisions, repo_root=root, ci_evidence_document=doc,
+        )
+        assert report.decisions[0].protection_tier == "requires_modelling", outcome
+        assert report.protected == 0, outcome
+
+
+# ── 11+12. malformed / unknown-schema evidence fails closed ─────────────────
+
+
+def test_malformed_evidence_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    for bad in ("not json", "[", "null", '{"schema": 1}'):
+        report = generate_protection_report(
+            decisions, repo_root=root, ci_evidence_document=bad,
+        )
+        assert report.decisions[0].protection_tier == "requires_modelling", bad
+        assert report.protected == 0, bad
+
+
+def test_unknown_schema_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}],
+                    schema="someone.else/v9")
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.protected == 0
+
+
+# ── 13. Ambiguous selector declaration fails closed ────────────────────────
+
+
+def test_ambiguous_selector_fails_closed(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-a", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+        _record("dp-b", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [
+        Decision(id="dp-a", decision=DETERMINISTIC_DECISION,
+                 test_evidence=[{"selector": SELECTOR}]),
+        Decision(id="dp-b", decision=DETERMINISTIC_DECISION,
+                 test_evidence=[{"selector": SELECTOR}]),
+    ]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.protected == 0
+    assert all(
+        d.protection_tier == "requires_modelling" for d in report.decisions
+    )
+
+
+# ── 14. Guidance remains Guidance even with valid evidence ──────────────────
+
+
+def test_guidance_never_upgraded_even_with_valid_evidence(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-guid", ADVISORY_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [
+        Decision(id="dp-guid", decision=ADVISORY_DECISION,
+                 test_evidence=[{"selector": SELECTOR}]),
+    ]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}])
+    report = generate_protection_report(
+        decisions, repo_root=root, ci_evidence_document=doc,
+    )
+    assert report.decisions[0].intent == "guidance"
+    assert report.decisions[0].protection_tier == "guidance"
+    assert report.protected == 0
+
+
+# ── 15+16. Existing typed-rule / CI-enforcement protection unchanged ────────
+
+
+def test_typed_rule_and_ci_enforcement_unchanged(tmp_path):
+    root, memory, _sha = _init_repo(tmp_path, [
+        _record("dp-typed", "Keep the package namespace distinct"),
+        _record("dp-ci", "No psycopg2 in the service layer"),
+    ])
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(
+        "jobs:\n  guard:\n    steps:\n"
+        "      - run: if grep -rq psycopg2 src/; then exit 1; fi\n",
+        encoding="utf-8",
+    )
+    from mneme.memory_store import MemoryStore
+
+    memory.write_text(json.dumps({
+        "meta": {"name": "ci-evidence", "description": "fixture"},
+        "items": [],
+        "examples": [],
+        "decisions": [
+            {
+                "id": "dp-typed", "decision": "Keep the package namespace distinct",
+                "rationale": "", "scope": [], "constraints": [],
+                "anti_patterns": [],
+                "rules": [{"type": "FORBID_LITERAL", "value": "sqlite"}],
+                "created_at": BASE_TS, "updated_at": BASE_TS,
+            },
+            {
+                "id": "dp-ci", "decision": "No psycopg2 in the service layer",
+                "rationale": "", "scope": [], "constraints": [],
+                "anti_patterns": ["psycopg2"],
+                "created_at": BASE_TS, "updated_at": BASE_TS,
+            },
+        ],
+    }, indent=2) + "\n", encoding="utf-8")
+    store = MemoryStore(memory)
+    store.load()
+    report = generate_protection_report(store.decisions(), repo_root=root)
+    by_id = {d.id: d for d in report.decisions}
+    assert by_id["dp-typed"].protection_tier == "protected"
+    assert by_id["dp-ci"].protection_tier == "protected"
+    assert report.protected == 2
+
+
+# ── 17. Protect / Validate / strict refusal unchanged ───────────────────────
+
+
+def test_protect_loop_unchanged(tmp_path):
+    from mneme.protection import activation_precheck
+
+    root, memory, _sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    # A declared-only decision is not a candidate.
+    decision = _declared_decision()
+    pre = activation_precheck(decision, repo_root=root)
+    assert pre.eligible is False and pre.tier == "requires_modelling"
+
+    # A Mneme-ready decision remains eligible.
+    ready = Decision(id="d-ready", decision="No postgres in the service layer",
+                     anti_patterns=["postgres"])
+    ready_pre = activation_precheck(ready)
+    assert ready_pre.eligible is True and ready_pre.tier == "mneme_ready"
+
+
+# ── 18. Ordinary Audit does not execute repository code ─────────────────────
+
+
+def test_ordinary_audit_is_passive(tmp_path, monkeypatch):
+    import mneme.evidence as evidence_module
+
+    executions: list[list[str]] = []
+    real_run = evidence_module.subprocess.run
+
+    def recording_run(command, *args, **kwargs):
+        executions.append([str(p) for p in command])
+        return real_run(command, *args, **kwargs)
+
+    sentinel = (
+        "from pathlib import Path\n"
+        "Path(__file__).resolve().parent / 'EXECUTED.txt'"
+        ".write_text('ran')\n"
+    )
+    root, memory, sha = _init_repo(
+        tmp_path,
+        [_record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}])],
+        extra_files={"conftest.py": sentinel},
+    )
+
+    monkeypatch.setattr(evidence_module.subprocess, "run", recording_run)
+    exit_code = main(["audit", "--memory", str(memory), "--repo-root", str(root)])
+    assert exit_code == 0
+    for command in executions:
+        assert command[:3] == ["git", "rev-parse", "HEAD"], command
+        assert not any("pytest" in p for p in command), command
+    assert not (root / "EXECUTED.txt").exists()
+    assert not (root / ".pytest_cache").exists()
+    assert not list(root.rglob("__pycache__"))
+
+
+# ── 19. Deterministic output for identical inputs ──────────────────────────
+
+
+def test_deterministic_ci_evidence_output(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    doc = _evidence(sha, [{"selector": SELECTOR, "outcome": "passed"}])
+    first = generate_protection_report(decisions, repo_root=root, ci_evidence_document=doc)
+    second = generate_protection_report(decisions, repo_root=root, ci_evidence_document=doc)
+
+    def snapshot(r):
+        return (
+            r.protected, r.mneme_ready, r.requires_modelling, r.guidance,
+            r.current_protection_pct, r.identified_mneme_potential_pct,
+            tuple(
+                (d.id, d.protection_tier, d.evidence_confidence,
+                 tuple(d.evidence_sources))
+                for d in r.decisions
+            ),
+        )
+
+    assert snapshot(first) == snapshot(second)
+
+
+# ── match_ci_evidence is a pure function (no provenance trust, no exec) ────
+
+
+def test_match_ci_evidence_is_pure_and_requires_sha_and_provenance(tmp_path):
+    root, memory, sha = _init_repo(tmp_path, [
+        _record("dp-empty-input", DETERMINISTIC_DECISION, [{"selector": SELECTOR}]),
+    ])
+    decisions = [_declared_decision()]
+    valid, _ = parse_ci_evidence_document(_evidence(
+        sha, [{"selector": SELECTOR, "outcome": "passed"}],
+    ))
+    assert valid is not None
+    assert match_ci_evidence(decisions, sha, valid) == {
+        "dp-empty-input": [SELECTOR],
+    }
+    # Wrong HEAD SHA → nothing verified.
+    assert match_ci_evidence(decisions, "0" * 40, valid) == {}
+    # None document → nothing verified.
+    assert match_ci_evidence(decisions, sha, None) == {}

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -657,11 +657,15 @@ jobs:
 
         if pr > 0:
             expected_cp = round(p / pr * 100, 1)
-            expected_imp = round((p + m) / pr * 100, 1)
+            # ADR-023: Potential counts Mneme-ready + Requires modelling
+            # (deterministically enforceable in principle, not yet enforced),
+            # not only decisions immediately expressible by existing rules.
+            expected_imp = round((m + r) / pr * 100, 1)
             expected_gap = round((m + r) / pr * 100, 1)
             assert report.current_protection_pct == expected_cp
             assert report.identified_mneme_potential_pct == expected_imp
             assert report.protection_gap_pct == expected_gap
+            assert report.current_protection_pct + report.identified_mneme_potential_pct == 100.0
 
     def test_mixed_status_decisions(self, tmp_path):
         """Decisions with different statuses handled correctly."""

--- a/tests/test_github_evidence.py
+++ b/tests/test_github_evidence.py
@@ -1,0 +1,430 @@
+"""Authenticated GitHub Actions CI *claim* (ADR-024).
+
+Focused regression tests for the authenticated retrieval path. The GitHub API
+is faked by monkeypatching the module's HTTP seams; no real network, no
+repository code executes.
+
+Pinned invariants:
+
+- an authenticated run + artifact is a CI *claim* (``authenticated_ci_claim``),
+  never ``verified``/Protected — the artifact content is repository-controlled;
+- direct construction / caller injection of any authenticated-looking value
+  cannot reach Protected through the supported public API;
+- forged run_id, wrong repository, SHA mismatch, missing/partial/non-passed
+  selector, malformed artifact, and artifact SHA mismatch all fail closed;
+- the artifact redirect never forwards the bearer token to a non-API host;
+- Guidance is never upgraded; typed-rule / CI-enforcement protection and
+  offline passive Audit are unchanged.
+"""
+import io
+import json
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from mneme.cli import main
+from mneme.enforcer import (
+    assess_protection,
+    generate_protection_report,
+)
+from mneme.github_evidence import (
+    GitHubVerificationError,
+    audit_with_github_claim,
+    verify_github_run,
+)
+from mneme.schemas import Decision
+
+MEMORY_REL = Path(".mneme") / "project_memory.json"
+BASE_TS = "2026-01-01T00:00:00Z"
+
+SELECTOR = "tests/test_boundary.py::test_empty_input_rejected"
+DETERMINISTIC_DECISION = "Reject empty input before calling the model."
+ADVISORY_DECISION = "Prefer simple architectures where practical."
+
+
+def _evidence_zip(sha: str, results: list[dict]) -> bytes:
+    doc = json.dumps({
+        "schema": "mneme.test-evidence/v1",
+        "repository_sha": sha,
+        "producer": {"type": "github-actions", "run_id": "1"},
+        "results": results,
+    })
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("evidence.json", doc)
+    return buf.getvalue()
+
+
+class FakeGitHub:
+    """Canned GitHub API/artifact responses for one run."""
+
+    def __init__(self, run: dict, artifacts: list[dict], artifact_zip: bytes):
+        self.run = run
+        self.artifacts = artifacts
+        self.artifact_zip = artifact_zip
+        self.calls: list[tuple[str, str]] = []
+
+    def api_get_json(self, path, token, base_url, timeout):
+        self.calls.append(("api", path))
+        if "/artifacts" in path:
+            return {"artifacts": self.artifacts}
+        return self.run
+
+    def download_artifact(self, path, token, base_url, timeout):
+        self.calls.append(("download", path))
+        return self.artifact_zip
+
+
+def _install_fake(monkeypatch, fake: FakeGitHub):
+    import mneme.github_evidence as module
+
+    monkeypatch.setattr(module, "_api_get_json", fake.api_get_json)
+    monkeypatch.setattr(module, "_download_artifact", fake.download_artifact)
+    return fake
+
+
+def _decision(decision_id: str = "dp-empty-input", text: str = DETERMINISTIC_DECISION):
+    return Decision(id=decision_id, decision=text, test_evidence=[{"selector": SELECTOR}])
+
+
+def _valid_run(sha: str, repo: str = "acme/widgets") -> dict:
+    return {
+        "id": 42,
+        "head_sha": sha,
+        "status": "completed",
+        "conclusion": "success",
+        "head_repository": {"full_name": repo},
+    }
+
+
+def _artifact(artifact_id: int = 1, name: str = "mneme-test-results") -> dict:
+    return {"id": artifact_id, "name": name, "expired": False}
+
+
+def _git_repo(tmp_path) -> tuple[Path, Path, str]:
+    """A real git repo with a declared decision; returns (root, memory, sha)."""
+    root = tmp_path / "repo"
+    (root / "tests").mkdir(parents=True)
+    (root / "tests" / "test_boundary.py").write_text(
+        "def test_empty_input_rejected():\n    assert True\n", encoding="utf-8",
+    )
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "x", "description": "x"},
+        "items": [], "examples": [],
+        "decisions": [{
+            "id": "dp-empty-input", "decision": DETERMINISTIC_DECISION,
+            "rationale": "", "scope": [], "constraints": [], "anti_patterns": [],
+            "test_evidence": [{"selector": SELECTOR}],
+            "created_at": BASE_TS, "updated_at": BASE_TS,
+        }],
+    }, indent=2) + "\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "-c", "user.email=t@e", "-c", "user.name=t",
+                    "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "-c", "user.email=t@e", "-c", "user.name=t",
+                    "commit", "-q", "-m", "f"], cwd=root, check=True)
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=root,
+                         capture_output=True, text=True, check=True).stdout.strip()
+    return root, memory, sha
+
+
+# ── 1+2. Direct construction / injection cannot reach Protected ────────────
+
+
+def test_direct_construction_cannot_reach_protected(tmp_path, monkeypatch):
+    """The supported public API accepts no trust-bearing parameter."""
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    claim = verify_github_run(root, 42, sha, token="tok",
+                              owner="acme", repo="widgets")
+
+    # No public API accepts the authenticated claim as a trust argument.
+    with pytest.raises(TypeError):
+        generate_protection_report([_decision()], repo_root=root,
+                                   github_verification=claim)
+    with pytest.raises(TypeError):
+        assess_protection(_decision(), repo_root=root, github_verification=claim)
+    with pytest.raises(TypeError):
+        generate_protection_report([_decision()], repo_root=root,
+                                   test_evidence_results={"x": []})
+
+    # A hand-built "verified" record cannot be injected either.
+    from mneme.evidence import TestEvidenceVerification
+    forged = TestEvidenceVerification(
+        decision_id="dp-empty-input", selector=SELECTOR, state="verified",
+        sha=sha, code="x", detail="x",
+    )
+    with pytest.raises(TypeError):
+        assess_protection(_decision(), repo_root=root,
+                          test_evidence_results={"dp-empty-input": [forged]})
+
+
+def test_cannot_fabricate_verified_from_carrier_only(tmp_path, monkeypatch):
+    """Even a perfect local carrier never reaches verified via public API."""
+    root, memory, sha = _git_repo(tmp_path)
+    carrier = json.dumps({
+        "schema": "mneme.test-evidence/v1",
+        "repository_sha": sha,
+        "producer": {"type": "github-actions", "run_id": "1"},
+        "results": [{"selector": SELECTOR, "outcome": "passed"}],
+    })
+    report = generate_protection_report(
+        [_decision()], repo_root=root, ci_evidence_document=carrier,
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling"
+    assert report.decisions[0].evidence_sources == [f"test:ci-claim:{SELECTOR}@{sha}"]
+    assert report.protected == 0
+
+
+# ── 3. Authenticated run + arbitrary artifact is a claim, not protection ───
+
+
+def test_authenticated_run_yields_claim_not_protected(tmp_path, monkeypatch):
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    report = audit_with_github_claim(
+        [_decision()], root, 42, token="tok", owner="acme", repo="widgets",
+    )
+    assessment = report.decisions[0]
+    assert assessment.protection_tier == "requires_modelling"
+    assert assessment.evidence_confidence == "none"
+    assert assessment.evidence_sources == [f"test:ci-authenticated:{SELECTOR}@{sha}"]
+    assert report.protected == 0
+    assert "test:verified:" not in str(assessment.evidence_sources)
+
+
+# ── 7. forged run / repo / SHA / selector fail closed ──────────────────────
+
+
+def test_forged_run_id_fails(monkeypatch):
+    import mneme.github_evidence as module
+
+    def not_found(path, token, base_url, timeout):
+        raise GitHubVerificationError("run 404", status=404)
+
+    monkeypatch.setattr(module, "_api_get_json", not_found)
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(Path("x"), 999, "a" * 40, token="tok",
+                          owner="acme", repo="widgets")
+
+
+def test_run_from_other_repository_fails(tmp_path, monkeypatch):
+    sha = "a" * 40
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha, repo="evil/corp"), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(tmp_path, 42, sha, token="tok",
+                          owner="acme", repo="widgets")
+
+
+def test_run_sha_mismatch_fails(tmp_path, monkeypatch):
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run("b" * 40), [_artifact()],
+        _evidence_zip("b" * 40, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(tmp_path, 42, "a" * 40, token="tok",
+                          owner="acme", repo="widgets")
+
+
+def test_missing_selector_result_fails(tmp_path, monkeypatch):
+    sha = "a" * 40
+    _install_fake(monkeypatch, FakeGitHub(_valid_run(sha), [], b""))
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(tmp_path, 42, sha, token="tok",
+                          owner="acme", repo="widgets")
+
+
+@pytest.mark.parametrize("outcome", ["failed", "skipped", "xfailed", "error"])
+def test_non_passed_outcomes_do_not_verify(tmp_path, monkeypatch, outcome):
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": outcome}]),
+    ))
+    report = audit_with_github_claim(
+        [_decision()], root, 42, token="tok", owner="acme", repo="widgets",
+    )
+    assert report.decisions[0].protection_tier == "requires_modelling", outcome
+    assert report.protected == 0, outcome
+
+
+def test_substring_selector_does_not_verify(tmp_path, monkeypatch):
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": "tests/test_boundary.py::test_empty_input", "outcome": "passed"}]),
+    ))
+    report = audit_with_github_claim(
+        [_decision()], root, 42, token="tok", owner="acme", repo="widgets",
+    )
+    assert report.protected == 0
+    assert report.decisions[0].protection_tier == "requires_modelling"
+
+
+def test_malformed_artifact_fails(tmp_path, monkeypatch):
+    sha = "a" * 40
+    _install_fake(monkeypatch, FakeGitHub(_valid_run(sha), [_artifact()], b"not a zip"))
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(tmp_path, 42, sha, token="tok",
+                          owner="acme", repo="widgets")
+
+
+def test_artifact_sha_mismatch_fails(tmp_path, monkeypatch):
+    sha = "a" * 40
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip("c" * 40, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    with pytest.raises(GitHubVerificationError):
+        verify_github_run(tmp_path, 42, sha, token="tok",
+                          owner="acme", repo="widgets")
+
+
+# ── 9. Guidance is never upgraded ──────────────────────────────────────────
+
+
+def test_guidance_never_upgraded(tmp_path, monkeypatch):
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    report = audit_with_github_claim(
+        [_decision("dp-guid", ADVISORY_DECISION)], root, 42,
+        token="tok", owner="acme", repo="widgets",
+    )
+    assert report.decisions[0].intent == "guidance"
+    assert report.decisions[0].protection_tier == "guidance"
+    assert report.protected == 0
+
+
+# ── 12. typed-rule / CI-enforcement unchanged ──────────────────────────────
+
+
+def test_typed_rule_and_ci_enforcement_unchanged(tmp_path):
+    from mneme.schemas import Rule
+
+    root = tmp_path / "repo"
+    (root / ".github" / "workflows").mkdir(parents=True)
+    (root / ".github" / "workflows" / "ci.yml").write_text(
+        "jobs:\n  guard:\n    steps:\n"
+        "      - run: if grep -rq psycopg2 src/; then exit 1; fi\n",
+        encoding="utf-8",
+    )
+    memory = root / MEMORY_REL
+    memory.parent.mkdir(parents=True)
+    memory.write_text(json.dumps({
+        "meta": {"name": "x", "description": "x"},
+        "items": [], "examples": [],
+        "decisions": [
+            {"id": "d1", "decision": "Keep the package namespace distinct",
+             "rationale": "", "scope": [], "constraints": [], "anti_patterns": [],
+             "rules": [{"type": "FORBID_LITERAL", "value": "sqlite"}],
+             "created_at": BASE_TS, "updated_at": BASE_TS},
+            {"id": "d2", "decision": "No psycopg2 in the service layer",
+             "rationale": "", "scope": [], "constraints": [],
+             "anti_patterns": ["psycopg2"],
+             "created_at": BASE_TS, "updated_at": BASE_TS},
+        ],
+    }, indent=2) + "\n", encoding="utf-8")
+    from mneme.memory_store import MemoryStore
+
+    store = MemoryStore(memory)
+    store.load()
+    report = generate_protection_report(store.decisions(), repo_root=root)
+    by_id = {d.id: d for d in report.decisions}
+    assert by_id["d1"].protection_tier == "protected"
+    assert by_id["d2"].protection_tier == "protected"
+    assert report.protected == 2
+
+
+# ── 10. offline Audit performs no GitHub calls ─────────────────────────────
+
+
+def test_offline_audit_makes_no_github_calls(tmp_path, monkeypatch):
+    import mneme.github_evidence as module
+
+    def boom(*a, **k):
+        raise AssertionError("GitHub must not be called during offline audit")
+
+    monkeypatch.setattr(module, "_api_get_json", boom)
+    monkeypatch.setattr(module, "_download_artifact", boom)
+    monkeypatch.setattr(module, "_http_open", boom)
+
+    root, memory, _sha = _git_repo(tmp_path)
+    exit_code = main(["audit", "--memory", str(memory), "--repo-root", str(root)])
+    assert exit_code == 0
+    assert not (root / ".pytest_cache").exists()
+    assert not list(root.rglob("__pycache__"))
+
+
+# ── SECURITY: artifact redirect must not forward the bearer token ──────────
+
+
+def test_artifact_redirect_does_not_forward_token(monkeypatch):
+    import mneme.github_evidence as module
+
+    seen: list[tuple[str, dict[str, str]]] = []
+
+    def fake_open(url, headers, timeout):
+        seen.append((url, dict(headers)))
+        if "api.github.com" in url:
+            return 302, {"location": "https://objects.githubusercontent.com/signed-blob"}, b""
+        return 200, {}, b"zip-bytes"
+
+    monkeypatch.setattr(module, "_http_open", fake_open)
+
+    result = module._download_artifact(
+        "/repos/acme/widgets/actions/artifacts/1/zip",
+        "SECRET-TOKEN", "https://api.github.com", 5.0,
+    )
+    assert result == b"zip-bytes"
+
+    api_call = next((h for u, h in seen if "api.github.com" in u), None)
+    assert api_call is not None
+    assert any(k.lower() == "authorization" for k in api_call)
+
+    blob_call = next(
+        (h for u, h in seen if "objects.githubusercontent.com" in u), None
+    )
+    assert blob_call is not None
+    assert not any(k.lower() == "authorization" for k in blob_call), blob_call
+
+
+# ── determinism for identical authenticated inputs ─────────────────────────
+
+
+def test_deterministic_authenticated_claim(tmp_path, monkeypatch):
+    root, memory, sha = _git_repo(tmp_path)
+    _install_fake(monkeypatch, FakeGitHub(
+        _valid_run(sha), [_artifact()],
+        _evidence_zip(sha, [{"selector": SELECTOR, "outcome": "passed"}]),
+    ))
+    first = audit_with_github_claim(
+        [_decision()], root, 42, token="tok", owner="acme", repo="widgets",
+    )
+    second = audit_with_github_claim(
+        [_decision()], root, 42, token="tok", owner="acme", repo="widgets",
+    )
+
+    def snapshot(r):
+        return (
+            r.protected, r.mneme_ready, r.requires_modelling, r.guidance,
+            tuple((d.id, d.protection_tier, d.evidence_confidence,
+                   tuple(d.evidence_sources)) for d in r.decisions),
+        )
+
+    assert snapshot(first) == snapshot(second)


### PR DESCRIPTION
## Summary

Coherent P1.2 Architecture Audit hardening sequence landing as one squash commit on `main`:

- **ADR-023** (`9f1720c4`) — audit tier classification now derives from decision-text semantics (prescriptive vs advisory language), not from which structured fields happen to be populated. Fixes the first Design Partner P0 (byte-identical decision text flipping tier when a structural constraint was added).
- **ADR-024** (`f478c414`, `e51533d5`, `8f57f051`) — declared test-evidence channel: per-decision `test_evidence` declarations validated passively; untrusted `mneme.test-evidence/v1` carrier parsing/matching (`matched_unverified`); authenticated GitHub Actions CI claim (`authenticated_ci_claim`). All fail-closed; no public API accepts a trust-bearing parameter.
- **ADR-025** (`1995ac8a`) — records (proposed) the design for a cryptographically trusted execution-attestation producer and defers it. `verified`/Protected via test evidence remains intentionally unreachable.

Key invariant preserved throughout: `mneme audit` is passive/offline and executes no repository-controlled code; `mneme.audit/v1`, CLI, and existing CI-enforcement/typed-rule protection are unchanged.

## Validation

- `python -m pytest tests -q` → 1304 passed, 6 skipped
- Focused suites: `test_github_evidence.py` (19), `test_ci_test_evidence.py` (20), `test_audit_test_evidence.py` (13) all green
- Execution-sentinel regression (no repository code executed during audit) green

## Execution provenance

- Change author: agent
- Agent: opencode
- Agent model: deepseek-v4-pro
- Agent session: not-exposed
- Task origin: local
- Human owner: @TheoV823