### PR TITLE
fix(audit): ADR-026 renumber, advisory/prescriptive precedence, Protection Gap CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,25 @@
 
 ### Fixed
 
-- P1.2 Architecture Audit tier semantics (ADR-023): intent is now judged
+- P1.2 Architecture Audit tier semantics (ADR-026, renumbered from a
+  colliding ADR-023 id): intent is now judged
   from the decision text (prescriptive vs advisory language) instead of
   record shape, so byte-identical decision text no longer changes tier
   when an unrelated structured constraint is added, and deterministic
   architectural requirements without structured fields no longer fall to
-  Guidance. `Identified Mneme Potential` is now
+  Guidance. Advisory wording outranks prescriptive markers, so qualified
+  prose ("we should never use SQLite") stays Guidance even when it also
+  contains `must`, `never`, or `enforce`; an installed typed rule still
+  protects regardless of advisory prose (enforcement precedence).
+  `Identified Mneme Potential` is now
   (Mneme-ready + Requires modelling) / protection-relevant — decisions
   deterministically enforceable in principle, not only records
-  immediately expressible by existing rule types. `mneme.audit/v1`,
-  CLI, Protect behavior, and enforcement/refusal semantics are unchanged.
+  immediately expressible by existing rule types.
+  `mneme.audit/v1`, Protect behavior, and enforcement/refusal semantics
+  are unchanged. Human-facing `mneme audit` output now presents
+  Current Protection and Protection Gap (the compat-identical
+  Identified Mneme Potential metric is no longer shown as an independent
+  headline; the JSON field is retained for compatibility).
 
 ---
 

--- a/docs/adr/ADR-024-declared-test-evidence-ingestion.md
+++ b/docs/adr/ADR-024-declared-test-evidence-ingestion.md
@@ -115,7 +115,7 @@ question: "which architectural decisions are actually protected in this
 system, regardless of which deterministic mechanism provides that
 protection?"
 
-ADR-023 fixed tier semantics (intent from decision text, not record
+ADR-026 fixed tier semantics (intent from decision text, not record
 shape) but left the protection-evidence channels at exactly two: typed
 `FORBID_LITERAL` rules and verified CI linkage on literalizable tokens.
 
@@ -196,7 +196,7 @@ separately opt-in future capability and is never performed implicitly.
 
 ### Protection semantics
 
-- A **deterministic** decision (ADR-023: prescriptive text, or documented
+- A **deterministic** decision (ADR-026: prescriptive text, or documented
   enforcement fields with non-advisory text) with **trusted verified**
   test evidence is **Protected**: `evidence_confidence: "verified"`,
   evidence sources `test:verified:<selector>@<sha>`. M0 has no trusted
@@ -267,6 +267,6 @@ declared linkage did not establish protection.
 ## Related
 
 - ADR-019: Typed Literal Rule Contract (explicit-directive trust model)
-- ADR-023: Audit Tier Semantics and Mneme Potential
+- ADR-026: Audit Tier Semantics and Mneme Potential
 - Design Partner diagnostic repository (read-only fixture):
   `sagarika29/ai-system-architect`

--- a/docs/adr/ADR-026-audit-tier-semantics-and-mneme-potential.md
+++ b/docs/adr/ADR-026-audit-tier-semantics-and-mneme-potential.md
@@ -1,5 +1,5 @@
 ---
-id: ADR-023
+id: ADR-026
 title: "Audit Tier Semantics and Mneme Potential"
 status: accepted
 priority: foundational
@@ -7,11 +7,16 @@ date: 2026-09-11
 scope: audit.tier_semantics
 ---
 
-# ADR-023: Audit Tier Semantics and Mneme Potential
+# ADR-026: Audit Tier Semantics and Mneme Potential
 
 **Status:** Accepted
 **Date:** 2026-09-11
 **Deciders:** Theo Valmis
+
+> **Renumbering note:** this ADR originally landed as ADR-023 in PR #360,
+> after ADR-023 had already been assigned to the Canonical Decision Index
+> in PR #359. It was renumbered to ADR-026 to restore unique ADR identity.
+> No architectural semantics changed as part of the renumbering.
 
 ---
 
@@ -81,13 +86,17 @@ enforcement material):
 
 Intent (deterministic vs guidance) is judged from the decision text:
 
+- advisory language (`prefer`, `consider`, `should`, `can`, `where
+  practical`, `judgment`, `tradeoffs`) marks the statement guidance:
+  prescriptive markers are ignored when advisory qualifiers are present,
+  so clearly advisory/qualified wording must not become deterministic
+  merely because it also contains words such as `must`, `never`, or
+  `enforce` ("we should never use SQLite" is Guidance, not a prohibition);
 - prescriptive language (obligation, requirement, prohibition — `must`,
   `never`, `reject`, `fail closed`, `forbidden`, `enforce`, `validate`,
-  leading `No X` headlines) makes a decision protection-relevant
-  regardless of which structured fields are populated;
-- advisory language (`prefer`, `consider`, `should`, `can`, `where
-  practical`, `judgment`, `tradeoffs`) marks the statement guidance, and
-  no structured field can upgrade it;
+  leading `No X` headlines) makes a decision protection-relevant only
+  when the wording is unequivocal (no advisory qualifier);
+- absent clear deterministic intent defaults to Guidance;
 - structured prohibition fields remain documented enforcement material
   for decisions whose text is not advisory, preserving the frozen
   Mneme-ready guardrail derivation for every pre-existing record shape.
@@ -100,6 +109,27 @@ prescriptive markers never fire on advisory wording, absent markers
 default to guidance, and prose prohibitions that need interpretation are
 never literalized from text alone (no repository- or partner-specific
 vocabulary is special-cased).
+
+### Enforcement precedence: installed rules vs advisory prose
+
+Two different kinds of evidence must not be conflated — the distinction
+between "structured metadata exists" and "deterministic enforcement is
+actually installed" is load-bearing:
+
+- **Prose semantics classify unenforced decisions.** For a decision with
+  no installed deterministic enforcement, the decision text determines
+  whether it is deterministic intent or Guidance, per the rules above.
+- **Installed deterministic enforcement is authoritative evidence of
+  protection.** An active supported typed rule (typed `FORBID_LITERAL`)
+  classifies the decision Protected regardless of advisory prose. Audit
+  must not report an actively enforced decision as Guidance merely
+  because the decision text is weakly worded: the installed rule is
+  objective, verifiable enforcement evidence, and it outranks prose
+  intent.
+- **Merely descriptive structure is not enforcement.** Adding structure
+  such as constraints or anti-pattern fields must still NOT, by itself,
+  upgrade Guidance. Descriptive metadata existing on the record never
+  moves a tier; deterministic enforcement actually being installed does.
 
 ### Identified Mneme Potential
 
@@ -120,7 +150,10 @@ numerically identical to the Protection Gap (`(M + R) / PR`) by
 construction, and the exact complement of Current Protection
 (`Potential = 100 − Current Protection`). It is NOT an independent second
 metric, and user-facing output must not present Current Protection and
-Identified Mneme Potential as two separate findings. The
+Identified Mneme Potential as two separate findings: the human-facing
+CLI presents Current Protection and Protection Gap, with the tier counts
+(P protected, M Mneme-ready, R Requires modelling, G Guidance-only)
+alongside. The
 `identified_mneme_potential_pct` field is retained in `mneme.audit/v1`
 for compatibility. A future, genuinely distinct metric may express
 immediately protectable coverage as `(P + M) / PR`, with

--- a/docs/plans/p1-2-architecture-audit-redesign.md
+++ b/docs/plans/p1-2-architecture-audit-redesign.md
@@ -1,14 +1,21 @@
 # P1.2 Architecture Audit Redesign — Design Document
 
-> **Amendment (2026-09-11, ADR-023):** after the first Design Partner
+> **Amendment (2026-09-11, ADR-026):** after the first Design Partner
 > diagnostic exposed that tier classification depended on record shape
 > (byte-identical decision text changed tier when a structured constraint
 > was added) and that Identified Mneme Potential counted only records
 > immediately expressible by existing rule types, the tier semantics and
 > the Potential formula were amended. Tier intent is now judged from the
 > decision text (prescriptive vs advisory); Potential =
-> (Mneme-ready + Requires modelling) / protection-relevant. See
-> `docs/adr/ADR-023-audit-tier-semantics-and-mneme-potential.md`. The
+> (Mneme-ready + Requires modelling) / protection-relevant. Installed
+> deterministic enforcement (a typed FORBID_LITERAL rule) is authoritative
+> evidence of protection and outranks advisory prose, while merely
+> descriptive structure still never upgrades Guidance. User-facing CLI
+> output presents Current Protection and Protection Gap — Identified
+> Mneme Potential is numerically identical to the Protection Gap and is
+> retained in `mneme.audit/v1` for compatibility only, not shown as an
+> independent headline. See
+> `docs/adr/ADR-026-audit-tier-semantics-and-mneme-potential.md`. The
 > sections below record the original P1.2 freeze.
 
 ## Executive Summary

--- a/mneme/cli.py
+++ b/mneme/cli.py
@@ -522,6 +522,12 @@ def _cmd_audit(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root) if args.repo_root else None
     if repo_root is not None and not repo_root.exists():
         return _error_exit(f"repo root {repo_root} does not exist")
+    # TODO(trust-boundary, ADR-024/025): before any trusted producer accepts
+    # CI-claimed test evidence as "verified", the GitHub inputs (owner, repo,
+    # base_url) must be explicitly pinned — owner/repo to the audited
+    # repository and base_url to trusted hosts — so evidence cannot be
+    # ingested from an attacker-chosen endpoint. Not implemented here; the
+    # public paths never produce "verified" test evidence.
 
     store = MemoryStore(args.memory)
     store.load()
@@ -541,12 +547,19 @@ def _cmd_audit(args: argparse.Namespace) -> int:
         print("=" * 60)
         print(f"Decisions discovered:         {s.total_decisions}")
         print(f"Protection-relevant:          {s.protection_relevant}")
+        print()
+        # ADR-026: Identified Mneme Potential is numerically identical to
+        # the Protection Gap and is NOT an independent second metric, so
+        # the human-facing output presents Current Protection and
+        # Protection Gap only. identified_mneme_potential_pct remains in
+        # the JSON payload (mneme.audit/v1) for compatibility.
+        print(f"Current Protection:           {s.current_protection_pct}%")
+        print(f"Protection Gap:               {s.protection_gap_pct}%")
+        print()
         print(f"Protected today:              {s.protected}")
         print(f"Mneme-ready:                  {s.mneme_ready}")
-        print(f"Requires further modelling:   {s.requires_modelling}")
+        print(f"Requires modelling:           {s.requires_modelling}")
         print(f"Guidance-only:                {s.guidance}")
-        print(f"Current Protection:           {s.current_protection_pct}%")
-        print(f"Identified Mneme Potential:   {s.identified_mneme_potential_pct}%")
         print()
         print("Per-decision breakdown:")
         for d in s.decisions:

--- a/mneme/enforcer.py
+++ b/mneme/enforcer.py
@@ -441,7 +441,7 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
 # enforce this today?"; the P1.2 audit asks "how much of this repository's
 # deterministic architectural intent is already protected, and what remains?".
 #
-# Tier semantics (ADR-023; amends the P1.2 freeze in
+# Tier semantics (ADR-026; amends the P1.2 freeze in
 # docs/plans/p1-2-architecture-audit-redesign.md after the first Design
 # Partner diagnostic, sagarika29/ai-system-architect):
 #   protected          a documented architectural decision for which Mneme
@@ -485,7 +485,7 @@ def assess_governability(decision: "Decision") -> GovernabilityAssessment:
 #      state requires a trusted producer (CI-produced exact-SHA +
 #      exact-selector ingestion — the next task).
 #
-# Semantic invariants (ADR-023, extended by ADR-024):
+# Semantic invariants (ADR-026, extended by ADR-024):
 #   - Structure invariance: adding syntactic structure or a constraint
 #     field MUST NOT, by itself, move a decision out of guidance. Intent is
 #     judged from the decision text (prescriptive vs advisory language);
@@ -543,7 +543,7 @@ class ArchitectureProtectionReport:
     requires_modelling: int
     guidance: int
     current_protection_pct: float
-    # Compat metric (ADR-023): the unprotected deterministic opportunity —
+    # Compat metric (ADR-026): the unprotected deterministic opportunity —
     # numerically identical to ``protection_gap_pct`` and the exact
     # complement of ``current_protection_pct``; not an independent metric.
     identified_mneme_potential_pct: float
@@ -638,7 +638,7 @@ def _split_no_constraints(
     return single, multi
 
 
-# ── Semantic intent classification (ADR-023) ─────────────────────────────────
+# ── Semantic intent classification (ADR-026) ─────────────────────────────────
 #
 # The audit tier must track what the documented decision MEANS, not which
 # structured fields happen to be populated (P0 finding #1 of the first
@@ -646,29 +646,34 @@ def _split_no_constraints(
 # → requires_modelling when an unrelated structured constraint was added).
 #
 # Intent is therefore judged from the decision text itself:
-#   - prescriptive language (obligation, requirement, prohibition — must,
-#     never, reject, fail closed, forbidden, enforce, validate, "No X"
-#     headlines) makes a decision protection-relevant regardless of which
-#     structured fields are populated;
 #   - advisory language (prefer, consider, should, can, where practical,
-#     judgment, tradeoffs) marks the statement guidance, and no structured
-#     field can upgrade it;
+#     judgment, tradeoffs) marks the statement guidance: prescriptive
+#     markers are ignored when advisory qualifiers are present, so
+#     qualified wording ("we should never use SQLite") never becomes
+#     deterministic merely because it also contains `must`, `never`, or
+#     `enforce`;
+#   - unequivocal requirements (no advisory marker) remain deterministic,
+#     and absent clear deterministic intent defaults to guidance;
 #   - structured prohibition fields (anti_patterns / "no X" constraints)
-#     remain documented enforcement material for decisions whose text is
-#     not advisory, preserving the frozen Mneme-ready guardrail derivation
-#     for every pre-existing record shape.
+#     are merely descriptive structure: they remain documented enforcement
+#     material only for decisions whose text is not advisory, never
+#     upgrading Guidance by themselves.
 #
-# Both classifiers are deliberately conservative: prescriptive markers
-# never fire on advisory wording, and absent markers default to guidance
-# (silent text is never inferred to be deterministic). No repository- or
-# partner-specific vocabulary is special-cased.
+# Installed deterministic enforcement is a different, stronger kind of
+# evidence than prose or structure: a typed FORBID_LITERAL rule resolves
+# before prose intent entirely (see _assess_protection), so an actively
+# enforced decision is Protected regardless of advisory wording.
+#
+# Both classifiers are deliberately conservative: absent markers default
+# to guidance (silent text is never inferred to be deterministic). No
+# repository- or partner-specific vocabulary is special-cased.
 
 _ADVISORY_RE = re.compile(
-    r"\b(?:prefer\w*|consider\w*|recommen\w+|should|ideally|optional|"
+    r"\b(?:prefer\w*|consider\w*|recommen(?!dation)\w*|should|ideally|optional|"
     r"flexible|judg(?:e|ment|ement)\w*|trade[- ]?off\w*|aspirational|"
     r"where\s+practical|when\s+possible|when\s+appropriate|"
     r"as\s+appropriate|as\s+needed|in\s+general|generally|typically|"
-    r"usually|nice[- ]to[- ]have|may\b|might\b|can\b|could\b)\b",
+    r"usually|nice[- ]to[- ]have|may\b|might\b|can\b(?!'t)|could\b)\b",
     re.IGNORECASE,
 )
 
@@ -881,8 +886,14 @@ def _assess_protection(
 
     Intent (deterministic vs guidance) is judged from the decision text
     (``_is_prescriptive_text`` / ``_is_advisory_text``), never from which
-    structured fields happen to be populated (ADR-023 structure-invariance
-    invariant). Structured prohibition fields still supply the concrete
+    structured fields happen to be populated (ADR-026 structure-invariance
+    invariant). Advisory wording outranks prescriptive markers, so
+    qualified prose never becomes deterministic merely by containing
+    ``must``/``never``/``enforce``. Installed deterministic enforcement
+    precedes prose intent entirely: the typed FORBID_LITERAL check above
+    resolves before classification, so an actively enforced decision is
+    Protected regardless of advisory prose (ADR-026 enforcement
+    precedence). Structured prohibition fields still supply the concrete
     guardrail derivation, and they keep non-advisory decisions
     protection-relevant exactly as in the frozen P1.2 model.
 
@@ -921,9 +932,14 @@ def _assess_protection(
     advisory = _is_advisory_text(decision.decision)
     prescriptive = _is_prescriptive_text(decision.decision)
 
-    has_deterministic_intent = prescriptive or (
-        documented_enforcement and not advisory
-    )
+    # Precedence (ADR-026): advisory wording outranks prescriptive markers —
+    # a prescriptive term inside qualified/advisory prose does not make the
+    # decision deterministic. Unequivocal requirements (no advisory marker)
+    # remain deterministic; absent clear deterministic intent defaults to
+    # Guidance. Descriptive structure alone is not enforcement.
+    has_deterministic_intent = (
+        prescriptive or documented_enforcement
+    ) and not advisory
 
     if not has_deterministic_intent:
         return ProtectionDecisionReport(
@@ -1037,7 +1053,7 @@ def _build_report(
     guidance = sum(1 for r in active if r.protection_tier == "guidance")
     protection_relevant = protected + mneme_ready + requires_modelling
 
-    # Metric formulas (ADR-023, exact numerator/denominator):
+    # Metric formulas (ADR-026, exact numerator/denominator):
     #
     #   Current Protection          = P / PR × 100
     #       fraction of protection-relevant decisions with verified

--- a/tests/test_adr_validator.py
+++ b/tests/test_adr_validator.py
@@ -1,6 +1,9 @@
 """Tests for the ADR corpus validator."""
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import pytest
 
 from mneme.adr_compiler import validate_corpus
@@ -125,3 +128,58 @@ def test_validation_error_aggregates_multiple_problems():
         validate_corpus([a, b])
     # Both errors should be reported, not just the first.
     assert len(excinfo.value.errors) >= 2
+
+
+# ── Canonical ADR file identity (frontmatter id uniqueness) ──────────────────
+#
+# Regression: PR #360 landed the Audit-tier ADR as a second ADR-023 after
+# PR #359 had already assigned ADR-023 to the Canonical Decision Index.
+# The Audit-tier ADR was renumbered to ADR-026; this scan fails if two
+# canonical ADR documents ever declare the same frontmatter id again.
+
+ADR_DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "adr"
+_FRONTMATTER_ID_RE = re.compile(r"^id:\s*(ADR-\d+)\s*$", re.MULTILINE)
+
+
+def _scan_canonical_adr_ids(directory: Path) -> dict[str, list[str]]:
+    """Map each frontmatter ``id:`` to the canonical ADR files declaring it."""
+    found: dict[str, list[str]] = {}
+    for path in sorted(directory.glob("ADR-*.md")):
+        match = _FRONTMATTER_ID_RE.search(path.read_text(encoding="utf-8"))
+        if match:
+            found.setdefault(match.group(1), []).append(path.name)
+    return found
+
+
+def _find_duplicate_ids(directory: Path) -> dict[str, list[str]]:
+    ids = _scan_canonical_adr_ids(directory)
+    return {adr_id: files for adr_id, files in ids.items() if len(files) > 1}
+
+
+def test_canonical_adr_files_have_unique_frontmatter_ids():
+    duplicates = _find_duplicate_ids(ADR_DOCS_DIR)
+    assert duplicates == {}, (
+        f"ADR id collision: {duplicates}"
+    )
+
+
+def test_duplicate_frontmatter_id_is_detected(tmp_path: Path):
+    (tmp_path / "ADR-001-alpha.md").write_text(
+        "---\nid: ADR-001\ntitle: first\n---\n", encoding="utf-8"
+    )
+    (tmp_path / "ADR-001-beta.md").write_text(
+        "---\nid: ADR-001\ntitle: second\n---\n", encoding="utf-8"
+    )
+    assert _find_duplicate_ids(tmp_path) == {
+        "ADR-001": ["ADR-001-alpha.md", "ADR-001-beta.md"],
+    }
+
+
+def test_canonical_tree_has_exactly_one_adr_023_and_one_adr_026():
+    ids = _scan_canonical_adr_ids(ADR_DOCS_DIR)
+    assert ids.get("ADR-023") == [
+        "ADR-023-canonical-decision-index-and-runtime-projection-boundary.md",
+    ]
+    assert ids.get("ADR-026") == [
+        "ADR-026-audit-tier-semantics-and-mneme-potential.md",
+    ]

--- a/tests/test_audit_tier_semantics.py
+++ b/tests/test_audit_tier_semantics.py
@@ -1,4 +1,4 @@
-"""P1.2 Architecture Audit tier semantics (ADR-023 hardening).
+"""P1.2 Architecture Audit tier semantics (ADR-026 hardening).
 
 Regression tests for the two P0 defects found by the first real Design
 Partner diagnostic (sagarika29/ai-system-architect):
@@ -164,6 +164,69 @@ def test_interpretation_needing_prohibition_stays_requires_modelling():
     assert report.intent == "deterministic"
     assert report.protection_tier == "requires_modelling"
     assert report.mneme_guardrail is None
+
+
+# ── Mixed advisory + prescriptive wording (ADR-026 precedence) ───────────────
+
+# Qualified/advisory wording must not become deterministic merely because it
+# also contains words such as `must`, `never`, or `enforce`.
+MIXED_ADVISORY_TEXTS = [
+    "We should never use SQLite.",
+    "Where practical, services must reject invalid input.",
+    "Consider whether this must be enforced.",
+    "We should consider using SQLite.",
+]
+
+# Unequivocal requirements (no advisory qualifier) remain deterministic.
+UNEQUIVOCAL_TEXTS = [
+    "The system must reject invalid input.",
+    "The pipeline never deploys unvalidated changes.",
+]
+
+
+def test_mixed_advisory_wording_does_not_become_deterministic():
+    """Advisory wording outranks prescriptive markers: qualified prose stays
+    Guidance even when it contains `must`, `never`, or `enforce`."""
+    for text in MIXED_ADVISORY_TEXTS:
+        report = assess_protection(Decision(id="d1", decision=text))
+        assert report.intent == "guidance", text
+        assert report.protection_tier == "guidance", text
+        assert report.mneme_guardrail is None, text
+
+
+def test_unequivocal_requirements_remain_deterministic():
+    """Unequivocal `must` requirements and `never` prohibitions (no advisory
+    qualifier) remain deterministic."""
+    for text in UNEQUIVOCAL_TEXTS:
+        report = assess_protection(Decision(id="d1", decision=text))
+        assert report.intent == "deterministic", text
+        assert report.protection_tier == "requires_modelling", text
+
+
+def test_contraction_prohibition_remains_deterministic():
+    """A `can't` prohibition is not neutralized by the advisory `can`
+    marker — the lookahead keeps prohibitions prescriptive."""
+    report = assess_protection(Decision(
+        id="d1",
+        decision="Services can't depend on postgres directly.",
+    ))
+    assert report.intent == "deterministic"
+    assert report.protection_tier == "requires_modelling"
+
+
+def test_advisory_prose_with_installed_typed_rule_is_protected():
+    """Installed deterministic enforcement is authoritative: a decision with
+    an active typed rule is Protected regardless of advisory prose (ADR-026
+    enforcement precedence), while descriptive structure alone never
+    upgrades Guidance."""
+    enforced = Decision(
+        id="d1",
+        decision=ADVISORY_TEXT,
+        rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+    )
+    report = assess_protection(enforced)
+    assert report.protection_tier == "protected"
+    assert report.evidence_confidence == "verified"
 
 
 # ── Part C.5: Potential calculation ──────────────────────────────────────────
@@ -341,7 +404,7 @@ def _write_repo(tmp_path: Path, decisions: list[dict]) -> tuple[Path, Path]:
     memory = root / MEMORY_REL
     memory.parent.mkdir(parents=True)
     memory.write_text(json.dumps({
-        "meta": {"name": "adr23", "description": "ADR-023 fixture"},
+        "meta": {"name": "adr26", "description": "ADR-026 fixture"},
         "items": [],
         "examples": [],
         "decisions": decisions,

--- a/tests/test_cli_audit.py
+++ b/tests/test_cli_audit.py
@@ -496,11 +496,76 @@ jobs:
         assert "Protection-relevant:" in out
         assert "Protected today:" in out
         assert "Mneme-ready:" in out
-        assert "Requires further modelling:" in out
+        assert "Requires modelling:" in out
         assert "Guidance-only:" in out
         assert "Current Protection:" in out
-        assert "Identified Mneme Potential:" in out
         assert "Per-decision breakdown:" in out
+
+    def test_audit_terminal_presents_protection_gap(self, tmp_path, capsys):
+        """ADR-026: the human-facing output shows Current Protection and
+        Protection Gap, and never presents Identified Mneme Potential as an
+        independent headline metric."""
+        decisions = [
+            Decision(
+                id="ADR-001",
+                decision="No sqlite",
+                rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+            ),
+            Decision(
+                id="ADR-002",
+                decision="No ORM",
+                anti_patterns=["orm"],
+            ),
+            Decision(
+                id="ADR-003",
+                decision="Loose coupling",
+                rationale="Architectural principle",
+            ),
+        ]
+        mem = _create_test_memory(tmp_path, decisions)
+        exit_code = main(["audit", "--memory", str(mem)])
+        out = capsys.readouterr().out
+
+        assert exit_code == 0
+        assert "Current Protection:" in out
+        assert "Protection Gap:" in out
+        assert "Identified Mneme Potential" not in out
+
+        # Gap and Current Protection are complementary (1 protected,
+        # 1 mneme-ready, 1 guidance → PR = 2, gap = 50%).
+        assert "Current Protection:           50.0%" in out
+        assert "Protection Gap:               50.0%" in out
+
+    def test_audit_json_retains_identified_mneme_potential(self, tmp_path):
+        """mneme.audit/v1 keeps identified_mneme_potential_pct for
+        compatibility; only the human presentation changed (no schema bump)."""
+        decisions = [
+            Decision(
+                id="ADR-001",
+                decision="No sqlite",
+                rules=[Rule(type="FORBID_LITERAL", value="sqlite")],
+            ),
+            Decision(
+                id="ADR-002",
+                decision="No ORM",
+                anti_patterns=["orm"],
+            ),
+        ]
+        mem = _create_test_memory(tmp_path, decisions)
+        json_out = tmp_path / "audit.json"
+        exit_code = main(["audit", "--memory", str(mem), "--json", str(json_out)])
+        assert exit_code == 0
+
+        data = json.loads(json_out.read_text(encoding="utf-8"))
+        assert data["schema"] == "mneme.audit/v1"
+        summary = data["summary"]
+        assert "identified_mneme_potential_pct" in summary
+        assert "protection_gap_pct" in summary
+        assert "current_protection_pct" in summary
+        # Compatibility metric is numerically identical to the gap.
+        assert summary["identified_mneme_potential_pct"] == (
+            summary["protection_gap_pct"]
+        )
 
 
 class TestAuditSemanticContract:
@@ -657,7 +722,7 @@ jobs:
 
         if pr > 0:
             expected_cp = round(p / pr * 100, 1)
-            # ADR-023: Potential counts Mneme-ready + Requires modelling
+            # ADR-026: Potential counts Mneme-ready + Requires modelling
             # (deterministically enforceable in principle, not yet enforced),
             # not only decisions immediately expressible by existing rules.
             expected_imp = round((m + r) / pr * 100, 1)


### PR DESCRIPTION
﻿## Summary

Contract/presentation cleanup following #360 (7a4e5afd), found while reviewing the first Design Partner diagnostic output. No schema change, no tier-model change, no evidence-stack expansion. Three narrowly scoped fixes:

1. **ADR-023 collision resolved.** PR #360 landed the Audit-tier ADR as a second `ADR-023` after #359 had already assigned ADR-023 to the Canonical Decision Index. The Audit-tier ADR is renumbered to **ADR-026** (file renamed, frontmatter/H1 updated, renumbering note added). All semantic-tier references across ADR-024, the P1.2 plan, CHANGELOG, code comments, and tests now point to ADR-026; ADR-023 keeps only Canonical-Decision-Index meaning. Added a narrow regression test that fails when two canonical `docs/adr/ADR-*.md` files declare the same frontmatter `id`.

2. **Mixed advisory + prescriptive wording (ADR-026 intent precedence).** `_assess_protection` previously let any prescriptive marker (`must`, `never`, `enforce`) make qualified/advisory prose deterministic, contradicting ADR-023/026's own invariant ("prescriptive markers never fire on advisory wording"). Advisory wording now outranks prescriptive markers for unenforced decisions: "We should never use SQLite." is Guidance; "The system must reject invalid input." remains deterministic. Two lexical false positives fixed: `recommen\w+` no longer matches the noun "recommendation(s)", and `can\b` no longer matches the prohibition "can't". Installed typed `FORBID_LITERAL` enforcement still resolves before prose intent and classifies Protected regardless of advisory prose — now stated explicitly in ADR-026 (enforcement precedence), with the structured-metadata-vs-installed-enforcement distinction made explicit.

3. **Human-facing Audit metric presentation.** `mneme audit` now shows `Current Protection` and `Protection Gap` only; `Identified Mneme Potential` is numerically identical to the Protection Gap and is no longer presented as an independent headline finding. `identified_mneme_potential_pct` is retained in `mneme.audit/v1` unchanged (no schema bump, no compat-field removal); only human output changed. A comment documents the deferred GitHub `owner`/`repo`/`base_url` trust-boundary hardening required before trusted `verified` evidence (no functional change).

Deferred and untouched: Decision→Rule→Enforcement traceability, trusted test execution (ADR-025 implementation), evidence schema redesign, exception/bypass lifecycle, decision supersession, enterprise reporting.

## Validation

- Focused: `tests/test_audit_tier_semantics.py`, `tests/test_cli_audit.py`, `tests/test_adr_validator.py`, ADR import/freshness suites — 93 passed.
- Full repository battery: **1313 passed, 6 skipped, 0 failures**.
- `mneme check --mode warn`: PASS (pre-existing ADR_UNIMPORTED/ADR_CHANGED worktree warnings unchanged).
- New regression coverage: mixed advisory/prescriptive wording cases, `can't` prohibition, installed-rule precedence over advisory prose, Protection Gap presentation (and absence of Identified Mneme Potential as headline), JSON compat retention of `identified_mneme_potential_pct`, ADR id uniqueness.
- Sagarika regression corpus (DP_BOUNDARIES, sagarika29/ai-system-architect fixture) expectations unchanged and passing.
- `mneme.audit/v1` schema string and fields unchanged; deterministic output for identical inputs verified.

## Execution provenance

- Change author: agent
- Agent: claude-code
- Agent model: glm-5.3-flash (opencode-go)
- Agent session: opencode-go session, worktree `.worktrees/fix-audit-semantic-contract-cleanup`
- Task origin: claude
- Human owner: @TheoV823

Commit trailers: `Agent: claude-code`, `Agent-Model: glm-5.3-flash`, `Agent-Session: opencode-go`, `Task-Origin: claude`, `Human-Owner: TheoV823`.
